### PR TITLE
Fix map filter on Hash inputs

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -250,7 +250,7 @@ module Liquid
     def flatten_if_necessary(input)
       ary = if input.is_a?(Array)
         input.flatten
-      elsif input.kind_of?(Enumerable)
+      elsif input.is_a?(Enumerable) && !input.is_a?(Hash)
         input
       else
         [input].flatten

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -140,6 +140,10 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_equal "woot: 1", Liquid::Template.parse('{{ foo | map: "whatever" }}').render("foo" => [t])
   end
 
+  def test_map_on_hashes
+    assert_equal "4217", Liquid::Template.parse('{{ thing | map: "foo" | map: "bar" }}').render("thing" => { "foo" => [ { "bar" => 42 }, { "bar" => 17 } ] })
+  end
+
   def test_sort_calls_to_liquid
     t = TestThing.new
     assert_equal "woot: 1", Liquid::Template.parse('{{ foo | sort: "whatever" }}').render("foo" => [t])


### PR DESCRIPTION
Fixes breakage which showed up in Jekyll, see https://github.com/Shopify/liquid/pull/239#issuecomment-25845173 and https://github.com/mojombo/jekyll/issues/1620.

If we really want the new behaviour, we should wait for a new major release to introduce it.

Please review @arthurnn @dylanahsmith / cc @parkr
