### PR TITLE
Add support for I18n on the date filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -172,7 +172,11 @@ module Liquid
       date = input.is_a?(String) ? Time.parse(input) : input
 
       if date.respond_to?(:strftime)
-        date.strftime(format.to_s)
+        if should_use_I18n
+          I18n.localize(date, :format => format_for_I18n(format))
+        else
+          date.strftime(format.to_s)
+        end
       else
         input
       end
@@ -232,6 +236,19 @@ module Liquid
           (obj.strip =~ /^\d+\.\d+$/) ? obj.to_f : obj.to_i
         else
           0
+        end
+      end
+
+      def should_use_I18n
+        defined? I18n
+      end
+
+      def format_for_I18n(format)
+        return if !format
+        if format.to_s.include?('%')
+          format.to_s
+        else
+          format.to_sym
         end
       end
 


### PR DESCRIPTION
Hi,

I'd like to have support for I18n when displaying dates with liquid in my rails app. This comes from a real user scenario and I'd like to see it upstream instead of having to patch the library. Hope this helps, let me know if there's anything else I can do.

P.S. I haven't added tests because I didn't want to introduce an external dependency.
