### PR TITLE
Fix bad range parsing.

### DIFF
--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -15,6 +15,7 @@ module Liquid
     SINGLE_STRING_LITERAL = /'[^\']*'/
     DOUBLE_STRING_LITERAL = /"[^\"]*"/
     NUMBER_LITERAL = /-?\d+(\.\d+)?/
+    DOTDOT = /\.\./
     COMPARISON_OPERATOR = /==|!=|<>|<=?|>=?|contains/
 
     def initialize(input)
@@ -32,6 +33,7 @@ module Liquid
         when t = @ss.scan(DOUBLE_STRING_LITERAL) then [:string, t]
         when t = @ss.scan(NUMBER_LITERAL) then [:number, t]
         when t = @ss.scan(IDENTIFIER) then [:id, t]
+        when t = @ss.scan(DOTDOT) then [:dotdot, t]
         else
           c = @ss.getch
           if s = SPECIALS[c]

--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -53,8 +53,7 @@ module Liquid
       elsif token.first == :open_round
         consume
         first = expression
-        consume(:dot)
-        consume(:dot)
+        consume(:dotdot)
         last = expression
         consume(:close_round)
         "(#{first}..#{last})"

--- a/test/liquid/parser_test.rb
+++ b/test/liquid/parser_test.rb
@@ -56,6 +56,14 @@ class ParserTest < Test::Unit::TestCase
     assert_equal '"wut"', p.expression
   end
 
+  def test_ranges
+    p = Parser.new("(5..7) (1.5..9.6) (young..old) (hi[5].wat..old)")
+    assert_equal '(5..7)', p.expression
+    assert_equal '(1.5..9.6)', p.expression
+    assert_equal '(young..old)', p.expression
+    assert_equal '(hi[5].wat..old)', p.expression
+  end
+
   def test_arguments
     p = Parser.new("filter: hi.there[5], keyarg: 7")
     assert_equal 'filter', p.consume(:id)


### PR DESCRIPTION
@fw42 

This should fix a bug @jules2689 discovered in the parsing of ranges like `(young..old)` with the new parser.
It lexes a `..` as a separate token from `.`, which it is. This should stop the parser from looking for the field in a field lookup when it encounters `young.`

Also includes a regression test.
