### PR TITLE
Added replace_last and corresponding tests to list of standard filters.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -121,7 +121,7 @@ module Liquid
 
     # Replace the last occurrence of a string with another
     def replace_last(input, string, replacement = '')
-      input.to_s.sub(/(.*)#{string}$/, "\\1#{replacement}")
+      input.to_s.sub(/(.*)#{string}(.*)$/, "\\1#{replacement}\\2")
     end
  
     # remove a substring

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -202,6 +202,7 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_equal '2 2 2 2', @filters.replace('1 1 1 1', '1', 2)
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2)
     assert_equal '1 1 1 2', @filters.replace_last('1 1 1 1', '1', 2)
+    assert_equal '1 1 2 2', @filters.replace_last('1 1 1 2', '1', 2)
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
     assert_template_result '1 1 1 2', "{{ '1 1 1 1' | replace_last: '1', 2 }}"
   end


### PR DESCRIPTION
Hi @dylanahsmith. I'd like to contribute the following change to liquid. Would you be able to do a code review?

The change is to add a standard filter called "replace_last" which simply replaces the last occurrence of a string with another string.

Although this of course could be implemented as a custom filter, I thought it was basic enough that it should be included in the list of standard filters.

I also added some corresponding tests.

Best regards,
Mark Benson
