### PR TITLE
Fix escape_once filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -4,6 +4,8 @@ require 'bigdecimal'
 module Liquid
 
   module StandardFilters
+    HTML_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;', '"' => '&quot;', "'" => '&#39;' }
+    HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
 
     # Return the size of an array or of an string
     def size(input)
@@ -31,9 +33,7 @@ module Liquid
     end
 
     def escape_once(input)
-      ActionView::Helpers::TagHelper.escape_once(input)
-    rescue NameError
-      input
+      input.to_s.gsub(HTML_ESCAPE_ONCE_REGEXP, HTML_ESCAPE)
     end
 
     alias_method :h, :escape

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -89,7 +89,7 @@ class StandardFiltersTest < Test::Unit::TestCase
   end
 
   def test_escape_once
-    assert_equal '&lt;strong&gt;', @filters.escape_once(@filters.escape('<strong>'))
+    assert_equal '&lt;strong&gt;Hulk&lt;/strong&gt;', @filters.escape_once('&lt;strong&gt;Hulk</strong>')
   end
 
   def test_truncatewords


### PR DESCRIPTION
Solves #283 

We don't want to add actionpack dependency. So i've just replicated its `#escape_once` implementation. I'd say this is good enough? We could also just remove the filter otherwise.

@fw42 @arthurnn what do you think?
