### PR TITLE
Fix clashing method names in enumerable drops

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -59,7 +59,7 @@ module Liquid
         blacklist = (Liquid::Drop.public_instance_methods + [:each]).map(&:to_s)
         if include?(Enumerable)
           blacklist += Enumerable.public_instance_methods.map(&:to_s)
-          blacklist -= [:sort, :count, :first, :min, :max].map(&:to_s)
+          blacklist -= [:sort, :count, :first, :min, :max, :include?].map(&:to_s)
         end
         whitelist = [:to_liquid] + (public_instance_methods.map(&:to_s) - blacklist.map(&:to_s))
         @invokable_methods = Set.new(whitelist.map(&:to_s))

--- a/test/liquid/drop_test.rb
+++ b/test/liquid/drop_test.rb
@@ -220,6 +220,8 @@ class DropsTest < Test::Unit::TestCase
       assert_equal "3", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => EnumerableDrop.new)
     end
 
+    assert_equal "yes", Liquid::Template.parse("{% if collection contains 3 %}yes{% endif %}").render('collection' => RealEnumerableDrop.new)
+
     [ :min, :first ].each do |method|
       assert_equal "1", Liquid::Template.parse("{{collection.#{method}}}").render('collection' => RealEnumerableDrop.new)
       assert_equal "1", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => RealEnumerableDrop.new)


### PR DESCRIPTION
Make sure that including the Enumerable module will not clash with `before_method`.
