### PR TITLE
Add support for keyword filter arguments

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -23,9 +23,9 @@ module Liquid
         if match[2].match(/#{FilterSeparator}\s*(.*)/o)
           filters = Regexp.last_match(1).scan(FilterParser)
           filters.each do |f|
-            if matches = f.match(/\s*(\w+)/)
+            if matches = f.match(/\s*(\w+)(?:\s*#{FilterArgumentSeparator}(.*))?/)
               filtername = matches[1]
-              filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*(#{QuotedFragment})/o).flatten
+              filterargs = matches[2].to_s.scan(/(?:\A|#{ArgumentSeparator})\s*((?:\w+\s*\:\s*)?#{QuotedFragment})/o).flatten
               @filters << [filtername.to_sym, filterargs]
             end
           end
@@ -36,9 +36,16 @@ module Liquid
     def render(context)
       return '' if @name.nil?
       @filters.inject(context[@name]) do |output, filter|
-        filterargs = filter[1].to_a.collect do |a|
-          context[a]
+        filterargs = []
+        keyword_args = {}
+        filter[1].to_a.each do |a|
+          if matches = a.match(/\A#{TagAttributes}\z/o)
+            keyword_args[matches[1]] = context[matches[2]]
+          else
+            filterargs << context[a]
+          end
         end
+        filterargs << keyword_args unless keyword_args.empty?
         begin
           output = context.invoke(filter[0], output, *filterargs)
         rescue FilterNotFound

--- a/test/liquid/filter_test.rb
+++ b/test/liquid/filter_test.rb
@@ -16,6 +16,12 @@ module CanadianMoneyFilter
   end
 end
 
+module SubstituteFilter
+  def substitute(input, params={})
+    input % Hash[params.map{|k,v| [k.to_sym, v] }]
+  end
+end
+
 class FiltersTest < Test::Unit::TestCase
   include Liquid
 
@@ -91,6 +97,13 @@ class FiltersTest < Test::Unit::TestCase
     @context['var'] = 1000
 
     assert_equal 1000, Variable.new("var | xyzzy").render(@context)
+  end
+
+  def test_filter_with_keyword_arguments
+    @context['surname'] = 'john'
+    @context.add_filters(SubstituteFilter)
+    output = Variable.new(%! 'hello %{first_name}, %{last_name}' | substitute: first_name: surname, last_name: 'doe' !).render(@context)
+    assert_equal 'hello john, doe', output
   end
 end
 

--- a/test/liquid/variable_test.rb
+++ b/test/liquid/variable_test.rb
@@ -107,6 +107,12 @@ class VariableTest < Test::Unit::TestCase
     var = Variable.new(%| test.test |)
     assert_equal 'test.test', var.name
   end
+
+  def test_filter_with_keyword_arguments
+    var = Variable.new(%! hello | things: greeting: "world", farewell: 'goodbye'!)
+    assert_equal 'hello', var.name
+    assert_equal [[:things,["greeting: \"world\"","farewell: 'goodbye'"]]], var.filters
+  end
 end
 
 


### PR DESCRIPTION
@boourns & @Soleone for review
cc @tobi
## Usage

In liquid the syntax would be as follows to call the filter with keyword arguments.

```
'input' | filtername: key1: 'value1', key2: 'value2'
```

``` ruby
def filtername(input, params={})
  # ...
end
```

Positional arguments are also supported.

```
'input' | filtername: arg1, arg2, key1: 'value1', key2: 'value2'
```

``` ruby
def filtername(input, arg1, arg2, params={})
  # ...
end
```
