### PR TITLE
Ignore singular curly brackets in template parser

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -40,7 +40,7 @@ module Liquid
   Expression                  = /(?:#{QuotedFragment}(?:#{SpacelessFilter})*)/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/o
+  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableEnd}/o
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/o
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 end

--- a/test/liquid/template_test.rb
+++ b/test/liquid/template_test.rb
@@ -37,6 +37,11 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal ['  ', '{% comment %}', ' ', '{% endcomment %}', ' '], Template.new.send(:tokenize, "  {% comment %} {% endcomment %} ")
   end
 
+
+  def test_tokenize_string_with_curly_brackets
+    assert_equal ["{{ 'hello {world}' }}"], Template.new.send(:tokenize, "{{ 'hello {world}' }}")
+  end
+
   def test_instance_assigns_persist_on_same_template_object_between_parses
     t = Template.new
     assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render


### PR DESCRIPTION
By some reason Liquid parser currently don't allow to use curly brackets
inside of {{  }}. 

``` liquid
{{ 'hello {world}' }}
```

This will cause syntax error.
I don't know what was a reason for this limitation.
There is no test case covering this behavior so I think we can fix
that.
