### PR TITLE
Added break and continue statements

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -48,6 +48,7 @@ end
 require 'liquid/drop'
 require 'liquid/extensions'
 require 'liquid/errors'
+require 'liquid/interrupts'
 require 'liquid/strainer'
 require 'liquid/context'
 require 'liquid/tag'

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -89,13 +89,27 @@ module Liquid
     end
 
     def render_all(list, context)
-      list.collect do |token|
+      output = []
+      list.each do |token|
+        # Break out if we have any unhanded interrupts.
+        break if context.has_interrupt?
+
         begin
-          token.respond_to?(:render) ? token.render(context) : token
+          # If we get an Interrupt that means the block must stop processing. An
+          # Interrupt is any command that stops block execution such as {% break %} 
+          # or {% continue %}
+          if token.is_a? Continue or token.is_a? Break
+            context.push_interrupt(token.interrupt)
+            break
+          end
+
+          output << (token.respond_to?(:render) ? token.render(context) : token)
         rescue ::StandardError => e
-          context.handle_error(e)
+          output << (context.handle_error(e))
         end
-      end.join
+      end
+
+      output.join
     end
   end
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -22,6 +22,8 @@ module Liquid
       @errors         = []
       @rethrow_errors = rethrow_errors
       squash_instance_assigns_with_environments
+
+      @interrupts = []
     end
 
     def strainer
@@ -39,6 +41,21 @@ module Liquid
         raise ArgumentError, "Expected module but got: #{f.class}" unless f.is_a?(Module)
         strainer.extend(f)
       end
+    end
+
+    # are there any not handled interrupts?
+    def has_interrupt?
+      !@interrupts.empty?
+    end
+
+    # push an interrupt to the stack. this interrupt is considered not handled.
+    def push_interrupt(e)
+      @interrupts.push(e)
+    end
+
+    # pop an interrupt from the stack
+    def pop_interrupt
+      @interrupts.pop
     end
 
     def handle_error(e)

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -8,9 +8,4 @@ module Liquid
   class StandardError < Error; end
   class SyntaxError < Error; end
   class StackLevelError < Error; end
-
-
-  class Interrupt < Error; end
-  class BreakInterrupt < Interrupt; end
-  class ContinueInterrupt < Interrupt; end
 end

--- a/lib/liquid/interrupts.rb
+++ b/lib/liquid/interrupts.rb
@@ -1,0 +1,17 @@
+module Liquid
+
+  # An interrupt is any command that breaks processing of a block (ex: a for loop).
+  class Interrupt
+    attr_reader :message
+
+    def initialize(message=nil)
+      @message = message || "interrupt"
+    end
+  end
+
+  # Interrupt that is thrown whenever a {% break %} is called.
+  class BreakInterrupt < Interrupt; end
+
+  # Interrupt that is thrown whenever a {% continue %} is called.
+  class ContinueInterrupt < Interrupt; end
+end

--- a/lib/liquid/tags/break.rb
+++ b/lib/liquid/tags/break.rb
@@ -9,15 +9,12 @@ module Liquid
   #      {% endif %}
   #    {% endfor %}
   # 
-  class Break < Tag
+  class Break < Tag 
 
-    ##
-    # Add an interrupt to context errors so a for loop can check
-    # for interrupts. 
-    def render(context)
-      context.handle_error(BreakInterrupt.new)
+    def interrupt
+      BreakInterrupt.new
     end
-    
+
   end
 
   Template.register_tag('break', Break)

--- a/lib/liquid/tags/continue.rb
+++ b/lib/liquid/tags/continue.rb
@@ -11,13 +11,10 @@ module Liquid
   # 
   class Continue < Tag
 
-    ##
-    # Add an interrupt to context errors so a for loop can check
-    # for interrupts. 
-    def render(context)
-      context.handle_error(ContinueInterrupt.new)
+    def interrupt
+      ContinueInterrupt.new
     end
-    
+
   end
 
   Template.register_tag('continue', Continue)

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -114,19 +114,14 @@ module Liquid
             'first'   => (index == 0),
             'last'    => (index == length - 1) }
 
-          rendered = render_all(@for_block, context)
+          result << render_all(@for_block, context)
 
-          if context.errors.last.is_a? BreakInterrupt
-            context.errors.pop
-            break
+          # Handle any interrupts if they exist.
+          if context.has_interrupt?
+            interrupt = context.pop_interrupt
+            break if interrupt.is_a? BreakInterrupt
+            next if interrupt.is_a? ContinueInterrupt
           end
-
-          if context.errors.last.is_a? ContinueInterrupt
-            context.errors.pop 
-            next
-          end
-
-          result << rendered
         end
       end
       result     

--- a/test/liquid/tags/break_tag_test.rb
+++ b/test/liquid/tags/break_tag_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class BreakTagTest < Test::Unit::TestCase
+  include Liquid
+
+  # tests that no weird errors are raised if break is called outside of a
+  # block
+  def test_break_with_no_block
+    assigns = {'i' => 1}
+    markup = '{% break %}'
+    expected = ''
+
+    assert_template_result(expected, markup, assigns)
+  end
+
+end

--- a/test/liquid/tags/continue_tag_test.rb
+++ b/test/liquid/tags/continue_tag_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class ContinueTagTest < Test::Unit::TestCase
+  include Liquid
+
+  # tests that no weird errors are raised if continue is called outside of a
+  # block
+  def test_continue_with_no_block
+    assigns = {}
+    markup = '{% continue %}'
+    expected = ''
+
+    assert_template_result(expected, markup, assigns)
+  end
+
+end

--- a/test/liquid/tags/for_tag_test.rb
+++ b/test/liquid/tags/for_tag_test.rb
@@ -168,18 +168,87 @@ HERE
       assert_template_result(expected,markup,assigns)
   end
 
-  def test_break
+  def test_for_with_break
     assigns = {'array' => {'items' => [1,2,3,4,5,6,7,8,9,10]}}
-    markup = '{% for i in array.items %}{{ i }}{% if i > 3 %}{% break %}{% endif %}{% endfor %}'
-    expected = "123"
+
+    markup = '{% for i in array.items %}{% break %}{% endfor %}'
+    expected = ""
     assert_template_result(expected,markup,assigns)
+
+    markup = '{% for i in array.items %}{{ i }}{% break %}{% endfor %}'
+    expected = "1"
+    assert_template_result(expected,markup,assigns)
+
+    markup = '{% for i in array.items %}{% break %}{{ i }}{% endfor %}'
+    expected = ""
+    assert_template_result(expected,markup,assigns)
+
+    markup = '{% for i in array.items %}{{ i }}{% if i > 3 %}{% break %}{% endif %}{% endfor %}'
+    expected = "1234"
+    assert_template_result(expected,markup,assigns)
+
+    # tests to ensure it only breaks out of the local for loop 
+    # and not all of them.
+    assigns = {'array' => [[1,2],[3,4],[5,6]] }
+    markup = '{% for item in array %}' + 
+               '{% for i in item %}' + 
+                 '{% if i == 1 %}' + 
+                   '{% break %}' + 
+                 '{% endif %}' + 
+                 '{{ i }}' + 
+               '{% endfor %}' + 
+             '{% endfor %}'
+    expected = '3456'
+    assert_template_result(expected, markup, assigns)
+
+    # test break does nothing when unreached
+    assigns = {'array' => {'items' => [1,2,3,4,5]}}
+    markup = '{% for i in array.items %}{% if i == 9999 %}{% break %}{% endif %}{{ i }}{% endfor %}'
+    expected = '12345'
+    assert_template_result(expected, markup, assigns)
   end
 
-  def test_continue
+  def test_for_with_continue
     assigns = {'array' => {'items' => [1,2,3,4,5]}}
+
+    markup = '{% for i in array.items %}{% continue %}{% endfor %}'
+    expected = ""
+    assert_template_result(expected,markup,assigns) 
+
+    markup = '{% for i in array.items %}{{ i }}{% continue %}{% endfor %}'
+    expected = "12345"
+    assert_template_result(expected,markup,assigns) 
+
+    markup = '{% for i in array.items %}{% continue %}{{ i }}{% endfor %}'
+    expected = ""
+    assert_template_result(expected,markup,assigns) 
+
+    markup = '{% for i in array.items %}{% if i > 3 %}{% continue %}{% endif %}{{ i }}{% endfor %}'
+    expected = "123"
+    assert_template_result(expected,markup,assigns)
+
     markup = '{% for i in array.items %}{% if i == 3 %}{% continue %}{% else %}{{ i }}{% endif %}{% endfor %}'
     expected = "1245"
     assert_template_result(expected,markup,assigns)
+
+    # tests to ensure it only continues the local for loop and not all of them.
+    assigns = {'array' => [[1,2],[3,4],[5,6]] }
+    markup = '{% for item in array %}' + 
+               '{% for i in item %}' + 
+                 '{% if i == 1 %}' + 
+                   '{% continue %}' + 
+                 '{% endif %}' + 
+                 '{{ i }}' + 
+               '{% endfor %}' + 
+             '{% endfor %}'
+    expected = '23456'
+    assert_template_result(expected, markup, assigns)
+
+    # test continue does nothing when unreached
+    assigns = {'array' => {'items' => [1,2,3,4,5]}}
+    markup = '{% for i in array.items %}{% if i == 9999 %}{% continue %}{% endif %}{{ i }}{% endfor %}'
+    expected = '12345'
+    assert_template_result(expected, markup, assigns)
   end
 
   def test_for_tag_string


### PR DESCRIPTION
At my day job we've been using Liquid to allow clients to customize the look and feel of our product. While doing various client implementations I noticed that statements like `break` and `continue` were missing from the language's vocabulary.

If this isn't a feature Shopify want's to see included with Liquid I totally understand, I just figured I would share some of my work.
## Example

Break out of the loop entirely.

``` liquid
{% for item in collection %}
  {% if item.condition %}
    {% break %}
  {% endif %}
{% endfor %}
```

Stop processing this iteration, but keep the loop going.

``` liquid
{% for item in collection %}
  {% if item.other_condition %}
    {% continue %}
  {% endif %}
{% endfor %}
```
## Implementation

These statements are implemented by pushing and popping an Interrupt object to the context. When an Interrupt has been pushed to the stack  `Block#render_all` will break execution until the Interrupt is handled (only by `For#render` for now).
