### PR TITLE
Ensure for-loop on an empty string does not enter for-body.

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -76,7 +76,7 @@ module Liquid
       collection = collection.to_a if collection.is_a?(Range)
     
       # Maintains Ruby 1.8.7 String#each behaviour on 1.9
-      return render_else(context) unless collection.respond_to?(:each) or collection.is_a?(String)
+      return render_else(context) unless iterable?(collection)
                                                  
       from = if @attributes['offset'] == 'continue'
         context.registers[:for][@name].to_i
@@ -150,6 +150,9 @@ module Liquid
         return @else_block ? [render_all(@else_block, context)] : ''
       end
 
+      def iterable?(collection)
+        collection.respond_to?(:each) || (collection.is_a?(String) && collection != '')
+      end
   end
 
   Template.register_tag('for', For)

--- a/test/liquid/tags/for_tag_test.rb
+++ b/test/liquid/tags/for_tag_test.rb
@@ -195,4 +195,8 @@ HERE
                 '{{val}}{%endfor%}', 
                 'string' => "test string")
   end
+
+  def test_blank_string_not_iterable
+    assert_template_result('', "{% for char in characters %}I WILL NOT BE OUTPUT{% endfor %}", 'characters' => '')
+  end
 end


### PR DESCRIPTION
Ruby 1.8 compatibility fix

Best shown at the following example Liquid content:

```
{% for something in '' %}I AM NOT BEING OUTPUT{% endfor %}
```

Old broken behavior without this commit:

`I AM NOT BEING OUTPUT` was inserted into the template

New behavior with this commit (this is the same behavior as running Shopify on Ruby 1.8):

Nothing is inserted into the template

Please review @burke @kristianpd 
