### PR TITLE
Extend Strainer with filters in a predictable order

### DIFF
--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -19,7 +19,7 @@ module Liquid
     # Ruby 1.9.2 introduces Object#respond_to_missing?, which is invoked by Object#respond_to?
     @@required_methods << :respond_to_missing? if Object.respond_to? :respond_to_missing?
 
-    @@filters = {}
+    @@filters = []
 
     def initialize(context)
       @context = context
@@ -27,12 +27,12 @@ module Liquid
 
     def self.global_filter(filter)
       raise ArgumentError, "Passed filter is not a module" unless filter.is_a?(Module)
-      @@filters[filter.name] = filter
+      @@filters << filter
     end
 
     def self.create(context)
-      strainer = Strainer.new(context)
-      @@filters.each { |k,m| strainer.extend(m) }
+      strainer = self.new(context)
+      @@filters.each { |filter| strainer.extend(filter) }
       strainer
     end
 


### PR DESCRIPTION
Currently Strainer saves the registered filter modules in a hash, keyed by the name of the module.

As Ruby 1.8 doesn't have sorted Hashes, the final order in which the modules are included into the class is unpredictable. The hashing is also unnecessary as the key is never used.

This patch saves the filter list in an array which leads to the extension in the order in which the modules are registered which allows later modules to reliably overwrite existing filter methods.
