### PR TITLE
Raise liquid argument error instead of ruby argument

### DIFF
--- a/History.md
+++ b/History.md
@@ -21,6 +21,7 @@
 * Fix clashing method names in enumerable drops, see #238 [Florian Weingarten, fw42]
 * Make map filter work on enumerable drops, see #233 [Florian Weingarten, fw42]
 * Improved whitespace stripping for blank blocks, related to #216 [Florian Weingarten, fw42]
+* Raise `Liquid::ArgumentError` instead of `::ArgumentError` when filter has wrong number of arguments #309 [Bogdan Gusiev, bogdan]
 
 ## 2.6.0 / 2013-11-25 / branch "2.6-stable"
 

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -52,6 +52,8 @@ module Liquid
       else
         args.first
       end
+    rescue ::ArgumentError => e
+      raise Liquid::ArgumentError.new(e.message)
     end
 
     def invokable?(method)

--- a/test/liquid/strainer_test.rb
+++ b/test/liquid/strainer_test.rb
@@ -22,6 +22,13 @@ class StrainerTest < Test::Unit::TestCase
     assert_equal "public", strainer.invoke("public_filter")
   end
 
+  def test_stainer_raises_argument_error
+    strainer = Strainer.create(nil)
+    assert_raises(Liquid::ArgumentError) do
+      strainer.invoke("public_filter", 1)
+    end
+  end
+
   def test_strainer_only_invokes_public_filter_methods
     strainer = Strainer.create(nil)
     assert_equal false, strainer.invokable?('__test__')


### PR DESCRIPTION
Wrong number of arguments excepetion for filter should be easy to catch and display proper validation message.

Wrong number of arguments for filter invocation now raises
`Liuqid::ArgumentError` but not `::ArgumentError`
