### PR TITLE
Sort in for loop

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -69,10 +69,10 @@ module Liquid
     
       return '' unless collection.respond_to?(:each) 
       if context[@attributes['sort']] == 'asc'
-        collection = collection.sort! { |a,b| a<=>b }
+        collection = collection.sort { |a,b| a<=>b }
       elsif context[@attributes['sort']] == 'desc'
-        collection = collection.sort! { |a,b| b<=>a }
-      end    
+        collection = collection.sort { |a,b| b<=>a }
+    end    
                                              
       from = if @attributes['offset'] == 'continue'
         context.registers[:for][@name].to_i

--- a/test/lib/liquid/tags/standard_tag_test.rb
+++ b/test/lib/liquid/tags/standard_tag_test.rb
@@ -153,7 +153,7 @@ HERE
   def test_sort_with_limit_and_offset
     assigns = {'array' => [3,2,1,5,6,8,9,7,0,4]}
     assert_template_result('23456', "{% for i in array limit:5 sort:'asc' offset:2 %}{{ i }}{%endfor%}", assigns)
-    assert_template_result('67', "{% for i in array offset:6 sort:'acs' limit:2 %}{{ i }}{%endfor%}", assigns)
+    assert_template_result('67', "{% for i in array offset:6 sort:'asc' limit:2 %}{{ i }}{%endfor%}", assigns)
     assert_template_result('76543', "{% for i in array limit:5 sort:'desc' offset:2 %}{{ i }}{%endfor%}", assigns)
     assert_template_result('32', "{% for i in array offset:6 sort:'desc' limit:2 %}{{ i }}{%endfor%}", assigns)
   end


### PR DESCRIPTION
I wanted to be able to do a basic sort of items in a collection and then output them and I could not find a way to do this using the existing mechanisms so I came up with an extension to the for syntax.

For ascending sort:

```
{% for item in collection sort:'asc' %}{{item}}{% endfor %}
```

For descending sort:

```
{% for item in collection sort:'desc' %}{{item}}{% endfor %}
```
