### PR TITLE
Allow custom formatting of rendered nodes

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -89,13 +89,15 @@ module Liquid
     end
 
     def render_all(list, context)
-      list.collect do |token|
+      parts = list.collect do |token|
         begin
           token.respond_to?(:render) ? token.render(context) : token
         rescue ::StandardError => e
           context.handle_error(e)
         end
-      end.join
+      end
+
+      context.format_parts(parts)
     end
   end
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -41,6 +41,10 @@ module Liquid
       end
     end
 
+    def format_parts(parts)
+      Template.formatter.call(parts)
+    end
+
     def handle_error(e)
       errors.push(e)
       raise if @rethrow_errors

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -34,6 +34,12 @@ module Liquid
         @tags ||= {}
       end
 
+      attr_writer :formatter
+
+      def formatter
+        @formatter || lambda {|parts| parts.join }
+      end
+
       # Pass a module with filter methods which should be available
       # to all liquid views. Good for registering the standard library
       def register_filter(mod)

--- a/test/liquid/context_test.rb
+++ b/test/liquid/context_test.rb
@@ -162,6 +162,16 @@ class ContextTest < Test::Unit::TestCase
 
   end
 
+  def test_formatter
+    Template.formatter = lambda {|parts| parts.join(":") }
+
+    output = Template.parse("foo{{x}}baz").render('x' => 'bar')
+
+    assert_equal "foo:bar:baz", output
+  ensure
+    Template.formatter = nil
+  end
+
   def test_override_global_filter
     global = Module.new do
       def notice(output)


### PR DESCRIPTION
This allows injecting a custom formatter that can transform the list of
rendered nodes into a string. The default formatter still simply joins
the parts.

By doing this, we allow people to do postprocessing on the result of a
Liquid evaluation, which can be useful for, say, HTML formatting.

``` ruby
Template.formatter = lambda do |parts|
  parts.map do |part|
    if needs_html_escaping?(part)
      escape_html(part)
    else
      part
    end
  end.join
end

template = Liquid::Template.parse("hello!\n\n{{foo}}\n\nbar")
template.render
```

The formatter is currently set globally on Template. It didn't seem like it was straightforward to inject in into the template per instance, although that may be preferable. If you'd rather want it per instance I can fix the code.

I need this in order to do HTML sanitization while taking into account the origin of parts by using `String#html_safe?` on parts that have already been sanitized.
