### PR TITLE
Add ERB-like trim mode to tag syntax

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -26,11 +26,14 @@ module Liquid
   VariableAttributeSeparator  = '.'
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
+  TagEndTrim                  = /-#{TagEnd}\n?/o
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
   VariableSegment             = /[\w\-]/
   VariableStart               = /\{\{/
   VariableEnd                 = /\}\}/
+  VariableEndTrim             = /-#{VariableEnd}\n?/o
   VariableIncompleteEnd       = /\}\}?/
+  VariableIncompleteEndTrim   = /-#{VariableIncompleteEnd}\n?/o
   QuotedString                = /"[^"]*"|'[^']*'/
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
   StrictQuotedFragment        = /"[^"]+"|'[^']+'|[^\s|:,]+/
@@ -40,7 +43,7 @@ module Liquid
   Expression                  = /(?:#{QuotedFragment}(?:#{SpacelessFilter})*)/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/o
+  PartialTemplateParser       = /#{TagStart}.*?(?:#{TagEndTrim}|#{TagEnd})|#{VariableStart}.*?(?:#{VariableIncompleteEndTrim}|#{VariableIncompleteEnd})/o
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/o
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 end

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -3,8 +3,8 @@ module Liquid
   class Block < Tag
     IsTag             = /^#{TagStart}/o
     IsVariable        = /^#{VariableStart}/o
-    FullToken         = /^#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/o
-    ContentOfVariable = /^#{VariableStart}(.*)#{VariableEnd}$/o
+    FullToken         = /^#{TagStart}\s*(\w+)\s*(.*?)(?:#{TagEndTrim}|#{TagEnd})$/o
+    ContentOfVariable = /^#{VariableStart}(.*?)(?:#{VariableEndTrim}|#{VariableEnd})$/o
 
     def parse(tokens)
       @nodelist ||= []

--- a/test/lib/liquid/trim_test.rb
+++ b/test/lib/liquid/trim_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class TrimTest < Test::Unit::TestCase
+  include Liquid
+
+  def test_tag
+    assert_template_result "123\n", "{%if true-%}\n123\n{%endif%}"
+  end
+
+  def test_tag_without_newlink
+    assert_template_result "123\n", "{%if true-%}123\n{%endif%}"
+  end
+
+  def test_variable
+    template = Liquid::Template.parse("{{funk-}}\n{{so}}")
+    assert_equal 2, template.root.nodelist.size
+    assert_equal 'funk', template.root.nodelist[0].name
+    assert_equal 'so', template.root.nodelist[1].name
+  end
+
+  def test_variable_without_newline
+    template = Liquid::Template.parse("{{funk-}}{{so}}")
+    assert_equal 2, template.root.nodelist.size
+    assert_equal 'funk', template.root.nodelist[0].name
+    assert_equal 'so', template.root.nodelist[1].name
+  end
+
+end # TrimTest


### PR DESCRIPTION
This is a rebased and updated version of #49. It solves #162.

It performs slightly worse on the benchmark, but not much worse. I think this is important functionality if liquid is going to be useful for email templates, so I'm hopeful that you'll find the slight performance impact to be muted by the value of the functionality for that purpose.

Before:

```
                   user     system      total        real
parse:         4.150000   0.000000   4.150000 (  4.160474)
parse & run:   8.790000   0.020000   8.810000 (  8.830523)
```

After:

```
                   user     system      total        real
parse:         4.570000   0.000000   4.570000 (  4.574668)
parse & run:   9.140000   0.010000   9.150000 (  9.161449)
```
