### PR TITLE
Correct formatting for doc comments 

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -1,6 +1,6 @@
 module Liquid
 
-  # A drop in liquid is a class which allows you to to export DOM like things to liquid
+  # A drop in liquid is a class which allows you to to export DOM like things to liquid.
   # Methods of drops are callable.
   # The main use for liquid drops is the implement lazy loaded objects.
   # If you would like to make data available to the web designers which you don't want loaded unless needed then
@@ -8,14 +8,14 @@ module Liquid
   #
   # Example:
   #
-  # class ProductDrop < Liquid::Drop
-  #   def top_sales
-  #      Shop.current.products.find(:all, :order => 'sales', :limit => 10 )
+  #   class ProductDrop < Liquid::Drop
+  #     def top_sales
+  #       Shop.current.products.find(:all, :order => 'sales', :limit => 10 )
+  #     end
   #   end
-  # end
   #
-  # tmpl = Liquid::Template.parse( ' {% for product in product.top_sales %} {{ product.name }} {%endfor%} '  )
-  # tmpl.render('product' => ProductDrop.new ) # will invoke top_sales query.
+  #   tmpl = Liquid::Template.parse( ' {% for product in product.top_sales %} {{ product.name }} {%endfor%} '  )
+  #   tmpl.render('product' => ProductDrop.new ) # will invoke top_sales query.
   #
   # Your drop can either implement the methods sans any parameters or implement the before_method(name) method which is a
   # catch all


### PR DESCRIPTION
Portions of the code examples were not being rendered as code because they lacked a leading tab. Also, a missing period on the first sentence made the first paragraph confusing.
