### PR TITLE
Fix passing 'now' to the date filter to get the current time under ruby 1.9

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -169,6 +169,10 @@ module Liquid
         input = Time.at(input.to_i)
       end
 
+      if input == 'now'
+        input = Time.now()
+      end
+
       date = input.is_a?(String) ? Time.parse(input) : input
 
       if date.respond_to?(:strftime)

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -108,6 +108,8 @@ class StandardFiltersTest < Test::Unit::TestCase
 
     assert_equal "07/05/2006", @filters.date(1152098955, "%m/%d/%Y")
     assert_equal "07/05/2006", @filters.date("1152098955", "%m/%d/%Y")
+
+    assert_equal Time.now().strftime("%m/%d/%Y"), @filters.date("now", "%m/%d/%Y")
   end
 
 


### PR DESCRIPTION
In ruby 1.8.7, `Time.parse('now')` would return the current time, which allowed `{{ 'now' | date: "%Y %h" }}` (listed as an example in your Liquid for Designers page) to work. Under 1.9, however, this throws an exception.
