### PR TITLE
Use stackprof for profiling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 *.rbc
 .rvmrc
 .ruby-version
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -23,4 +23,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = ["History.md", "README.md"]
 
   s.require_path = "lib"
+
+  s.add_development_dependency 'stackprof' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'activesupport'
 end

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -1,19 +1,12 @@
-require 'rubygems'
-require 'ruby-prof' rescue fail("install ruby-prof extension/gem")
+require 'stackprof' rescue fail("install stackprof extension/gem")
 require File.dirname(__FILE__) + '/theme_runner'
 
 profiler = ThemeRunner.new
-
-puts 'Running profiler...'
-
-results  = profiler.run_profile
-
-puts 'Success'
-puts
-
-[RubyProf::FlatPrinter, RubyProf::GraphHtmlPrinter, RubyProf::CallTreePrinter, RubyProf::DotPrinter].each do |klass|
-  filename = (ENV['TMP'] || '/tmp') + (klass.name.include?('Html') ? "/liquid.#{klass.name.downcase}.html" : "/callgrind.liquid.#{klass.name.downcase}.txt")
-  filename.gsub!(/:+/, '_')
-  File.open(filename, "w+") { |fp| klass.new(results).print(fp, :print_file => true, :min_percent => 3) }
-  $stderr.puts "wrote #{klass.name} output to #{filename}"
+profiler.run
+results = StackProf.run(mode: :cpu) do
+  100.times do
+    profiler.run
+  end
 end
+StackProf::Report.new(results).print_text(false, 20)
+File.write(ENV['FILENAME'], Marshal.dump(results)) if ENV['FILENAME']

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -64,41 +64,6 @@ class ThemeRunner
   end
 
 
-  def run_profile
-    RubyProf.measure_mode = RubyProf::WALL_TIME
-
-    # Dup assigns because will make some changes to them
-    assigns = Database.tables.dup
-
-    @tests.each do |liquid, layout, template_name|
-
-      # Compute page_tempalte outside of profiler run, uninteresting to profiler
-      html = nil
-      page_template = File.basename(template_name, File.extname(template_name))
-
-      unless @started
-        RubyProf.start
-        RubyProf.pause
-        @started = true
-      end
-
-      html = nil
-
-      RubyProf.resume
-      html = compile_and_render(liquid, layout, assigns, page_template, template_name)
-      RubyProf.pause
-
-
-      # return the result and the MD5 of the content, this can be used to detect regressions between liquid version
-      $stdout.puts "* rendered template %s, content: %s" % [template_name, Digest::MD5.hexdigest(html)]
-
-      # Uncomment to dump html files to /tmp so that you can inspect for errors
-      # File.open("/tmp/#{File.basename(template_name)}.html", "w+") { |fp| fp <<html}
-    end
-
-    RubyProf.stop
-  end
-
   def compile_and_render(template, layout, assigns, page_template, template_file)
     tmpl = Liquid::Template.new
     tmpl.assigns['page_title'] = 'Page title'


### PR DESCRIPTION
@arthurnn & @fw42 for review

I have found stackprof quite helpful for profiling liquid.  I think we should just replace ruby-prof for with stackprof for `rake profile:run`
