### PR TITLE
strip_html to ignore comments with html tags. fixes #1650

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -59,7 +59,7 @@ module Liquid
     end
 
     def strip_html(input)
-      input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<.*?>/, '')
+      input.to_s.gsub(/<script.*?<\/script>/, '').gsub(/<!--.*?-->/, '').gsub(/<.*?>/, '')
     end
 
     # Remove all newlines from the string

--- a/test/liquid/filter_test.rb
+++ b/test/liquid/filter_test.rb
@@ -75,6 +75,12 @@ class FiltersTest < Test::Unit::TestCase
     assert_equal "bla blub", Variable.new("var | strip_html").render(@context)
   end
 
+  def test_strip_html_ignore_comments_with_html
+    @context['var'] = "<!-- split and some <ul> tag --><b>bla blub</a>"
+
+    assert_equal "bla blub", Variable.new("var | strip_html").render(@context)
+  end
+
   def test_capitalize
     @context['var'] = "blub"
 


### PR DESCRIPTION
fixes #1650. added additional gsub(/<!--.*?-->/, '') to strip_html method to ignore html comments even when they include html tags.

@burke @Soleone 
