### PR TITLE
Match condition

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -11,6 +11,7 @@ module Liquid
       '==' => lambda { |cond, left, right|  cond.send(:equal_variables, left, right) },
       '!=' => lambda { |cond, left, right| !cond.send(:equal_variables, left, right) },
       '<>' => lambda { |cond, left, right| !cond.send(:equal_variables, left, right) },
+      '=~' => lambda { |cond, left, right|  cond.send(:match_variables, left, right) },
       '<'  => :<,
       '>'  => :>,
       '>=' => :>=,
@@ -84,6 +85,28 @@ module Liquid
       end
 
       left == right
+    end
+
+    def match_variables(left, right)
+      if left.is_a?(Symbol)
+        if right.respond_to?(left)
+          return right.send(left.to_s)
+        else
+          return nil
+        end
+      end
+
+      if right.is_a?(Symbol)
+        if left.respond_to?(right)
+          return left.send(right.to_s)
+        else
+          return nil
+        end
+      end
+
+      return nil if left.nil? or right.nil?
+
+      !!(left.to_s =~ Regexp.new(right.to_s))
     end
 
     def interpret_condition(left, right, op, context)

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -13,7 +13,7 @@ module Liquid
   #
   class If < Block
     SyntaxHelp = "Syntax Error in tag 'if' - Valid syntax: if [expression]"
-    Syntax = /(#{QuotedFragment})\s*([=!<>a-z_]+)?\s*(#{QuotedFragment})?/
+    Syntax = /(#{QuotedFragment})\s*([=!<>a-z_~]+)?\s*(#{QuotedFragment})?/
     ExpressionsAndOperators = /(?:\b(?:\s?and\s?|\s?or\s?)\b|(?:\s*(?!\b(?:\s?and\s?|\s?or\s?)\b)(?:#{QuotedFragment}|\S+)\s*)+)/
 
     def initialize(tag_name, markup, tokens)

--- a/test/lib/liquid/condition_test.rb
+++ b/test/lib/liquid/condition_test.rb
@@ -18,6 +18,7 @@ class ConditionTest < Test::Unit::TestCase
     assert_evalutes_true '2', '>=', '1'
     assert_evalutes_true '1', '<=', '2'
     assert_evalutes_true '1', '<=', '1'
+    assert_evalutes_true '1', '=~', '1'
   end
 
   def test_default_operators_evalute_false
@@ -30,6 +31,7 @@ class ConditionTest < Test::Unit::TestCase
     assert_evalutes_false '2', '>=', '4'
     assert_evalutes_false '1', '<=', '0'
     assert_evalutes_false '1', '<=', '0'
+    assert_evalutes_false '1', '=~', '='
   end
 
   def test_contains_works_on_strings
@@ -62,6 +64,18 @@ class ConditionTest < Test::Unit::TestCase
     @context = Liquid::Context.new
     assert_evalutes_false "not_assigned", 'contains', '0'
     assert_evalutes_false "0", 'contains', 'not_assigned'
+  end
+
+  def test_match_regexp
+    assert_evalutes_true "11", '=~', '"^\d+$"'
+    assert_evalutes_false "alert('javascript attack')", '=~', '"^\d+$"'
+    assert_evalutes_false "1", '=~', '"^\D+$"'
+  end
+
+  def test_match_returns_false_for_nil_operands
+    @context = Liquid::Context.new
+    assert_evalutes_false "not_assigned", '=~', "'\d+'"
+    assert_evalutes_false "0", '=~', 'not_assigned'
   end
 
   def test_or_condition


### PR DESCRIPTION
This patch adds a =~ operator to the Conditions for matching based on regular expressions.  This is extremely useful when dealing with request parameters.  For example:

```
{% if request.get.event_id =~ '^\d+$' %}
  ... write javascript doing something with the event_id GET parameter
{% endif %}
```
