### PR TITLE
Fix behaviour of Context#stack when Context#push raises.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -88,9 +88,12 @@ module Liquid
     #   context['var]  #=> nil
     def stack(new_scope={})
       push(new_scope)
-      yield
-    ensure
-      pop
+
+      begin
+        yield
+      ensure
+        pop
+      end
     end
 
     def clear_instance_assigns


### PR DESCRIPTION
`test_recursively_included_template_does_not_produce_endless_loop` is currently failing. This is because `Context#stack` will always pop a scope from the stack even when push raised an exception because the stack was too deep. We only want to pop the scope at the end of the method if pushing it succeeded, so the push needs to be outside the block with the ensure.
