### PR TITLE
The random tag

### DIFF
--- a/lib/liquid/tags/random.rb
+++ b/lib/liquid/tags/random.rb
@@ -1,0 +1,34 @@
+
+module Liquid
+
+  #Select random block separated by -OR-
+  #i.e.
+  # {% random %}
+  #   {% random %} One -OR- Two  -OR- Three {% endrandom %}
+  #   -OR-
+  #   {% if false %}
+  #      Last
+  #   {% else %}
+  #      LastElse
+  #   {% endif %}
+  #   -OR-
+  #     End Last
+  # {% endrandom %}" 
+  #
+  #Output: 'One' or 'LastElse' or 'End Last'
+  #
+  class Random < Block
+
+    def initialize(tag_name, markup, tokens)
+      super
+    end
+
+    def render(context)
+      value = super.split('-OR-')
+      return value[rand(value.length)]
+    end
+
+  end
+
+  Template.register_tag('random', Random)
+end


### PR DESCRIPTION
There is no way to process random blocks of code currently. The use-case for this could easily be in any sort of randomization on a templated web-page. 

Feedback requested: I am not sure if the use of the delimiter -OR- is ideal and would be keen to know if there is a more 'tag-based' generic way to do this. 

Select random block separated by -OR-
i.e
{% random %} One -OR- Two  -OR- Three {% endrandom %}
Output: 'One' or 'Two' or 'Three'

{% random %}
    {% random %} One -OR- Two  -OR- Three {% endrandom %}
     -OR-
     {% if false %}
        Last
     {% else %}
        LastElse
     {% endif %}
     -OR-
       End Last
{% endrandom %}"
