### PR TITLE
Instantiate blank string once instead of at every comparison

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -22,6 +22,8 @@ module Liquid
   class Drop
     attr_writer :context
 
+    EMPTY_STRING = ''.freeze
+
     # Catch all for the method
     def before_method(method)
       nil
@@ -29,7 +31,7 @@ module Liquid
 
     # called by liquid to invoke a drop
     def invoke_drop(method_or_key)
-      if method_or_key && !method_or_key.empty? && self.class.public_method_defined?(method_or_key.to_s.to_sym)
+      if method_or_key && method_or_key != EMPTY_STRING && self.class.public_method_defined?(method_or_key.to_s.to_sym)
         send(method_or_key.to_s.to_sym)
       else
         before_method(method_or_key)


### PR DESCRIPTION
@burke @hornairs @camilo Please review

Running dtrace with the following probe:

```
sudo dtrace -n 'ruby*:::string-create{@[copyinstr(arg1),arg2]=count();}' -p
```

I found that during one normal liquid render, `/lib/liquid/drop.rb:35` would instantiate 3149 Strings.

Making the blank string a class attribute saves us the runtime allocations.
