### PR TITLE
Fix mapping over procs

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -101,11 +101,12 @@ module Liquid
     def map(input, property)
       ary = [input].flatten
       ary.map do |e|
-        if e.respond_to?(:to_liquid)
-          e = e.to_liquid
-        end
+        e = e.call if e.is_a?(Proc)
+        e = e.to_liquid if e.respond_to?(:to_liquid)
 
-        if e.respond_to?('[]')
+        if property == "to_liquid"
+          e
+        elsif e.respond_to?(:[])
           e[property]
         end
       end

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -6,6 +6,27 @@ class Filters
   include Liquid::StandardFilters
 end
 
+class TestThing
+  def initialize
+    @foo = 0
+  end
+
+  def to_s
+    "woot: #{@foo}"
+  end
+
+  def to_liquid
+    @foo += 1
+    self
+  end
+end
+
+class TestDrop < Liquid::Drop
+  def test
+    "testfoo"
+  end
+end
+
 class StandardFiltersTest < Test::Unit::TestCase
   include Liquid
 
@@ -100,6 +121,18 @@ class StandardFiltersTest < Test::Unit::TestCase
   def test_map_doesnt_call_arbitrary_stuff
     assert_equal "", Liquid::Template.parse('{{ "foo" | map: "__id__" }}').render
     assert_equal "", Liquid::Template.parse('{{ "foo" | map: "inspect" }}').render
+  end
+
+  def test_map_calls_to_liquid
+    t = TestThing.new
+    assert_equal "woot: 1", Liquid::Template.parse('{{ foo }}').render("foo" => t)
+  end
+
+  def test_map_over_proc
+    drop = TestDrop.new
+    p = Proc.new{ drop }
+    templ = '{{ procs | map: "test" }}'
+    assert_equal "testfoo", Liquid::Template.parse(templ).render("procs" => [p])
   end
 
   def test_date


### PR DESCRIPTION
Turns out, #232 didn't completely fix the issue. We sometimes use Proc objects to lazy load stuff in drops. This PR takes that into account. Also, make sure that we always call `to_liquid` if possible (and for backwards compatibility, make `map: "to_liquid"` a no-op if we call it on something which doesn't respond to it).

Please review @dylanahsmith 
