### PR TITLE
Fix broken 'raw' tag parsing (issue #204)

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,12 +1,14 @@
 module Liquid
   class Raw < Block
+    FullTokenPossiblyInvalid = /^(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/o
+
     def parse(tokens)
       @nodelist ||= []
       @nodelist.clear
-
       while token = tokens.shift
-        if token =~ FullToken
-          if block_delimiter == $1
+        if token =~ FullTokenPossiblyInvalid
+          @nodelist << $1 if $1 != ""
+          if block_delimiter == $2
             end_tag
             return
           end
@@ -18,4 +20,3 @@ module Liquid
 
   Template.register_tag('raw', Raw)
 end
-

--- a/test/liquid/tags/raw_tag_test.rb
+++ b/test/liquid/tags/raw_tag_test.rb
@@ -9,7 +9,16 @@ class RawTagTest < Test::Unit::TestCase
   end
 
   def test_output_in_raw
-    assert_template_result '{{ test }}',
-                           '{% raw %}{{ test }}{% endraw %}'
+    assert_template_result '{{ test }}', '{% raw %}{{ test }}{% endraw %}'
+  end
+
+  def test_open_tag_in_raw
+    assert_template_result ' Foobar {% invalid ', '{% raw %} Foobar {% invalid {% endraw %}'
+    assert_template_result ' Foobar invalid %} ', '{% raw %} Foobar invalid %} {% endraw %}'
+    assert_template_result ' Foobar {{ invalid ', '{% raw %} Foobar {{ invalid {% endraw %}'
+    assert_template_result ' Foobar invalid }} ', '{% raw %} Foobar invalid }} {% endraw %}'
+    assert_template_result ' Foobar {% invalid {% {% endraw ', '{% raw %} Foobar {% invalid {% {% endraw {% endraw %}'
+    assert_template_result ' Foobar {% {% {% ', '{% raw %} Foobar {% {% {% {% endraw %}'
+    assert_template_result ' test {% raw %} {% endraw %}', '{% raw %} test {% raw %} {% {% endraw %}endraw %}'
   end
 end


### PR DESCRIPTION
This should fix issue #204.

Something like `{% raw %} {% whatever {% endraw %}` wasn't parsed correctly.

Please review @dylanahsmith 
cc @SLaks
