### PR TITLE
More extensible include

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -25,8 +25,8 @@ module Liquid
 
     def render(context)
       context.stack do
-        source = _read_template_from_file_system(context)
-        partial = Liquid::Template.parse(source)
+        template = _read_template_from_file_system(context)
+        partial = Liquid::Template.parse _template_source(template)
         variable = context[@variable_name || @template_name[1..-2]]
 
         @attributes.each do |key, value|
@@ -36,16 +36,24 @@ module Liquid
         if variable.is_a?(Array)
           variable.collect do |variable|
             context[@template_name[1..-2]] = variable
-            partial.render(context)
+            _render_partial(partial, template, context)
           end
         else
           context[@template_name[1..-2]] = variable
-          partial.render(context)
+          _render_partial(partial, template, context)
         end
       end
     end
 
   private
+    def _template_source(template)
+      template
+    end
+
+    def _render_partial(partial, template, context)
+      partial.render(context)
+    end
+
     def _read_template_from_file_system(context)
       file_system = context.registers[:file_system] || Liquid::Template.file_system
 


### PR DESCRIPTION
This pull request make the bundled include tag more modular to allow other implementations with complex more template concepts to hook into it.

My specific use-case here is the introduction of Liquid into ChiliProject (a Redmine fork). We want to use the liquid include to include wiki pages. The templates here are ActiveRecord models. As an additional challenge, the templates are also required to be parsed with Textile. Our basic rendering pipeline goes like 

```
Text ~> Liquid parser ~> Textile parser ~> HTML
```

During the inclusion phase, we need to make sure that the context is updated with the correct, well, context. E.g. we need to render each page with the correct project drop in the context, as we allow cross-project includes and need to properly resolve the targets of sub-includes.

See the full example at https://github.com/meineerde/chiliproject/blob/issues/unstable/604-liquid/lib/chili_project/liquid/tags/include.rb
