### PR TITLE
Render with timeout

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Error < ::StandardError; end
-  
+
   class ArgumentError < Error; end
   class ContextError < Error; end
   class FilterNotFound < Error; end
@@ -8,4 +8,5 @@ module Liquid
   class StandardError < Error; end
   class SyntaxError < Error; end
   class StackLevelError < Error; end
+  class TimeoutError < Error; end
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -87,8 +87,18 @@ module Liquid
     #    filters and tags and might be useful to integrate liquid more with its host application
     #
     def render(*args)
+      render_without_timeout(*args)
+    end
+
+    def render_with_timeout(seconds, *args)
+      Timeout::timeout(seconds, Liquid::TimeoutError) do
+        render_without_timeout(*args)
+      end
+    end
+
+    def render_without_timeout(*args)
       return '' if @root.nil?
-      
+
       context = case args.first
       when Liquid::Context
         args.shift

--- a/test/liquid/template_test.rb
+++ b/test/liquid/template_test.rb
@@ -71,4 +71,8 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal '1', t.render(assigns)
     @global = nil
   end
+
+  def test_render_with_timeout
+    assert_equal "Liquid error: execution expired", Template.new.parse("{{foo}}").render_with_timeout(0.1, {'foo' => lambda { sleep 5 }})
+  end
 end # TemplateTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 require 'test/unit'
 require 'test/unit/assertions'
+require "timeout"
 begin
   require 'ruby-debug'
 rescue LoadError


### PR DESCRIPTION
Introduce opt-in time limits for template rendering.

Default behaviour doesn't change.

If you want timeouts, require timeout gem in your own code and overwrite Liquid::Template render() instance method.

Please review @boourns @burke
