### PR TITLE
Make 'map' filter work on Enumerable drops

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -99,7 +99,14 @@ module Liquid
 
     # map/collect on a given property
     def map(input, property)
-      ary = [input].flatten
+      ary = if input.is_a?(Array)
+        input.flatten
+      elsif !input.class.include?(Enumerable)
+        [input].flatten
+      else
+        input
+      end
+
       ary.map do |e|
         e = e.call if e.is_a?(Proc)
         e = e.to_liquid if e.respond_to?(:to_liquid)

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -27,6 +27,14 @@ class TestDrop < Liquid::Drop
   end
 end
 
+class TestEnumerable < Liquid::Drop
+  include Enumerable
+
+  def each(&block)
+    [ { "foo" => 1 }, { "foo" => 2 }, { "foo" => 3 } ].each(&block)
+  end
+end
+
 class StandardFiltersTest < Test::Unit::TestCase
   include Liquid
 
@@ -133,6 +141,10 @@ class StandardFiltersTest < Test::Unit::TestCase
     p = Proc.new{ drop }
     templ = '{{ procs | map: "test" }}'
     assert_equal "testfoo", Liquid::Template.parse(templ).render("procs" => [p])
+  end
+
+  def test_map_works_on_enumerables
+    assert_equal "123", Liquid::Template.parse('{{ foo | map: "foo" }}').render!("foo" => TestEnumerable.new)
   end
 
   def test_date


### PR DESCRIPTION
The map filter does not work on Enumerable drops, but I think it should (and after talking to some people, they would like to use the map filter more often, but they can't really, because it doesn't work on CachedDrop or CollectionDrop in Shopify). This should hopefully fix that.

Please review @dylanahsmith @arthurnn 
