### PR TITLE
Make strip_html filter strip contents of style tags

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -59,7 +59,7 @@ module Liquid
     end
 
     def strip_html(input)
-      input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<.*?>/, '')
+      input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<style.*?<\/style>/, '').gsub(/<.*?>/, '')
     end
 
     # Remove all newlines from the string


### PR DESCRIPTION
Strip the contents of style tags (like with script tags) since style tags are valid as descendants of the body element in HTML5 (as opposed to descendants of the head element only). See issue #114.
