### PR TITLE
Include tag context proper object naming

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -26,7 +26,8 @@ module Liquid
     def render(context)
       source = _read_template_from_file_system(context)
       partial = Liquid::Template.parse(source)
-      variable = context[@variable_name || @template_name[1..-2]]
+      object_name = context[@template_name].split('/').last
+      variable = context[@variable_name || object_name]
       
       context.stack do
         @attributes.each do |key, value|
@@ -35,11 +36,11 @@ module Liquid
 
         if variable.is_a?(Array)
           variable.collect do |variable|
-            context[@template_name[1..-2]] = variable
+            context[object_name] = variable
             partial.render(context)
           end
         else
-          context[@template_name[1..-2]] = variable
+          context[object_name] = variable
           partial.render(context)
         end
       end

--- a/test/lib/liquid/include_tag_test.rb
+++ b/test/lib/liquid/include_tag_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestFileSystem
   def read_template_file(template_path, context)
     case template_path
-    when "product"
+    when "product", "superdir/product"
       "Product: {{ product.title }} "
 
     when "locale_variables"
@@ -66,6 +66,16 @@ class IncludeTagTest < Test::Unit::TestCase
 
     assert_equal "Product: Draft 151cm Product: Element 155cm ",
       Template.parse("{% include 'product' for products %}").render( "products" => [ {'title' => 'Draft 151cm'}, {'title' => 'Element 155cm'} ]  )
+  end
+
+  def test_include_tag_object_variable_name
+    assert_equal "Product: Draft 151cm ",
+      Template.parse("{% include 'superdir/product' with products[0] %}").render( "products" => [ {'title' => 'Draft 151cm'}, {'title' => 'Element 155cm'} ]  )
+  end
+
+  def test_include_tag_object_variable_name_with_variable_template_name
+    assert_equal "Product: Draft 151cm ",
+      Template.parse("{% assign tpl = 'superdir/product' %}{% include tpl with products[0] %}").render( "products" => [ {'title' => 'Draft 151cm'}, {'title' => 'Element 155cm'} ]  )
   end
 
   def test_include_tag_with_local_variables


### PR DESCRIPTION
I think, for templates with i.e. 'superdir/partial' path inner object should be named 'partial'. A rails-like convension
