### PR TITLE
Template Inheritance

### DIFF
--- a/lib/liquid/locales/en.yml
+++ b/lib/liquid/locales/en.yml
@@ -7,6 +7,7 @@
       case_invalid_when: "Syntax Error in tag 'case' - Valid when condition: {% when [condition] [or condition2...] %}"
       case_invalid_else: "Syntax Error in tag 'case' - Valid else condition: {% else %} (no parameters) "
       cycle: "Syntax Error in 'cycle' - Valid syntax: cycle [name :] var [, var2, var3 ...]"
+      extend: "Error in tag 'extend' - Valid syntax: extend '[template]'"
       for: "Syntax Error in 'for loop' - Valid syntax: for [item] in [collection]"
       for_invalid_in: "For loops require an 'in' clause"
       for_invalid_attribute: "Invalid attribute in for loop. Valid attributes are limit and offset"

--- a/lib/liquid/tags/extend.rb
+++ b/lib/liquid/tags/extend.rb
@@ -1,0 +1,32 @@
+module Liquid
+
+  # Extend allows templates to inherit from other templates
+  #
+  # Extend from another template like:
+  #
+  #   {% extend 'products' %}
+  #
+  require 'lib/liquid/tags/include'
+
+  class Extend < Liquid::Include
+    Syntax = /(#{QuotedFragment}+)/o
+
+    def initialize(tag_name, markup, tokens)
+      if markup =~ Syntax
+        @template_name = $1
+      else
+        raise SyntaxError.new(options[:locale].t("errors.syntax.extend"))
+      end
+
+      super
+    end
+
+    def render(context)
+      context[@template_name] = @template_name
+      template = load_cached_partial(context)
+      template.render(context)
+    end
+  end
+
+  Template.register_tag('extend', Extend)
+end

--- a/test/liquid/tags/extend_tag_test.rb
+++ b/test/liquid/tags/extend_tag_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class ExtendTestFileSystem
+  def read_template_file(template_path, context)
+    case template_path
+    when "base"
+      "<body>base</body>"
+
+    else
+      template_path
+    end
+  end
+end
+
+
+class ExtendTagTest < Test::Unit::TestCase
+  include Liquid
+
+  def setup
+    Liquid::Template.file_system = ExtendTestFileSystem.new
+  end
+
+  def test_extend
+    assert_equal "<body>base</body>", Template.parse("{% extend base %}").render
+  end
+end


### PR DESCRIPTION
This is a WIP branch from my Hack Days project to add Django-style template inheritance to Liquid.

So far I've got the `extend` tag working, but the `block` tag needs work. I created the pull request so other Shopifyers could see my progress.
