### PR TITLE
Support for passing variables to snippets in subdirs

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -51,13 +51,14 @@ module Liquid
           context[key] = context[value]
         end
 
+        context_variable_name = @template_name[1..-2].split('/').last # for a snippet in a subdir only use the filename
         if variable.is_a?(Array)
           variable.collect do |var|
-            context[@template_name[1..-2]] = var
+            context[context_variable_name] = var
             partial.render(context)
           end
         else
-          context[@template_name[1..-2]] = variable
+          context[context_variable_name] = variable
           partial.render(context)
         end
       end


### PR DESCRIPTION
Now you can use "include 'some/snippet' with variable".

Since the include tag uses the template name as variable a variable name like 'some/directory' seems (logically) not supported. This change only uses the last name 'directory' as the variable name.
