### PR TITLE
Use start and end of string rather than line matching in regexes.

### DIFF
--- a/example/server/liquid_servlet.rb
+++ b/example/server/liquid_servlet.rb
@@ -13,7 +13,7 @@ class LiquidServlet < WEBrick::HTTPServlet::AbstractServlet
   def handle(type, req, res)
     @request, @response = req, res
 
-    @request.path_info =~ /(\w+)$/
+    @request.path_info =~ /(\w+)\z/
     @action = $1 || 'index'
     @assigns = send(@action) if respond_to?(@action)
 

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -36,7 +36,7 @@ module Liquid
   StrictQuotedFragment        = /"[^"]+"|'[^']+'|[^\s|:,]+/
   FirstFilterArgument         = /#{FilterArgumentSeparator}(?:#{StrictQuotedFragment})/o
   OtherFilterArgument         = /#{ArgumentSeparator}(?:#{StrictQuotedFragment})/o
-  SpacelessFilter             = /^(?:'[^']+'|"[^"]+"|[^'"])*#{FilterSeparator}(?:#{StrictQuotedFragment})(?:#{FirstFilterArgument}(?:#{OtherFilterArgument})*)?/o
+  SpacelessFilter             = /\A(?:'[^']+'|"[^"]+"|[^'"])*#{FilterSeparator}(?:#{StrictQuotedFragment})(?:#{FirstFilterArgument}(?:#{OtherFilterArgument})*)?/o
   Expression                  = /(?:#{QuotedFragment}(?:#{SpacelessFilter})*)/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -1,9 +1,9 @@
 module Liquid
   class Block < Tag
-    IsTag             = /^#{TagStart}/o
-    IsVariable        = /^#{VariableStart}/o
-    FullToken         = /^#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/o
-    ContentOfVariable = /^#{VariableStart}(.*)#{VariableEnd}$/o
+    IsTag             = /\A#{TagStart}/o
+    IsVariable        = /\A#{VariableStart}/o
+    FullToken         = /\A#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/o
+    ContentOfVariable = /\A#{VariableStart}(.*)#{VariableEnd}\z/o
 
     def blank?
       @blank || false

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -171,15 +171,15 @@ module Liquid
           LITERALS[key]
         else
           case key
-          when /^'(.*)'$/ # Single quoted strings
+          when /\A'(.*)'\z/ # Single quoted strings
             $1
-          when /^"(.*)"$/ # Double quoted strings
+          when /\A"(.*)"\z/ # Double quoted strings
             $1
-          when /^(-?\d+)$/ # Integer and floats
+          when /\A(-?\d+)\z/ # Integer and floats
             $1.to_i
-          when /^\((\S+)\.\.(\S+)\)$/ # Ranges
+          when /\A\((\S+)\.\.(\S+)\)\z/ # Ranges
             (resolve($1).to_i..resolve($2).to_i)
-          when /^(-?\d[\d\.]+)$/ # Floats
+          when /\A(-?\d[\d\.]+)\z/ # Floats
             $1.to_f
           else
             variable(key)
@@ -218,7 +218,7 @@ module Liquid
       #  assert_equal 'tobi', @context['hash["name"]']
       def variable(markup)
         parts = markup.scan(VariableParser)
-        square_bracketed = /^\[(.*)\]$/
+        square_bracketed = /\A\[(.*)\]\z/
 
         first_part = parts.shift
 

--- a/lib/liquid/file_system.rb
+++ b/lib/liquid/file_system.rb
@@ -57,7 +57,7 @@ module Liquid
     end
 
     def full_path(template_path)
-      raise FileSystemError, "Illegal template name '#{template_path}'" unless template_path =~ /^[^.\/][a-zA-Z0-9_\/]+$/
+      raise FileSystemError, "Illegal template name '#{template_path}'" unless template_path =~ /\A[^.\/][a-zA-Z0-9_\/]+\z/
 
       full_path = if template_path.include?('/')
         File.join(root, File.dirname(template_path), @pattern % File.basename(template_path))
@@ -65,7 +65,7 @@ module Liquid
         File.join(root, @pattern % template_path)
       end
 
-      raise FileSystemError, "Illegal template path '#{File.expand_path(full_path)}'" unless File.expand_path(full_path) =~ /^#{File.expand_path(root)}/
+      raise FileSystemError, "Illegal template path '#{File.expand_path(full_path)}'" unless File.expand_path(full_path) =~ /\A#{File.expand_path(root)}/
 
       full_path
     end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -190,7 +190,7 @@ module Liquid
         return input.to_s
       end
 
-      if ((input.is_a?(String) && !/^\d+$/.match(input.to_s).nil?) || input.is_a?(Integer)) && input.to_i > 0
+      if ((input.is_a?(String) && !/\A\d+\z/.match(input.to_s).nil?) || input.is_a?(Integer)) && input.to_i > 0
         input = Time.at(input.to_i)
       end
 
@@ -281,7 +281,7 @@ module Liquid
       when Numeric
         obj
       when String
-        (obj.strip =~ /^\d+\.\d+$/) ? BigDecimal.new(obj) : obj.to_i
+        (obj.strip =~ /\A\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
       else
         0
       end

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -12,8 +12,8 @@ module Liquid
   #    <div class="green"> Item five</div>
   #
   class Cycle < Tag
-    SimpleSyntax = /^#{QuotedFragment}+/o
-    NamedSyntax  = /^(#{QuotedFragment})\s*\:\s*(.*)/o
+    SimpleSyntax = /\A#{QuotedFragment}+/o
+    NamedSyntax  = /\A(#{QuotedFragment})\s*\:\s*(.*)/o
 
     def initialize(tag_name, markup, tokens)
       case markup

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Raw < Block
-    FullTokenPossiblyInvalid = /^(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}$/o
+    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/o
 
     def parse(tokens)
       @nodelist ||= []

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -12,7 +12,7 @@ module Liquid
   #
   class Variable
     FilterParser = /(?:#{FilterSeparator}|(?:\s*(?:#{QuotedFragment}|#{ArgumentSeparator})\s*)+)/o
-    EasyParse = /^ *(\w+(?:\.\w+)*) *$/
+    EasyParse = /\A *(\w+(?:\.\w+)*) *\z/
     attr_accessor :filters, :name, :warnings
 
     def initialize(markup, options = {})

--- a/performance/shopify/shop_filter.rb
+++ b/performance/shopify/shop_filter.rb
@@ -54,7 +54,7 @@ module ShopFilter
 
   def product_img_url(url, style = 'small')
 
-    unless url =~ /^products\/([\w\-\_]+)\.(\w{2,4})/
+    unless url =~ /\Aproducts\/([\w\-\_]+)\.(\w{2,4})/
       raise ArgumentError, 'filter "size" can only be called on product images'
     end
 


### PR DESCRIPTION
@arthurnn & @fw42 for review
## Problem

Liquid uses the bad practice of using line anchors rather than start and end of string anchors.
## Solution

Use string anchors as long as the regex didn't actually expect matches in the middle of a multi-line string.
