### PR TITLE
Added alias for registering tag block

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -30,6 +30,8 @@ module Liquid
         tags[name.to_s] = klass
       end
 
+      alias_method :register_block, :register_tag
+
       def tags
         @tags ||= {}
       end


### PR DESCRIPTION
I found it confusing in the api, filters are registered one way, and both tags and blocks another.

Trying to make it consistant.

Thanks.
