### PR TITLE
Fix filter parser regex for filter args without separating spaces.

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -11,7 +11,7 @@ module Liquid
   #   {{ user | link }}
   #
   class Variable
-    FilterParser = /(?:#{FilterSeparator}|(?:\s*(?!(?:#{FilterSeparator}))(?:#{QuotedFragment}|\S+)\s*)+)/o
+    FilterParser = /(?:#{FilterSeparator}|(?:\s*(?:#{QuotedFragment}|#{ArgumentSeparator})\s*)+)/o
     attr_accessor :filters, :name
 
     def initialize(markup)

--- a/test/liquid/variable_test.rb
+++ b/test/liquid/variable_test.rb
@@ -66,6 +66,10 @@ class VariableTest < Test::Unit::TestCase
     var = Variable.new('hello|textileze|paragraph')
     assert_equal 'hello', var.name
     assert_equal [[:textileze,[]], [:paragraph,[]]], var.filters
+
+    var = Variable.new("hello|replace:'foo','bar'|textileze")
+    assert_equal 'hello', var.name
+    assert_equal [[:replace, ["'foo'", "'bar'"]], [:textileze, []]], var.filters
   end
 
   def test_symbol


### PR DESCRIPTION
@BlakeMesdag & @Soleone for review
## Problem

The following valid liquid was being parsed as if it had a single replace filter, so gave a liquid error since the replace filter was being called with 5 arguments instead of 3.

``` liquid
{{ product.description | replace:'<p>[[start tab]]</p>','<li class="tab">' | replace:'<p>[[end tab]]</p>','</li>' }}
```
## Diagnosis

The regex was using `\S+` to match the comma between the filters arguments, but would continue to match independent quote characters and filter separators. This can result in multiple filters being interpreted as a single one with many arguments.

In this case the `\S+` was matching `,'<li` after the first argument of the first filter, causing the end quote to be interpreted as the start of the quoted string `' | replace:'`
## Solution

Since `Liquid::QuotedFragment`  regex matched all non-whitespace characters, except for commas, pipes, or individual quotes characters (i.e. `[^\s,\|'"]`), the only remaining character to be handled was commas (i.e. `Liquid::ArgumentSeparator`).

Since pipe characters are excluded in `Liquid::QuotedFragment`, I was also able to remove `(?!(?:#{FilterSeparator}))` which was to avoid matching unquoted pipe characters, but only worked for the first character matched by `\S+`.

An alternative solution would be to change `\S` to `\S+`, but I believe the changes in this pull request make the code clearer and is a cleaner solution.
