### PR TITLE
Avoid creating singleton classes on nil, true and false objects

### DIFF
--- a/lib/liquid/extensions.rb
+++ b/lib/liquid/extensions.rb
@@ -43,14 +43,20 @@ class Date  # :nodoc:
   end
 end
 
-def true.to_liquid  # :nodoc:
-  self
+class TrueClass
+  def to_liquid  # :nodoc:
+    self
+  end
 end
 
-def false.to_liquid # :nodoc:
-  self
+class FalseClass
+  def to_liquid # :nodoc:
+    self
+  end
 end
 
-def nil.to_liquid # :nodoc:
-  self
+class NilClass
+  def to_liquid # :nodoc:
+    self
+  end
 end


### PR DESCRIPTION
Avoid creating singleton classes on nil, true and false objects. Instead extend their respective classes. Just because those objects are singletons in current Ruby implementations doesn't mean we should rely on that. Fixes liquid on Maglev.
