### PR TITLE
Speed up Context#increment_used_resources

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -29,7 +29,7 @@ module Liquid
     end
 
     def increment_used_resources(key, obj)
-      @resource_limits[key] += if obj.class.ancestors & [ String, Array, Hash ] != []
+      @resource_limits[key] += if obj.kind_of?(String) || obj.kind_of?(Array) || obj.kind_of?(Hash)
         obj.length
       else
         1


### PR DESCRIPTION
@camilo & @fw42 for review

Thanks for the stackprof dump Camilo.
## Problem

I noticed Context#increment_used_resources using a significant amount of time in Shopify with stackprof.
## Solution

I avoided array allocations and operations by using `.kind_of?` to check if the object is a Hash, Array or String, which was much faster in a micro benchmark.

```
irb> puts Benchmark.measure{ 100000.times.each { str.class.ancestors & [String, Array, Hash] != [] } }
  0.440000   0.000000   0.440000 (  0.452020)

irb> puts Benchmark.measure{ 100000.times.each { str.kind_of?(String) || str.kind_of?(Array) || str.kind_of?(Hash) } }
  0.010000   0.000000   0.010000 (  0.012779)
```

It also saved a significant amount of time in `rake benchmark:run`

before:

```
/Users/dylansmith/.rbenv/versions/2.1.0-github/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         4.460000   0.070000   4.530000 (  4.529557)
parse & run:  11.530000   0.070000  11.600000 ( 11.603152)
-------------------------------------- total: 16.130000sec

                   user     system      total        real
parse:         4.280000   0.040000   4.320000 (  4.328700)
parse & run:  11.470000   0.080000  11.550000 ( 11.541219)
```

after:

```
/Users/dylansmith/.rbenv/versions/2.1.0-github/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         4.360000   0.060000   4.420000 (  4.413552)
parse & run:   9.360000   0.040000   9.400000 (  9.411988)
-------------------------------------- total: 13.820000sec

                   user     system      total        real
parse:         4.400000   0.050000   4.450000 (  4.458606)
parse & run:   9.270000   0.060000   9.330000 (  9.329113)
```
