### PR TITLE
if the following tag is ['first','last' or 'size] defer to_liquid

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -204,8 +204,10 @@ module Liquid
         end
 
         if object = find_variable(first_part)
+          i = 0
+          while i < parts.length
+            part = parts[i]
 
-          parts.each do |part|
             part = resolve($1) if part_resolved = (part =~ square_bracketed)
 
             # If object is a hash- or array-like object we look for the
@@ -216,7 +218,13 @@ module Liquid
 
               # if its a proc we will replace the entry with the proc
               res = lookup_and_evaluate(object, part)
-              object = res.to_liquid
+
+              if i+1 < parts.length && res.respond_to?(next_part = parts[i+1]) && ['size', 'first', 'last'].include?(next_part)
+                object = res.send(next_part.intern).to_liquid
+                i+=1
+              else
+                object = res.to_liquid
+              end
 
               # Some special cases. If the part wasn't in square brackets and
               # no key with the same name was found we interpret following calls
@@ -233,6 +241,8 @@ module Liquid
 
             # If we are dealing with a drop here we have to
             object.context = self if object.respond_to?(:context=)
+
+            i+=1
           end
         end
 


### PR DESCRIPTION
@ssoroka @Soleone Please Review /cc @hornairs 

Currently, if a liquid user executes `collection.products.first`, `products` will be converted to_liquid before the `.first` is applied.

If the drop provides an ActiveRelation object to the liquid engine, calling `.to_liquid` on the ActiveRelation will load all the objects, and then throw out all but the first.

If we defer calling .to_liquid until after we've applied `.first` then ActiveRecord will do the right thing and only load the single product.

This fix is a first-principals approach to solving the problem: if the following tag is in `['first', 'last', 'size']` and we've got an object that responds to the tag, send it before rendering to_liquid.

I feel like there's potential for a bigger refactor here, to recursively apply the following tags and only render .to_liquid when necessary.
