### PR TITLE
Fix syntax error in htmltags.rb and for.rb for compatibility with rbx-2.0.0-dev (1.9.3)

### DIFF
--- a/lib/liquid/htmltags.rb
+++ b/lib/liquid/htmltags.rb
@@ -46,7 +46,7 @@ module Liquid
             'col0'    => col,
             'index0'  => index,
             'rindex'  => length - index,
-            'rindex0' => length - index -1,
+            'rindex0' => length - index - 1,
             'first'   => (index == 0),
             'last'    => (index == length - 1),
             'col_first' => (col == 0),

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -110,7 +110,7 @@ module Liquid
             'index'   => index + 1, 
             'index0'  => index, 
             'rindex'  => length - index,
-            'rindex0' => length - index -1,
+            'rindex0' => length - index - 1,
             'first'   => (index == 0),
             'last'    => (index == length - 1) }
 


### PR DESCRIPTION
When running liquid in Rails 3.1 on rbx-2.0.0-dev (1.9.3), received a syntax error in:

```
liquid-2.3.0/lib/liquid/htmltags.rb:49
liquid-2.3.0/lib/liquid/tags/for.rb:112
```

Full sample backtrace:

```
A syntax error has occurred:
    expecting keyword_do or '{' or '('
    near line /Users/chris/.rbenv/versions/rbx-2.0.0-dev/gems/1.9/gems/liquid-2.3.0/lib/liquid/htmltags.rb:49, column 41

Code:
            'rindex0' => length - index -1,
                                        ^

Backtrace:
  Rubinius::Melbourne(Rubinius::Melbourne19)#syntax_error at /Users/chris/.rbenv/versions/rbx-2.0.0-dev/runtime/19/melbourne.rbc:68
 Rubinius::Melbourne(Rubinius::Melbourne19)#parse_file at /Users/chris/.rbenv
                                                          /versions
                                                          /rbx-2.0.0-dev/runtime
                                                          /19/melbourne.rbc:84
 Rubinius::Compiler::FileParser#parse at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/runtime/19/compiler
                                         /stages.rbc:235
  Rubinius::Compiler::Parser(Rubinius::Compiler::FileParser)#run at \
          /Users/chris/.rbenv/versions/rbx-2.0.0-dev/runtime/19/compiler/stages.rbc:217
               Rubinius::Compiler#run at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/runtime/19/compiler
                                         /compiler.rbc:370
           Rubinius::Compiler.compile at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/runtime/19/compiler
                                         /compiler.rbc:84
     Rubinius::CodeLoader#compile_file at kernel/delta/codeloader.rb:166
        Rubinius::CodeLoader#load_file at kernel/delta/codeloader.rb:147
          Rubinius::CodeLoader#require at kernel/common/codeloader.rb:124
          Rubinius::CodeLoader.require at kernel/common/codeloader.rb:201
                Kernel(Object)#require at kernel/common/kernel.rb:639
  { } in ActiveSupport::Dependencies::Loadable(Object)#require at \
          /Users/chris/.rbenv/versions/rbx-2.0.0-dev/gems/1.9/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:240
  { } in ActiveSupport::Dependencies::Loadable(Object)#load_dependency at \
          /Users/chris/.rbenv/versions/rbx-2.0.0-dev/gems/1.9/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:223
 ActiveSupport::Dependencies(Module)#new_constants_in at /Users/chris/.rbenv
                                                         /versions/rbx-2.0.0-dev
                                                         /gems/1.9/gems
                                                         /activesupport-3.1.3
                                                         /lib/active_support
                                                         /dependencies.rb:640
  ActiveSupport::Dependencies::Loadable(Object)#load_dependency at \
          /Users/chris/.rbenv/versions/rbx-2.0.0-dev/gems/1.9/gems/activesupport-3.1.3/lib/active_support/dependencies.rb:223
 ActiveSupport::Dependencies::Loadable(Object)#require at /Users/chris/.rbenv
                                                          /versions
                                                          /rbx-2.0.0-dev/gems
                                                          /1.9/gems
                                                          /activesupport-3.1.3
                                                          /lib/active_support
                                                          /dependencies.rb:240
                    Object#__script__ at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /liquid-2.3.0/lib/liquid.rb:59
          Rubinius::CodeLoader.require at kernel/common/codeloader.rb:207
                        Kernel.require at kernel/common/kernel.rb:639
      { } in Bundler::Runtime#require at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /bundler-1.1.0/lib/bundler
                                         /runtime.rb:68
                            Array#each at kernel/bootstrap/array.rb:68
      { } in Bundler::Runtime#require at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /bundler-1.1.0/lib/bundler
                                         /runtime.rb:66
                            Array#each at kernel/bootstrap/array.rb:68
             Bundler::Runtime#require at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /bundler-1.1.0/lib/bundler
                                         /runtime.rb:55
                      Bundler.require at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /bundler-1.1.0/lib/bundler.rb:118
                     Object#__script__ at config/application.rb:13
          Rubinius::CodeLoader.require at kernel/common/codeloader.rb:207
                Kernel(Object)#require at kernel/common/kernel.rb:639
                    Object#__script__ at /Users/chris/.rbenv/versions
                                         /rbx-2.0.0-dev/gems/1.9/gems
                                         /railties-3.1.3/lib/rails
                                         /commands.rb:38
          Rubinius::CodeLoader.require at kernel/common/codeloader.rb:207
                Kernel(Object)#require at kernel/common/kernel.rb:639
                     Object#__script__ at script/rails:6
      Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:67
      Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:109
               Rubinius::Loader#script at kernel/loader.rb:630
                 Rubinius::Loader#main at kernel/loader.rb:834
```
