### PR TITLE
Add reverse filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -90,6 +90,12 @@ module Liquid
       end
     end
 
+    # Reverse the elements of an array
+    def reverse(input)
+      ary = [input].flatten
+      ary.reverse
+    end
+
     # map/collect on a given property
     def map(input, property)
       ary = [input].flatten

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -80,6 +80,10 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_equal [{"a" => 1}, {"a" => 2}, {"a" => 3}, {"a" => 4}], @filters.sort([{"a" => 4}, {"a" => 3}, {"a" => 1}, {"a" => 2}], "a")
   end
 
+  def test_reverse
+    assert_equal [4,3,2,1], @filters.reverse([1,2,3,4])
+  end
+
   def test_map
     assert_equal [1,2,3,4], @filters.map([{"a" => 1}, {"a" => 2}, {"a" => 3}, {"a" => 4}], 'a')
     assert_template_result 'abc', "{{ ary | map:'foo' | map:'bar' }}",


### PR DESCRIPTION
If we have the ability to sort an array, it would be nice to be able to reverse it as well (since there is no way to specify sort order in #sort)

``` ruby
{{ unsorted_thing | sort | reverse }}
```
