### PR TITLE
Overwrite drop inspect

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -44,6 +44,10 @@ module Liquid
       true
     end
 
+    def inspect
+      self.class.to_s
+    end
+
     def to_liquid
       self
     end


### PR DESCRIPTION
Overwrite the inspect method of Liquid drops to not trigger a deep inspect on NameError exceptions (see http://apidock.com/ruby/NameError/message/to_str and the default case in the obj switch).

Quick look please @csfrancis.
