### PR TITLE
Sort filter on Enumerables

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -101,7 +101,6 @@ module Liquid
     def map(input, property)
       flatten_if_necessary(input).map do |e|
         e = e.call if e.is_a?(Proc)
-        e = e.to_liquid if e.respond_to?(:to_liquid)
 
         if property == "to_liquid"
           e
@@ -249,13 +248,14 @@ module Liquid
     private
 
     def flatten_if_necessary(input)
-      if input.is_a?(Array)
+      ary = if input.is_a?(Array)
         input.flatten
       elsif input.kind_of?(Enumerable)
         input
       else
         [input].flatten
       end
+      ary.map{ |e| e.respond_to?(:to_liquid) ? e.to_liquid : e }
     end
 
     def to_number(obj)

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -15,6 +15,10 @@ class TestThing
     "woot: #{@foo}"
   end
 
+  def [](whatever)
+    to_s
+  end
+
   def to_liquid
     @foo += 1
     self
@@ -133,7 +137,12 @@ class StandardFiltersTest < Test::Unit::TestCase
 
   def test_map_calls_to_liquid
     t = TestThing.new
-    assert_equal "woot: 1", Liquid::Template.parse('{{ foo }}').render("foo" => t)
+    assert_equal "woot: 1", Liquid::Template.parse('{{ foo | map: "whatever" }}').render("foo" => [t])
+  end
+
+  def test_sort_calls_to_liquid
+    t = TestThing.new
+    assert_equal "woot: 1", Liquid::Template.parse('{{ foo | sort: "whatever" }}').render("foo" => [t])
   end
 
   def test_map_over_proc


### PR DESCRIPTION
Enumerable drops can't be sorted right now. This should fix that (including the Enumerable module defines a sort method).

Also, fix a broken test from before, which is kind of related.

Please take a quick look @arthurnn and @csfrancis.
