### PR TITLE
ERB like trim mode, another approach

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -28,11 +28,14 @@ module Liquid
   VariableAttributeSeparator  = '.'
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
+  TagEndTrim                  = /-#{TagEnd}\n?/
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
   VariableSegment             = /[\w\-]/
   VariableStart               = /\{\{/
   VariableEnd                 = /\}\}/
+  VariableEndTrim             = /-#{VariableEnd}\n?/
   VariableIncompleteEnd       = /\}\}?/
+  VariableIncompleteEndTrim   = /-#{VariableIncompleteEnd}\n?/
   QuotedString                = /"[^"]*"|'[^']*'/
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/
   StrictQuotedFragment        = /"[^"]+"|'[^']+'|[^\s,\|,\:,\,]+/
@@ -42,7 +45,7 @@ module Liquid
   Expression                  = /(?:#{QuotedFragment}(?:#{SpacelessFilter})*)/
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/
+  PartialTemplateParser       = /#{TagStart}.*?(?:#{TagEndTrim}|#{TagEnd})|#{VariableStart}.*?(?:#{VariableIncompleteEndTrim}|#{VariableIncompleteEnd})/
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/
   LiteralShorthand            = /^(?:\{\{\{\s?)(.*?)(?:\s*\}\}\})$/

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -3,8 +3,8 @@ module Liquid
   class Block < Tag
     IsTag             = /^#{TagStart}/
     IsVariable        = /^#{VariableStart}/
-    FullToken         = /^#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/
-    ContentOfVariable = /^#{VariableStart}(.*)#{VariableEnd}$/
+    FullToken         = /^#{TagStart}\s*(\w+)\s*(.*?)(?:#{TagEndTrim}|#{TagEnd})$/
+    ContentOfVariable = /^#{VariableStart}(.*?)(?:#{VariableEndTrim}|#{VariableEnd})$/
 
     def parse(tokens)
       @nodelist ||= []

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -63,8 +63,8 @@ module Liquid
 
     # Push new local scope on the stack. use <tt>Context#stack</tt> instead
     def push(new_scope={})
-      raise StackLevelError, "Nesting too deep" if @scopes.length > 100
       @scopes.unshift(new_scope)
+      raise StackLevelError, "Nesting too deep" if @scopes.length > 100
     end
 
     # Merge a hash of variables in the current local scope

--- a/test/lib/liquid/trim_test.rb
+++ b/test/lib/liquid/trim_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class TrimTest < Test::Unit::TestCase
+  include Liquid
+
+  def test_tag
+    assert_template_result "123\n", "{%if true-%}\n123\n{%endif%}"
+  end
+
+  def test_tag_without_newlink
+    assert_template_result "123\n", "{%if true-%}123\n{%endif%}"
+  end
+
+  def test_variable
+    template = Liquid::Template.parse("{{funk-}}\n{{so}}")
+    assert_equal 2, template.root.nodelist.size
+    assert_equal 'funk', template.root.nodelist[0].name
+    assert_equal 'so', template.root.nodelist[1].name
+  end
+
+  def test_variable_without_newline
+    template = Liquid::Template.parse("{{funk-}}{{so}}")
+    assert_equal 2, template.root.nodelist.size
+    assert_equal 'funk', template.root.nodelist[0].name
+    assert_equal 'so', template.root.nodelist[1].name
+  end
+
+end # TrimTest


### PR DESCRIPTION
I've added separate regular expressions for capturing `-%}` and `-}}` followed by an optional newline character. 
The markup capture in `block.rb` needed to be changed from greedy `(.*)?` to lazy `(.*?)?`.

Furthermore I've changed the `push` method to push the context before raising `StackLevelError` so it can be popped later. `IncludeTagTest` fails otherwise, at least on my system.
