### PR TITLE
add support for drops with dynamically added methods

### DIFF
--- a/test/liquid/drop_test.rb
+++ b/test/liquid/drop_test.rb
@@ -40,6 +40,13 @@ class ProductDrop < Liquid::Drop
     TextDrop.new
   end
 
+  def texts2
+    TextDrop.class_eval { attr_reader :text2 }
+    t = TextDrop.new
+    t.instance_variable_set('@text2', 'text2')
+    t
+  end
+
   def catchall
     CatchallDrop.new
   end
@@ -102,6 +109,11 @@ end
 
 class DropsTest < Test::Unit::TestCase
   include Liquid
+
+  def test_dynamically_added_methods
+    tpl = Liquid::Template.parse('{% assign text = product.texts.text %}{{ product.texts2.text2 }}')
+    assert_equal 'text2', tpl.render('product' => ProductDrop.new)
+  end
 
   def test_product_drop
     assert_nothing_raised do


### PR DESCRIPTION
I'm using Drops as a sort of OpenStruct and ran into an issue when adding different methods to the same class, it's likely a unique use case but you never know.  {{gift.desc}} in the example below should return 'description' but returns nil.  Since item.name was called first, its InvoiceItem methods ('name' and 'amount') were cached by Drop.invokable? and I'm unable to access gift.desc.

``` ruby
class Invoice < Liquid::Drop
  class InvoiceItem < Liquid::Drop
    def initialize(attrs)
      attrs.each do |k, v|
        # Create an attr_reader for each given attr
        instance_variable_set("@#{k}", v) 
        self.class.class_eval "attr_reader k"
      end
    end
  end

  def items
    [InvoiceItem.new(:name => 'item', :amount => '25.00')]
  end

  def gifts
    [InvoiceItem.new(:name => 'gift', :amount => '50.00', :desc => 'description')]
  end
end

str = '{% for item in invoice.items %}{% assign name = item.name %}{% endfor %}{% for gift in invoice.gifts %}{{gift.desc}}{% endfor %}'
tpl = Liquid::Template.parse(str)
assert_equal 'description', tpl.render('invoice' => Invoice.new)
```
