### PR TITLE
Make strip_html strip tags spread across lines

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -59,7 +59,7 @@ module Liquid
     end
 
     def strip_html(input)
-      input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<.*?>/, '')
+      input.to_s.gsub(/<script.*?<\/script>/m, '').gsub(/<.*?>/m, '')
     end
 
     # Remove all newlines from the string

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -67,6 +67,7 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_equal 'test', @filters.strip_html("<div>test</div>")
     assert_equal 'test', @filters.strip_html("<div id='test'>test</div>")
     assert_equal '', @filters.strip_html("<script type='text/javascript'>document.write('some stuff');</script>")
+    assert_equal 'test', @filters.strip_html("<div\nclass='multiline'>test</div>")
     assert_equal '', @filters.strip_html(nil)
   end
 


### PR DESCRIPTION
---

I'm assuming the tag-stripping is not used as a security feature anywhere, so this bug fix doesn't require sensitive handling. If that's not the case though, you should probably delete this pull request and notify people as appropriate.
