### PR TITLE
Fix unknown tags in comment tags, second try

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -4,6 +4,9 @@ module Liquid
       ''
     end
 
+    def unknown_tag(tag, markup, tokens)
+    end
+
     def blank?
       true
     end

--- a/test/liquid/tags/standard_tag_test.rb
+++ b/test/liquid/tags/standard_tag_test.rb
@@ -35,6 +35,12 @@ class StandardTagTest < Test::Unit::TestCase
     assert_template_result('','{% comment %}comment{% endcomment %}')
     assert_template_result('','{% comment %} 1 {% comment %} 2 {% endcomment %} 3 {% endcomment %}')
 
+    assert_template_result('','{%comment%}{%blabla%}{%endcomment%}')
+    assert_template_result('','{% comment %}{% blabla %}{% endcomment %}')
+    assert_template_result('','{%comment%}{% endif %}{%endcomment%}')
+    assert_template_result('','{% comment %}{% endwhatever %}{% endcomment %}')
+    assert_template_result('','{% comment %}{% raw %} {{%%%%}}  }} { {% endcomment %} {% comment {% endraw %} {% endcomment %}')
+
     assert_template_result('foobar','foo{%comment%}comment{%endcomment%}bar')
     assert_template_result('foobar','foo{% comment %}comment{% endcomment %}bar')
     assert_template_result('foobar','foo{%comment%} comment {%endcomment%}bar')


### PR DESCRIPTION
Had to revert #256, because people are using this in Shopify:
`{% comment %} foo {% comment %} bar {% endcomment %} bla {% endcomment %}`, which failed with #256.

So back to my original `unknown_tag` approach. This solves my original issue, but unfortunately does not allow comments around syntax errors. If people really need that, they can use `{% comment %} {% raw %} ... {% endraw %} {% endcomment %}` I guess. Not a nice solution, but everything else would be much more complicated I think.

Please take another look @Sirupsen @dylanahsmith / cc @silverstreaked
