### PR TITLE
Add Filters to Assign

### DIFF
--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -9,12 +9,12 @@ module Liquid
   #  {{ foo }}
   #
   class Assign < Tag
-    Syntax = /(#{VariableSignature}+)\s*=\s*(#{QuotedFragment}+)/   
+    Syntax = /(#{VariableSignature}+)\s*=\s*(.*)\s*/   
   
     def initialize(tag_name, markup, tokens)          
       if markup =~ Syntax
         @to = $1
-        @from = $2
+        @from = Variable.new($2)
       else
         raise SyntaxError.new("Syntax Error in 'assign' - Valid syntax: assign [var] = [source]")
       end
@@ -23,7 +23,7 @@ module Liquid
     end
   
     def render(context)
-       context.scopes.last[@to] = context[@from]
+       context.scopes.last[@to] = @from.render(context)
        ''
     end 
   

--- a/test/liquid/assign_test.rb
+++ b/test/liquid/assign_test.rb
@@ -12,4 +12,10 @@ class AssignTest < Test::Unit::TestCase
                            '{% assign foo = values %}.{{ foo[1] }}.',
                            'values' => %w{foo bar baz})
   end
+  
+  def test_assign_with_filter
+    assert_template_result('.bar.',
+                           '{% assign foo = values | split: "," %}.{{ foo[1] }}.',
+                           'values' => "foo,bar,baz")
+  end
 end # AssignTest


### PR DESCRIPTION
A simple attempt, but basically it shifts the parsing of the right hand side of the assign from a simple context lookup to using the Variable parser (that includes filters). Fixes #79.
