### PR TITLE
Use invoke_drop in map filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -100,10 +100,8 @@ module Liquid
     # map/collect on a given property
     def map(input, property)
       ary = [input].flatten
-      if ary.first.respond_to?('[]') and !ary.first[property].nil?
-        ary.map {|e| e[property] }
-      elsif ary.first.respond_to?(property)
-        ary.map {|e| e.send(property) }
+      ary.map do |e|
+        e.respond_to?('[]') ? e[property] : nil
       end
     end
 

--- a/test/liquid/drop_test.rb
+++ b/test/liquid/drop_test.rb
@@ -71,23 +71,29 @@ class DropsTest < Test::Unit::TestCase
   include Liquid
 
   def test_product_drop
-
     assert_nothing_raised do
       tpl = Liquid::Template.parse( '  '  )
       tpl.render('product' => ProductDrop.new)
     end
   end
 
+  def test_drop_does_only_respond_to_whitelisted_methods
+    assert_equal "", Liquid::Template.parse("{{ product.inspect }}").render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse("{{ product.pretty_inspect }}").render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse("{{ product.whatever }}").render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "inspect" }}').render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "pretty_inspect" }}').render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "whatever" }}').render('product' => ProductDrop.new)
+  end
+
   def test_text_drop
     output = Liquid::Template.parse( ' {{ product.texts.text }} '  ).render('product' => ProductDrop.new)
     assert_equal ' text1 ', output
-
   end
 
   def test_unknown_method
     output = Liquid::Template.parse( ' {{ product.catchall.unknown }} '  ).render('product' => ProductDrop.new)
     assert_equal ' method: unknown ', output
-
   end
 
   def test_integer_argument_drop

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -97,6 +97,11 @@ class StandardFiltersTest < Test::Unit::TestCase
       'ary' => [{'foo' => {'bar' => 'a'}}, {'foo' => {'bar' => 'b'}}, {'foo' => {'bar' => 'c'}}]
   end
 
+  def test_map_doesnt_call_arbitrary_stuff
+    assert_equal "", Liquid::Template.parse('{{ "foo" | map: "__id__" }}').render
+    assert_equal "", Liquid::Template.parse('{{ "foo" | map: "inspect" }}').render
+  end
+
   def test_date
     assert_equal 'May', @filters.date(Time.parse("2006-05-05 10:00:00"), "%B")
     assert_equal 'June', @filters.date(Time.parse("2006-06-05 10:00:00"), "%B")


### PR DESCRIPTION
This will make stuff a bit slower because of checking each element we are mapping over instead of just the first one, but it feels saner.

Please review ASAP @boourns @dylanahsmith

We should probably backport this into 2.5 and release 2.5.1.
