### PR TITLE
apply "o" option to regexps to improve process time

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -18,14 +18,14 @@ module Liquid
       @markup  = markup
       @name    = nil
       @filters = []
-      if match = markup.match(/\s*(#{QuotedFragment})(.*)/)
+      if match = markup.match(/\s*(#{QuotedFragment})(.*)/o)
         @name = match[1]
-        if match[2].match(/#{FilterSeparator}\s*(.*)/)
+        if match[2].match(/#{FilterSeparator}\s*(.*)/o)
           filters = Regexp.last_match(1).scan(FilterParser)
           filters.each do |f|
             if matches = f.match(/\s*(\w+)/)
               filtername = matches[1]
-              filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*(#{QuotedFragment})/).flatten
+              filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*(#{QuotedFragment})/o).flatten
               @filters << [filtername.to_sym, filterargs]
             end
           end


### PR DESCRIPTION
This change makes octopress fast about 8-10%
when I generate my website.
(I use liquid with octopress-jekyll.)
