### PR TITLE
Always call 'to_liquid' on stuff in map filter and allow to_liquid to be...

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -54,7 +54,7 @@ module Liquid
 
     # Check for method existence without invoking respond_to?, which creates symbols
     def self.invokable?(method_name)
-      @invokable_methods ||= Set.new((public_instance_methods - Liquid::Drop.public_instance_methods).map(&:to_s))
+      @invokable_methods ||= Set.new(["to_liquid"] + (public_instance_methods - Liquid::Drop.public_instance_methods).map(&:to_s))
       @invokable_methods.include?(method_name.to_s)
     end
   end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -101,7 +101,13 @@ module Liquid
     def map(input, property)
       ary = [input].flatten
       ary.map do |e|
-        e.respond_to?('[]') ? e[property] : nil
+        if e.respond_to?(:to_liquid)
+          e = e.to_liquid
+        end
+
+        if e.respond_to?('[]')
+          e[property]
+        end
       end
     end
 

--- a/test/liquid/drop_test.rb
+++ b/test/liquid/drop_test.rb
@@ -86,6 +86,11 @@ class DropsTest < Test::Unit::TestCase
     assert_equal "", Liquid::Template.parse('{{ product | map: "whatever" }}').render('product' => ProductDrop.new)
   end
 
+  def test_drops_respond_to_to_liquid
+    assert_equal "text1", Liquid::Template.parse("{{ product.to_liquid.texts.text }}").render('product' => ProductDrop.new)
+    assert_equal "text1", Liquid::Template.parse('{{ product | map: "to_liquid" | map: "texts" | map: "text" }}').render('product' => ProductDrop.new)
+  end
+
   def test_text_drop
     output = Liquid::Template.parse( ' {{ product.texts.text }} '  ).render('product' => ProductDrop.new)
     assert_equal ' text1 ', output


### PR DESCRIPTION
People are doing this

`{{cart.items|map:'to_liquid'|map:'product'|map:'to_liquid'|map:'id'|join:','}}`

which is broken since #230.

For backwards compatibility, this PR allows to call "to_liquid" on drops. Also, automatically call "to_liquid" on all the things if possible before doing anything.

Please review @dylanahsmith 
