### PR TITLE
Add EditorConfig file denoting indentation styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+end_of_line = LF


### PR DESCRIPTION
The `.editorconfig` file defines indentation styles for all the ruby source files.

[EditorConfig](http://editorconfig.org) is a project that defines coding style and makes editors format the code in a consistent way, especially the indentation. It's available for [many editors and IDEs](http://editorconfig.org/#download). [Many projects](https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig) have taken advantages of it, including [jQuery](https://github.com/jquery/jquery), [Modernizr](https://github.com/Modernizr/Modernizr).

I post the pull request here because I found liquid has many unexpected "tab" in the source code, while it seems that the indentation should be made by spaces. Wish this pull request could bring this project some benefits of consistent coding style.
