### PR TITLE
cleanup whitespace after tags (jinja style)

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -24,8 +24,8 @@ module Liquid
   ArgumentSeparator           = ','
   FilterArgumentSeparator     = ':'
   VariableAttributeSeparator  = '.'
-  TagStart                    = /\{\%/
-  TagEnd                      = /\%\}\s*/
+  TagStart                    = /[ \t\r\f]*\{\%/
+  TagEnd                      = /\%\}[ \t\r\f]*\n?/
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
   VariableSegment             = /[\w\-]/
   VariableStart               = /\{\{/


### PR DESCRIPTION
This removes extra whitespace around tags, just like Jinja2 does

template:

```
items:
{% for item in items %}
  - {{ item }}
{% endfor %}
```

before:

```
items:

  - 1

  - 2

  - 3
```

after:

```
items:
  - 1
  - 2
  - 3
```
