### PR TITLE
Use render! in benchmarks to avoid making it faster by breaking things.

### DIFF
--- a/performance/shopify/shop_filter.rb
+++ b/performance/shopify/shop_filter.rb
@@ -45,11 +45,11 @@ module ShopFilter
   end
 
   def url_for_vendor(vendor_title)
-    "/collections/#{vendor_title.to_handle}"
+    "/collections/#{to_handle(vendor_title)}"
   end
 
   def url_for_type(type_title)
-    "/collections/#{type_title.to_handle}"
+    "/collections/#{to_handle(type_title)}"
   end
 
   def product_img_url(url, style = 'small')
@@ -93,6 +93,18 @@ module ShopFilter
   # Returns the singular word if input equals 1, otherwise plural
   def pluralize(input, singular, plural)
     input == 1 ? singular : plural
+  end
+
+  private
+
+  def to_handle(str)
+    result = str.dup
+    result.downcase!
+    result.delete!("'\"()[]")
+    result.gsub!(/\W+/, '-')
+    result.gsub!(/-+\z/, '') if result[-1] == '-'
+    result.gsub!(/\A-+/, '') if result[0] == '-'
+    result
   end
 
 end

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -8,6 +8,7 @@
 
 require 'rubygems'
 require 'active_support'
+require 'active_support/json'
 require 'yaml'
 require 'digest/md5'
 require File.dirname(__FILE__) + '/shopify/liquid'
@@ -70,11 +71,11 @@ class ThemeRunner
     tmpl.assigns['template'] = page_template
     tmpl.registers[:file_system] = ThemeRunner::FileSystem.new(File.dirname(template_file))
 
-    content_for_layout = tmpl.parse(template).render(assigns)
+    content_for_layout = tmpl.parse(template).render!(assigns)
 
     if layout
       assigns['content_for_layout'] = content_for_layout
-      tmpl.parse(layout).render(assigns)
+      tmpl.parse(layout).render!(assigns)
     else
       content_for_layout
     end


### PR DESCRIPTION
@camilo & @arthurnn for review
## Problem

When making breaking changes, we need to make sure to update the benchmarks along with the code.  Without this change, we might think a change makes the code faster, when actually it just skips code by exceptions being raised, caught, and rendered.
## Solution

Use Template#render! in the benchmarks so that we don't catch exceptions during rendering.
