### PR TITLE
Modification to only catch exceptions of StandardError in block.rb

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -92,7 +92,7 @@ module Liquid
       list.collect do |token|
         begin
           token.respond_to?(:render) ? token.render(context) : token
-        rescue Exception => e
+        rescue ::StandardError => e
           context.handle_error(e)
         end
       end

--- a/test/lib/liquid/error_handling_test.rb
+++ b/test/lib/liquid/error_handling_test.rb
@@ -13,6 +13,10 @@ class ErrorDrop < Liquid::Drop
     raise Liquid::SyntaxError, 'syntax error'
   end
 
+  def exception
+    raise Exception, 'exception'
+  end
+
 end
 
 class ErrorHandlingTest < Test::Unit::TestCase
@@ -64,6 +68,14 @@ class ErrorHandlingTest < Test::Unit::TestCase
       assert_equal ' Liquid error: Unknown operator =! ', template.render
       assert_equal 1, template.errors.size
       assert_equal Liquid::ArgumentError, template.errors.first.class
+    end
+  end
+
+  # Liquid should not catch Exceptions that are not subclasses of StandardError, like Interrupt and NoMemoryError
+  def test_exceptions_propagate
+    assert_raise Exception do
+      template = Liquid::Template.parse( ' {{ errors.exception }} '  )
+      template.render('errors' => ErrorDrop.new)
     end
   end
 end # ErrorHandlingTest


### PR DESCRIPTION
Hello,

I noticed while doing some testing of our liquid functionality that it was occasionally catching errors that I really wanted to see immediately due to the 'rescue Exception' in block.rb. We were trying to wrap the template rendering in a timeout block so that we could limit the amount of time our system would spend handling any one request, but this rescue was handling the Timeout::Error, and preventing it from stopping the rendering. I've also seen some cases where it was catching Interrupt and it might catch other errors like NoMemoryError as well. I modified block.rb to only catch StandardError and its subclasses. 

I would normally raise a bug about this but I wasn't able to do anything in Lighthouse once I'd logged in. Hopefully you find this change helpful.

Thanks!
--Austin
