### PR TITLE
Reverse context from liquid_methods

### DIFF
--- a/test/lib/liquid/module_ex_test.rb
+++ b/test/lib/liquid/module_ex_test.rb
@@ -36,6 +36,13 @@ class TestClassC::LiquidDropClass
   end
 end
 
+class TestClassD
+  liquid_methods :allowedD, :reverse_context => :context
+  def allowedD
+    'allowedD'
+  end
+end
+
 class ModuleExTest < Test::Unit::TestCase
   include Liquid
 
@@ -43,24 +50,28 @@ class ModuleExTest < Test::Unit::TestCase
     @a = TestClassA.new
     @b = TestClassB.new
     @c = TestClassC.new
+    @d = TestClassD.new
   end
 
   def test_should_create_LiquidDropClass
     assert TestClassA::LiquidDropClass
     assert TestClassB::LiquidDropClass
     assert TestClassC::LiquidDropClass
+    assert TestClassD::LiquidDropClass
   end
 
   def test_should_respond_to_liquid
     assert @a.respond_to?(:to_liquid)
     assert @b.respond_to?(:to_liquid)
     assert @c.respond_to?(:to_liquid)
+    assert @d.respond_to?(:to_liquid)
   end
 
   def test_should_return_LiquidDropClass_object
     assert @a.to_liquid.is_a?(TestClassA::LiquidDropClass)
     assert @b.to_liquid.is_a?(TestClassB::LiquidDropClass)
     assert @c.to_liquid.is_a?(TestClassC::LiquidDropClass)
+    assert @d.to_liquid.is_a?(TestClassD::LiquidDropClass)
   end
 
   def test_should_respond_to_liquid_methods
@@ -70,6 +81,7 @@ class ModuleExTest < Test::Unit::TestCase
     assert @b.to_liquid.respond_to?(:chainedC)
     assert @c.to_liquid.respond_to?(:allowedC)
     assert @c.to_liquid.respond_to?(:another_allowedC)
+    assert @d.to_liquid.respond_to?(:allowedD)
   end
 
   def test_should_not_respond_to_restricted_methods
@@ -83,5 +95,18 @@ class ModuleExTest < Test::Unit::TestCase
     assert_equal 'another_allowedC', Liquid::Template.parse("{{ a.chainedB.chainedC.another_allowedC }}").render('a'=>@a)
     assert_equal '', Liquid::Template.parse("{{ a.restricted }}").render('a'=>@a)
     assert_equal '', Liquid::Template.parse("{{ a.unknown }}").render('a'=>@a)
+  end
+
+  def test_reverse_context
+    assert_nil TestClassA.reverse_context_method
+    assert_nil TestClassB.reverse_context_method
+    assert_nil TestClassC.reverse_context_method
+
+    assert_equal 'context', TestClassD.reverse_context_method
+    assert @d.respond_to?(:context)
+    d_drop = @d.to_liquid
+    d_drop.context = (d_context = Liquid::Context.new)
+    assert_same d_drop, @d.instance_variable_get('@liquid_drop')
+    assert_same d_context, @d.context
   end
 end # ModuleExTest


### PR DESCRIPTION
This patch adds the option to add the context from a liquid drop back into the original instance:

app/models/page.rb:

```
class Page
  liquid_methods :render, :reverse_context => :context
  def render
    Liquid::Template.parse(content).render(self.context)
  end
end
```

This way, `{{ page.render }}` will render the Page's content in the context provided to the drop.
