### PR TITLE
Context handles false value in an environment incorrectly

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -154,7 +154,7 @@ module Liquid
 
         if scope.nil?
           @environments.each do |e|
-            if variable = lookup_and_evaluate(e, key)
+            unless (variable = lookup_and_evaluate(e, key)).nil?
               scope = e
               break
             end

--- a/test/liquid/context_test.rb
+++ b/test/liquid/context_test.rb
@@ -70,32 +70,44 @@ class ContextTest < Test::Unit::TestCase
     @context = Liquid::Context.new
   end
 
+  # TODO All applicable tests should iterate their test through these two ways 
+  # of setting variables in the context; test_variables has been converted as 
+  # an example.
+  SET_METHODS = {
+    # @scopes - this is the method the test used and represents storing items 
+    # on the scopes of the context.
+    :scopes => Proc.new {|name, value| c = Liquid::Context.new; c[name] = value; c },
+    # @environments - this is the method that Liquid::Template.render uses 
+    # with a Hash passed in
+    :environments => Proc.new {|name, value| Liquid::Context.new([{name => value}, {}]) }
+  }
   def test_variables
-    @context['string'] = 'string'
-    assert_equal 'string', @context['string']
+    SET_METHODS.each do |set_method_name, set_method|
+      @context = set_method.call('string', 'string')
+      assert_equal 'string', @context['string'], set_method_name
 
-    @context['num'] = 5
-    assert_equal 5, @context['num']
+      @context = set_method.call('num', 5)
+      assert_equal 5, @context['num'], set_method_name
 
-    @context['time'] = Time.parse('2006-06-06 12:00:00')
-    assert_equal Time.parse('2006-06-06 12:00:00'), @context['time']
+      @context = set_method.call('time', Time.parse('2006-06-06 12:00:00'))
+      assert_equal Time.parse('2006-06-06 12:00:00'), @context['time'], set_method_name
 
-    @context['date'] = Date.today
-    assert_equal Date.today, @context['date']
+      @context = set_method.call('date', Date.today)
+      assert_equal Date.today, @context['date'], set_method_name
 
-    now = DateTime.now
-    @context['datetime'] = now
-    assert_equal now, @context['datetime']
+      now = DateTime.now
+      @context = set_method.call('datetime', now)
+      assert_equal now, @context['datetime'], set_method_name
 
-    @context['bool'] = true
-    assert_equal true, @context['bool']
+      @context = set_method.call('bool', true)
+      assert_equal true, @context['bool'], set_method_name
 
-    @context['bool'] = false
-    assert_equal false, @context['bool']
+      @context = set_method.call('bool', false)
+      assert_equal false, @context['bool'], set_method_name
 
-    @context['nil'] = nil
-    assert_equal nil, @context['nil']
-    assert_equal nil, @context['nil']
+      @context = set_method.call('nil', nil)
+      assert_equal nil, @context['nil'], set_method_name
+    end
   end
 
   def test_variables_not_existing

--- a/test/liquid/variable_test.rb
+++ b/test/liquid/variable_test.rb
@@ -126,6 +126,12 @@ class VariableResolutionTest < Test::Unit::TestCase
     assert_equal '', template.render
   end
 
+  def test_boolean_variables
+    template = Template.parse(%|{{test}}|)
+    assert_equal 'true', template.render('test' => true)
+    assert_equal 'false', template.render('test' => false)
+  end
+
   def test_hash_scoping
     template = Template.parse(%|{{ test.test }}|)
     assert_equal 'worked', template.render('test' => {'test' => 'worked'})


### PR DESCRIPTION
I've added tests to test/liquid/context_test.rb and test/liquid/variable_test.rb that demonstrate the issue, but basically if you have "foo" that gets set as part of the environments on initialization of a Context, which is how Template.render passes a Hash in, then the context returns the wrong value:

```
context = Context.new([{"foo" => false}, {}]))
assert_equal false, context["foo"]  # expected: false, got: nil
```

What does work, and what is tested currently, is using a scope of the Context:

```
context = Context.new
context["foo"] = false
assert_equal false, context["foo"]  # This works
```

The issue, as corrected in the commit to lib/liquid/context.rb is to check 

```
unless (variable = lookup_and_evaluate(e, key)).nil?
```

for returning nil specifically, which will break on true or false correctly, instead of checking

```
if variable = lookup_and_evaluate(e, key)
```

which only breaks the search on true and not false.

In the normal way of things I need this soon, so I've updated the test to check both of these setter methods in the test_variables test and it does indeed fail only with false in the environments case and then went and fixed that.  And in the name of giving back to the community, I am submitting this pull request to either get included, or improved upon as applicable.  However, I didn't scour the rest of the tests to see if they should also test both cases, but I figured doing one as an example would help someone with a better understanding of the library decide where to apply it.

Thanks,
\Peter
