### PR TITLE
Fix handling of unknown tags in comments

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -1,5 +1,7 @@
+require "liquid/tags/raw"
+
 module Liquid
-  class Comment < Block
+  class Comment < Raw
     def render(context)
       ''
     end

--- a/test/liquid/tags/standard_tag_test.rb
+++ b/test/liquid/tags/standard_tag_test.rb
@@ -34,6 +34,12 @@ class StandardTagTest < Test::Unit::TestCase
     assert_template_result('','{%comment%}comment{%endcomment%}')
     assert_template_result('','{% comment %}comment{% endcomment %}')
 
+    assert_template_result('','{%comment%}{%blabla%}{%endcomment%}')
+    assert_template_result('','{% comment %}{% blabla %}{% endcomment %}')
+    assert_template_result('','{%comment%}{% endif %}{%endcomment%}')
+    assert_template_result('','{% comment %}{% endwhatever %}{% endcomment %}')
+    assert_template_result('','{% comment %} {{ %} {{%%%}} {% endcomment {% endcomment %}')
+
     assert_template_result('foobar','foo{%comment%}comment{%endcomment%}bar')
     assert_template_result('foobar','foo{% comment %}comment{% endcomment %}bar')
     assert_template_result('foobar','foo{%comment%} comment {%endcomment%}bar')


### PR DESCRIPTION
Fixes this:

```
>> Liquid::Template.parse("{% comment %} {% whatever %} {% endcomment %}")
Liquid::SyntaxError: Unknown tag 'whatever'
```

Please review @Sirupsen @dylanahsmith
