### PR TITLE
Add split example to example servlet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,3 +48,8 @@ namespace :profile do
   end
 
 end
+
+desc "Run example"
+task :example do
+  ruby "-w -d -Ilib example/server/server.rb"
+end

--- a/example/server/example_servlet.rb
+++ b/example/server/example_servlet.rb
@@ -25,7 +25,11 @@ class Servlet < LiquidServlet
   def products    
     { 'products' => products_list, 'section' => 'Snowboards', 'cool_products' => true}    
   end
-  
+
+  def description
+    "List of Products ~ This is a list of products with price and description."
+  end
+
   private
   
   def products_list

--- a/example/server/server.rb
+++ b/example/server/server.rb
@@ -1,9 +1,11 @@
 require 'webrick'
 require 'rexml/document'
 
-require File.dirname(__FILE__) + '/../../lib/liquid'
-require File.dirname(__FILE__) + '/liquid_servlet'
-require File.dirname(__FILE__) + '/example_servlet'
+DIR = File.expand_path(File.dirname(__FILE__))
+
+require DIR + '/../../lib/liquid'
+require DIR + '/liquid_servlet'
+require DIR + '/example_servlet'
 
 # Setup webrick
 server = WEBrick::HTTPServer.new( :Port => ARGV[1] || 3000 )

--- a/example/server/templates/products.liquid
+++ b/example/server/templates/products.liquid
@@ -16,8 +16,12 @@
 	</head>
 	
 	<body>
-	  
-	  <h1>There are currently {{products | count}} products in the {{section}} catalog</h1>
+
+	  <h1>{{ description | split '~' | first }}</h1>
+
+	  <h2>{{ description | split '~' | last }}</h2>
+
+	  <h2>There are currently {{products | count}} products in the {{section}} catalog</h2>
 
     {% if cool_products %}
       Cool products :) 


### PR DESCRIPTION
An example of using the split filter is added to the example servlet in the example directory.

Also added task to Rakefile to make it easier to run the example.

Note that currently the split functionality seems to be failing. Although the unit tests pass, actual use appears to be producing: `Liquid error: wrong number of arguments (1 for 2)`. So this example should be helpful in tracking down that issue.
