### PR TITLE
Support sorting the collection in a for loop tag.

### DIFF
--- a/test/liquid/tags/for_tag_test.rb
+++ b/test/liquid/tags/for_tag_test.rb
@@ -69,6 +69,39 @@ HERE
     assert_template_result('-',   '{%for item in array%}+{%else%}-{%endfor%}', 'array'=>nil)
   end
 
+  class ConvertibleToLiquidObject
+    def initialize(params)
+      @params = params
+    end
+
+    def to_liquid
+      @params
+    end
+  end
+
+  def test_sorting
+    assigns = {'array' => [1,2,3,4,5,6,7,8,9,0]}
+    assert_template_result('0123456789', '{%for i in array order:ascending %}{{ i }}{%endfor%}', assigns)
+    assert_template_result('9876543210', '{%for i in array order:descending %}{{ i }}{%endfor%}', assigns)
+    assert_template_result('765', '{%for i in array order:descending offset:2 limit:3 %}{{ i }}{%endfor%}', assigns)
+
+    assigns = {'array' => [{"name" => 'A', "count" => '3'}, {"name" => 'C', "count" => '1'}, {"name" => 'B', "count" => '2'}]}
+    assert_template_result('A|B|C|', '{%for i in array sort_by:name %}{{ i["name"] }}|{%endfor%}', assigns)
+    assert_template_result('C|B|A|', '{%for i in array sort_by:name order:descending %}{{ i["name"] }}|{%endfor%}', assigns)
+    assert_template_result('1|2|3|', '{%for i in array sort_by:count %}{{ i["count"] }}|{%endfor%}', assigns)
+    assert_template_result('A|C|B|', '{%for i in array sort_by:missing_attribute %}{{ i["name"] }}|{%endfor%}', assigns)
+
+    assigns = {'array' => [
+      ConvertibleToLiquidObject.new("name" => 'A', "count" => '3'),
+      ConvertibleToLiquidObject.new("name" => 'C', "count" => '1'),
+      ConvertibleToLiquidObject.new("name" => 'B', "count" => '2')
+    ]}
+    assert_template_result('A|B|C|', '{%for i in array sort_by:name %}{{ i["name"] }}|{%endfor%}', assigns)
+    assert_template_result('C|B|A|', '{%for i in array sort_by:name order:descending %}{{ i["name"] }}|{%endfor%}', assigns)
+    assert_template_result('1|2|3|', '{%for i in array sort_by:count %}{{ i["count"] }}|{%endfor%}', assigns)
+    assert_template_result('A|C|B|', '{%for i in array sort_by:missing_attribute %}{{ i["name"] }}|{%endfor%}', assigns)
+  end
+
   def test_limiting
     assigns = {'array' => [1,2,3,4,5,6,7,8,9,0]}
     assert_template_result('12', '{%for i in array limit:2 %}{{ i }}{%endfor%}', assigns)


### PR DESCRIPTION
This is the updated version of #101. I am no longer at LivingSocial so can't push to the original repository.

I also incorporated the change from @mixonic to support sort_by on attributes on an object that responds to to_liquid.

You can specify ascending or descending by passing "order:ascending" or
"order:descending". You can specify what attribute you want to search on
by using the "sort_by" attribute.

So "{% for item in collection sort_by:name order:descending %}" will
iterate through the collection sorted by name in descending order.
