### PR TITLE
Fix conditions using negative number comparisons

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -136,11 +136,11 @@ module Liquid
             $1
           when /^"(.*)"$/ # Double quoted strings
             $1
-          when /^(\d+)$/ # Integer and floats
+          when /^(-?\d+)$/ # Integer and floats
             $1.to_i
           when /^\((\S+)\.\.(\S+)\)$/ # Ranges
             (resolve($1).to_i..resolve($2).to_i)
-          when /^(\d[\d\.]+)$/ # Floats
+          when /^(-?\d[\d\.]+)$/ # Floats
             $1.to_f
           else
             variable(key)

--- a/test/liquid/condition_test.rb
+++ b/test/liquid/condition_test.rb
@@ -18,6 +18,11 @@ class ConditionTest < Test::Unit::TestCase
     assert_evalutes_true '2', '>=', '1'
     assert_evalutes_true '1', '<=', '2'
     assert_evalutes_true '1', '<=', '1'
+    # negative numbers
+    assert_evalutes_true '1', '>', '-1'
+    assert_evalutes_true '-1', '<', '1'
+    assert_evalutes_true '1.0', '>', '-1.0'
+    assert_evalutes_true '-1.0', '<', '1.0'
   end
 
   def test_default_operators_evalute_false


### PR DESCRIPTION
Before this did not use to work:

{% if 1 > -1 %}
  1 should be greater than -1
{% endif %}

Please review @ssoroka @burke 
