### PR TITLE
Use render! in tests to make debugging test failures easier.

### DIFF
--- a/test/liquid/blank_test.rb
+++ b/test/liquid/blank_test.rb
@@ -93,9 +93,9 @@ class BlankTest < Test::Unit::TestCase
 
   def test_include_is_blank
     Liquid::Template.file_system = BlankTestFileSystem.new
-    assert_equal "foobar"*(N+1), Template.parse(wrap("{% include 'foobar' %}")).render()
-    assert_equal " foobar "*(N+1), Template.parse(wrap("{% include ' foobar ' %}")).render()
-    assert_equal "   ", Template.parse(" {% include ' ' %} ").render()
+    assert_template_result "foobar"*(N+1), wrap("{% include 'foobar' %}")
+    assert_template_result " foobar "*(N+1), wrap("{% include ' foobar ' %}")
+    assert_template_result "   "*(N+1), wrap(" {% include ' ' %} ")
   end
 
   def test_case_is_blank

--- a/test/liquid/capture_test.rb
+++ b/test/liquid/capture_test.rb
@@ -19,7 +19,7 @@ class CaptureTest < Test::Unit::TestCase
     {{var}}
     END_TEMPLATE
     template = Template.parse(template_source)
-    rendered = template.render
+    rendered = template.render!
     assert_equal "test-string", rendered.gsub(/\s/, '')
   end
 
@@ -34,7 +34,7 @@ class CaptureTest < Test::Unit::TestCase
     {{ first }}-{{ second }}
     END_TEMPLATE
     template = Template.parse(template_source)
-    rendered = template.render
+    rendered = template.render!
     assert_equal "3-3", rendered.gsub(/\s/, '')
   end
 end # CaptureTest

--- a/test/liquid/context_test.rb
+++ b/test/liquid/context_test.rb
@@ -176,8 +176,8 @@ class ContextTest < Test::Unit::TestCase
     end
 
     Template.register_filter(global)
-    assert_equal 'Global test', Template.parse("{{'test' | notice }}").render
-    assert_equal 'Local test', Template.parse("{{'test' | notice }}").render({}, :filters => [local])
+    assert_equal 'Global test', Template.parse("{{'test' | notice }}").render!
+    assert_equal 'Local test', Template.parse("{{'test' | notice }}").render!({}, :filters => [local])
   end
 
   def test_only_intended_filters_make_it_there

--- a/test/liquid/drop_test.rb
+++ b/test/liquid/drop_test.rb
@@ -106,140 +106,140 @@ class DropsTest < Test::Unit::TestCase
   def test_product_drop
     assert_nothing_raised do
       tpl = Liquid::Template.parse( '  '  )
-      tpl.render('product' => ProductDrop.new)
+      tpl.render!('product' => ProductDrop.new)
     end
   end
 
   def test_drop_does_only_respond_to_whitelisted_methods
-    assert_equal "", Liquid::Template.parse("{{ product.inspect }}").render('product' => ProductDrop.new)
-    assert_equal "", Liquid::Template.parse("{{ product.pretty_inspect }}").render('product' => ProductDrop.new)
-    assert_equal "", Liquid::Template.parse("{{ product.whatever }}").render('product' => ProductDrop.new)
-    assert_equal "", Liquid::Template.parse('{{ product | map: "inspect" }}').render('product' => ProductDrop.new)
-    assert_equal "", Liquid::Template.parse('{{ product | map: "pretty_inspect" }}').render('product' => ProductDrop.new)
-    assert_equal "", Liquid::Template.parse('{{ product | map: "whatever" }}').render('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse("{{ product.inspect }}").render!('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse("{{ product.pretty_inspect }}").render!('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse("{{ product.whatever }}").render!('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "inspect" }}').render!('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "pretty_inspect" }}').render!('product' => ProductDrop.new)
+    assert_equal "", Liquid::Template.parse('{{ product | map: "whatever" }}').render!('product' => ProductDrop.new)
   end
 
   def test_drops_respond_to_to_liquid
-    assert_equal "text1", Liquid::Template.parse("{{ product.to_liquid.texts.text }}").render('product' => ProductDrop.new)
-    assert_equal "text1", Liquid::Template.parse('{{ product | map: "to_liquid" | map: "texts" | map: "text" }}').render('product' => ProductDrop.new)
+    assert_equal "text1", Liquid::Template.parse("{{ product.to_liquid.texts.text }}").render!('product' => ProductDrop.new)
+    assert_equal "text1", Liquid::Template.parse('{{ product | map: "to_liquid" | map: "texts" | map: "text" }}').render!('product' => ProductDrop.new)
   end
 
   def test_text_drop
-    output = Liquid::Template.parse( ' {{ product.texts.text }} '  ).render('product' => ProductDrop.new)
+    output = Liquid::Template.parse( ' {{ product.texts.text }} '  ).render!('product' => ProductDrop.new)
     assert_equal ' text1 ', output
   end
 
   def test_unknown_method
-    output = Liquid::Template.parse( ' {{ product.catchall.unknown }} '  ).render('product' => ProductDrop.new)
+    output = Liquid::Template.parse( ' {{ product.catchall.unknown }} '  ).render!('product' => ProductDrop.new)
     assert_equal ' method: unknown ', output
   end
 
   def test_integer_argument_drop
-    output = Liquid::Template.parse( ' {{ product.catchall[8] }} '  ).render('product' => ProductDrop.new)
+    output = Liquid::Template.parse( ' {{ product.catchall[8] }} '  ).render!('product' => ProductDrop.new)
     assert_equal ' method: 8 ', output
   end
 
   def test_text_array_drop
-    output = Liquid::Template.parse( '{% for text in product.texts.array %} {{text}} {% endfor %}'  ).render('product' => ProductDrop.new)
+    output = Liquid::Template.parse( '{% for text in product.texts.array %} {{text}} {% endfor %}'  ).render!('product' => ProductDrop.new)
     assert_equal ' text1  text2 ', output
   end
 
   def test_context_drop
-    output = Liquid::Template.parse( ' {{ context.bar }} '  ).render('context' => ContextDrop.new, 'bar' => "carrot")
+    output = Liquid::Template.parse( ' {{ context.bar }} '  ).render!('context' => ContextDrop.new, 'bar' => "carrot")
     assert_equal ' carrot ', output
   end
 
   def test_nested_context_drop
-    output = Liquid::Template.parse( ' {{ product.context.foo }} '  ).render('product' => ProductDrop.new, 'foo' => "monkey")
+    output = Liquid::Template.parse( ' {{ product.context.foo }} '  ).render!('product' => ProductDrop.new, 'foo' => "monkey")
     assert_equal ' monkey ', output
   end
 
   def test_protected
-    output = Liquid::Template.parse( ' {{ product.callmenot }} '  ).render('product' => ProductDrop.new)
+    output = Liquid::Template.parse( ' {{ product.callmenot }} '  ).render!('product' => ProductDrop.new)
     assert_equal '  ', output
   end
 
   def test_object_methods_not_allowed
     [:dup, :clone, :singleton_class, :eval, :class_eval, :inspect].each do |method|
-      output = Liquid::Template.parse(" {{ product.#{method} }} ").render('product' => ProductDrop.new)
+      output = Liquid::Template.parse(" {{ product.#{method} }} ").render!('product' => ProductDrop.new)
       assert_equal '  ', output
     end
   end
 
   def test_scope
-    assert_equal '1', Liquid::Template.parse( '{{ context.scopes }}'  ).render('context' => ContextDrop.new)
-    assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ context.scopes }}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ context.scopes }}{%endfor%}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal '1', Liquid::Template.parse( '{{ context.scopes }}'  ).render!('context' => ContextDrop.new)
+    assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ context.scopes }}{%endfor%}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ context.scopes }}{%endfor%}{%endfor%}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
   end
 
   def test_scope_though_proc
-    assert_equal '1', Liquid::Template.parse( '{{ s }}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] })
-    assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ s }}{%endfor%}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
-    assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ s }}{%endfor%}{%endfor%}'  ).render('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
+    assert_equal '1', Liquid::Template.parse( '{{ s }}'  ).render!('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] })
+    assert_equal '2', Liquid::Template.parse( '{%for i in dummy%}{{ s }}{%endfor%}'  ).render!('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
+    assert_equal '3', Liquid::Template.parse( '{%for i in dummy%}{%for i in dummy%}{{ s }}{%endfor%}{%endfor%}'  ).render!('context' => ContextDrop.new, 's' => Proc.new{|c| c['context.scopes'] }, 'dummy' => [1])
   end
 
   def test_scope_with_assigns
-    assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{{a}}'  ).render('context' => ContextDrop.new)
-    assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{%for i in dummy%}{{a}}{%endfor%}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal 'test', Liquid::Template.parse( '{% assign header_gif = "test"%}{{header_gif}}'  ).render('context' => ContextDrop.new)
-    assert_equal 'test', Liquid::Template.parse( "{% assign header_gif = 'test'%}{{header_gif}}"  ).render('context' => ContextDrop.new)
+    assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{{a}}'  ).render!('context' => ContextDrop.new)
+    assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{%for i in dummy%}{{a}}{%endfor%}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal 'test', Liquid::Template.parse( '{% assign header_gif = "test"%}{{header_gif}}'  ).render!('context' => ContextDrop.new)
+    assert_equal 'test', Liquid::Template.parse( "{% assign header_gif = 'test'%}{{header_gif}}"  ).render!('context' => ContextDrop.new)
   end
 
   def test_scope_from_tags
-    assert_equal '1', Liquid::Template.parse( '{% for i in context.scopes_as_array %}{{i}}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '12', Liquid::Template.parse( '{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal '1', Liquid::Template.parse( '{% for i in context.scopes_as_array %}{{i}}{% endfor %}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal '12', Liquid::Template.parse( '{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
+    assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}{% endfor %}'  ).render!('context' => ContextDrop.new, 'dummy' => [1])
   end
 
   def test_access_context_from_drop
-    assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{{ context.loop_pos }}{% endfor %}'  ).render('context' => ContextDrop.new, 'dummy' => [1,2,3])
+    assert_equal '123', Liquid::Template.parse( '{%for a in dummy%}{{ context.loop_pos }}{% endfor %}'  ).render!('context' => ContextDrop.new, 'dummy' => [1,2,3])
   end
 
   def test_enumerable_drop
-    assert_equal '123', Liquid::Template.parse( '{% for c in collection %}{{c}}{% endfor %}').render('collection' => EnumerableDrop.new)
+    assert_equal '123', Liquid::Template.parse( '{% for c in collection %}{{c}}{% endfor %}').render!('collection' => EnumerableDrop.new)
   end
 
   def test_enumerable_drop_size
-    assert_equal '3', Liquid::Template.parse( '{{collection.size}}').render('collection' => EnumerableDrop.new)
+    assert_equal '3', Liquid::Template.parse( '{{collection.size}}').render!('collection' => EnumerableDrop.new)
   end
 
   def test_enumerable_drop_will_invoke_before_method_for_clashing_method_names
     ["select", "each", "map", "cycle"].each do |method|
-      assert_equal method.to_s, Liquid::Template.parse("{{collection.#{method}}}").render('collection' => EnumerableDrop.new)
-      assert_equal method.to_s, Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => EnumerableDrop.new)
-      assert_equal method.to_s, Liquid::Template.parse("{{collection.#{method}}}").render('collection' => RealEnumerableDrop.new)
-      assert_equal method.to_s, Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => RealEnumerableDrop.new)
+      assert_equal method.to_s, Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => EnumerableDrop.new)
+      assert_equal method.to_s, Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => EnumerableDrop.new)
+      assert_equal method.to_s, Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => RealEnumerableDrop.new)
+      assert_equal method.to_s, Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => RealEnumerableDrop.new)
     end
   end
 
   def test_some_enumerable_methods_still_get_invoked
     [ :count, :max ].each do |method|
-      assert_equal "3", Liquid::Template.parse("{{collection.#{method}}}").render('collection' => RealEnumerableDrop.new)
-      assert_equal "3", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => RealEnumerableDrop.new)
-      assert_equal "3", Liquid::Template.parse("{{collection.#{method}}}").render('collection' => EnumerableDrop.new)
-      assert_equal "3", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => EnumerableDrop.new)
+      assert_equal "3", Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => RealEnumerableDrop.new)
+      assert_equal "3", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => RealEnumerableDrop.new)
+      assert_equal "3", Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => EnumerableDrop.new)
+      assert_equal "3", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => EnumerableDrop.new)
     end
 
-    assert_equal "yes", Liquid::Template.parse("{% if collection contains 3 %}yes{% endif %}").render('collection' => RealEnumerableDrop.new)
+    assert_equal "yes", Liquid::Template.parse("{% if collection contains 3 %}yes{% endif %}").render!('collection' => RealEnumerableDrop.new)
 
     [ :min, :first ].each do |method|
-      assert_equal "1", Liquid::Template.parse("{{collection.#{method}}}").render('collection' => RealEnumerableDrop.new)
-      assert_equal "1", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => RealEnumerableDrop.new)
-      assert_equal "1", Liquid::Template.parse("{{collection.#{method}}}").render('collection' => EnumerableDrop.new)
-      assert_equal "1", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render('collection' => EnumerableDrop.new)
+      assert_equal "1", Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => RealEnumerableDrop.new)
+      assert_equal "1", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => RealEnumerableDrop.new)
+      assert_equal "1", Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => EnumerableDrop.new)
+      assert_equal "1", Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => EnumerableDrop.new)
     end
   end
 
   def test_empty_string_value_access
-    assert_equal '', Liquid::Template.parse('{{ product[value] }}').render('product' => ProductDrop.new, 'value' => '')
+    assert_equal '', Liquid::Template.parse('{{ product[value] }}').render!('product' => ProductDrop.new, 'value' => '')
   end
 
   def test_nil_value_access
-    assert_equal '', Liquid::Template.parse('{{ product[value] }}').render('product' => ProductDrop.new, 'value' => nil)
+    assert_equal '', Liquid::Template.parse('{{ product[value] }}').render!('product' => ProductDrop.new, 'value' => nil)
   end
 
   def test_default_to_s_on_drops
-    assert_equal 'ProductDrop', Liquid::Template.parse("{{ product }}").render('product' => ProductDrop.new)
-    assert_equal 'EnumerableDrop', Liquid::Template.parse('{{ collection }}').render('collection' => EnumerableDrop.new)
+    assert_equal 'ProductDrop', Liquid::Template.parse("{{ product }}").render!('product' => ProductDrop.new)
+    assert_equal 'EnumerableDrop', Liquid::Template.parse('{{ collection }}').render!('collection' => EnumerableDrop.new)
   end
 end # DropsTest

--- a/test/liquid/filter_test.rb
+++ b/test/liquid/filter_test.rb
@@ -113,13 +113,13 @@ class FiltersInTemplate < Test::Unit::TestCase
   def test_local_global
     Template.register_filter(MoneyFilter)
 
-    assert_equal " 1000$ ", Template.parse("{{1000 | money}}").render(nil, nil)
-    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render(nil, :filters => CanadianMoneyFilter)
-    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render(nil, :filters => [CanadianMoneyFilter])
+    assert_equal " 1000$ ", Template.parse("{{1000 | money}}").render!(nil, nil)
+    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render!(nil, :filters => CanadianMoneyFilter)
+    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render!(nil, :filters => [CanadianMoneyFilter])
   end
 
   def test_local_filter_with_deprecated_syntax
-    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render(nil, CanadianMoneyFilter)
-    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render(nil, [CanadianMoneyFilter])
+    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render!(nil, CanadianMoneyFilter)
+    assert_equal " 1000$ CAD ", Template.parse("{{1000 | money}}").render!(nil, [CanadianMoneyFilter])
   end
 end # FiltersTest

--- a/test/liquid/module_ex_test.rb
+++ b/test/liquid/module_ex_test.rb
@@ -77,11 +77,11 @@ class ModuleExTest < Test::Unit::TestCase
   end
 
   def test_should_use_regular_objects_as_drops
-    assert_equal 'allowedA', Liquid::Template.parse("{{ a.allowedA }}").render('a'=>@a)
-    assert_equal 'allowedB', Liquid::Template.parse("{{ a.chainedB.allowedB }}").render('a'=>@a)
-    assert_equal 'allowedC', Liquid::Template.parse("{{ a.chainedB.chainedC.allowedC }}").render('a'=>@a)
-    assert_equal 'another_allowedC', Liquid::Template.parse("{{ a.chainedB.chainedC.another_allowedC }}").render('a'=>@a)
-    assert_equal '', Liquid::Template.parse("{{ a.restricted }}").render('a'=>@a)
-    assert_equal '', Liquid::Template.parse("{{ a.unknown }}").render('a'=>@a)
+    assert_template_result 'allowedA', "{{ a.allowedA }}", 'a'=>@a
+    assert_template_result 'allowedB', "{{ a.chainedB.allowedB }}", 'a'=>@a
+    assert_template_result 'allowedC', "{{ a.chainedB.chainedC.allowedC }}", 'a'=>@a
+    assert_template_result 'another_allowedC', "{{ a.chainedB.chainedC.another_allowedC }}", 'a'=>@a
+    assert_template_result '', "{{ a.restricted }}", 'a'=>@a
+    assert_template_result '', "{{ a.unknown }}", 'a'=>@a
   end
 end # ModuleExTest

--- a/test/liquid/output_test.rb
+++ b/test/liquid/output_test.rb
@@ -41,76 +41,76 @@ class OutputTest < Test::Unit::TestCase
     text = %| {{best_cars}} |
 
     expected = %| bmw |
-    assert_equal expected, Template.parse(text).render(@assigns)
+    assert_equal expected, Template.parse(text).render!(@assigns)
   end
 
   def test_variable_traversing
     text = %| {{car.bmw}} {{car.gm}} {{car.bmw}} |
 
     expected = %| good bad good |
-    assert_equal expected, Template.parse(text).render(@assigns)
+    assert_equal expected, Template.parse(text).render!(@assigns)
   end
 
   def test_variable_piping
     text = %( {{ car.gm | make_funny }} )
     expected = %| LOL |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_variable_piping_with_input
     text = %( {{ car.gm | cite_funny }} )
     expected = %| LOL: bad |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_variable_piping_with_args
     text = %! {{ car.gm | add_smiley : ':-(' }} !
     expected = %| bad :-( |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_variable_piping_with_no_args
     text = %! {{ car.gm | add_smiley }} !
     expected = %| bad :-) |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_multiple_variable_piping_with_args
     text = %! {{ car.gm | add_smiley : ':-(' | add_smiley : ':-('}} !
     expected = %| bad :-( :-( |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_variable_piping_with_multiple_args
     text = %! {{ car.gm | add_tag : 'span', 'bar'}} !
     expected = %| <span id="bar">bad</span> |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_variable_piping_with_variable_args
     text = %! {{ car.gm | add_tag : 'span', car.bmw}} !
     expected = %| <span id="good">bad</span> |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_multiple_pipings
     text = %( {{ best_cars | cite_funny | paragraph }} )
     expected = %| <p>LOL: bmw</p> |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 
   def test_link_to
     text = %( {{ 'Typo' | link_to: 'http://typo.leetsoft.com' }} )
     expected = %| <a href="http://typo.leetsoft.com">Typo</a> |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => [FunnyFilter])
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => [FunnyFilter])
   end
 end # OutputTest

--- a/test/liquid/parsing_quirks_test.rb
+++ b/test/liquid/parsing_quirks_test.rb
@@ -7,7 +7,7 @@ class ParsingQuirksTest < Test::Unit::TestCase
     text = %| div { font-weight: bold; } |
     template = Template.parse(text)
 
-    assert_equal text, template.render
+    assert_equal text, template.render!
     assert_equal [String], template.root.nodelist.collect {|i| i.class}
   end
 

--- a/test/liquid/security_test.rb
+++ b/test/liquid/security_test.rb
@@ -13,14 +13,14 @@ class SecurityTest < Test::Unit::TestCase
     text = %( {{ '1+1' | instance_eval }} )
     expected = %| 1+1 |
 
-    assert_equal expected, Template.parse(text).render(@assigns)
+    assert_equal expected, Template.parse(text).render!(@assigns)
   end
 
   def test_no_existing_instance_eval
     text = %( {{ '1+1' | __instance_eval__ }} )
     expected = %| 1+1 |
 
-    assert_equal expected, Template.parse(text).render(@assigns)
+    assert_equal expected, Template.parse(text).render!(@assigns)
   end
 
 
@@ -28,7 +28,7 @@ class SecurityTest < Test::Unit::TestCase
     text = %( {{ '1+1' | instance_eval }} )
     expected = %| 1+1 |
 
-    assert_equal expected, Template.parse(text).render(@assigns)
+    assert_equal expected, Template.parse(text).render!(@assigns)
   end
 
 
@@ -36,7 +36,7 @@ class SecurityTest < Test::Unit::TestCase
     text = %( {{ '1+1' | add_one | instance_eval }} )
     expected = %| 1+1 + 1 |
 
-    assert_equal expected, Template.parse(text).render(@assigns, :filters => SecurityFilter)
+    assert_equal expected, Template.parse(text).render!(@assigns, :filters => SecurityFilter)
   end
 
   def test_does_not_add_filters_to_symbol_table
@@ -47,7 +47,7 @@ class SecurityTest < Test::Unit::TestCase
     template = Template.parse(test)
     assert_equal [], (Symbol.all_symbols - current_symbols)
 
-    template.render
+    template.render!
     assert_equal [], (Symbol.all_symbols - current_symbols)
   end
 

--- a/test/liquid/standard_filter_test.rb
+++ b/test/liquid/standard_filter_test.rb
@@ -126,37 +126,38 @@ class StandardFiltersTest < Test::Unit::TestCase
   end
 
   def test_map_doesnt_call_arbitrary_stuff
-    assert_equal "", Liquid::Template.parse('{{ "foo" | map: "__id__" }}').render
-    assert_equal "", Liquid::Template.parse('{{ "foo" | map: "inspect" }}').render
+    assert_template_result "", '{{ "foo" | map: "__id__" }}'
+    assert_template_result "", '{{ "foo" | map: "inspect" }}'
   end
 
   def test_map_calls_to_liquid
     t = TestThing.new
-    assert_equal "woot: 1", Liquid::Template.parse('{{ foo | map: "whatever" }}').render("foo" => [t])
+    assert_template_result "woot: 1", '{{ foo | map: "whatever" }}', "foo" => [t]
   end
 
   def test_map_on_hashes
-    assert_equal "4217", Liquid::Template.parse('{{ thing | map: "foo" | map: "bar" }}').render("thing" => { "foo" => [ { "bar" => 42 }, { "bar" => 17 } ] })
+    assert_template_result "4217", '{{ thing | map: "foo" | map: "bar" }}',
+      "thing" => { "foo" => [ { "bar" => 42 }, { "bar" => 17 } ] }
   end
 
   def test_sort_calls_to_liquid
     t = TestThing.new
-    assert_equal "woot: 1", Liquid::Template.parse('{{ foo | sort: "whatever" }}').render("foo" => [t])
+    assert_template_result "woot: 1", '{{ foo | sort: "whatever" }}', "foo" => [t]
   end
 
   def test_map_over_proc
     drop = TestDrop.new
     p = Proc.new{ drop }
     templ = '{{ procs | map: "test" }}'
-    assert_equal "testfoo", Liquid::Template.parse(templ).render("procs" => [p])
+    assert_template_result "testfoo", templ, "procs" => [p]
   end
 
   def test_map_works_on_enumerables
-    assert_equal "123", Liquid::Template.parse('{{ foo | map: "foo" }}').render!("foo" => TestEnumerable.new)
+    assert_template_result "123", '{{ foo | map: "foo" }}', "foo" => TestEnumerable.new
   end
 
   def test_sort_works_on_enumerables
-    assert_equal "213", Liquid::Template.parse('{{ foo | sort: "bar" | map: "foo" }}').render!("foo" => TestEnumerable.new)
+    assert_template_result "213", '{{ foo | sort: "bar" | map: "foo" }}', "foo" => TestEnumerable.new
   end
 
   def test_date
@@ -257,7 +258,7 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_template_result "4", "{{ 14 | divided_by:3 }}"
 
     assert_template_result "5", "{{ 15 | divided_by:3 }}"
-    assert_template_result "Liquid error: divided by 0", "{{ 5 | divided_by:0 }}"
+    assert_equal "Liquid error: divided by 0", Template.parse("{{ 5 | divided_by:0 }}").render
 
     assert_template_result "0.5", "{{ 2.0 | divided_by:4 }}"
   end

--- a/test/liquid/tags/standard_tag_test.rb
+++ b/test/liquid/tags/standard_tag_test.rb
@@ -180,11 +180,11 @@ class StandardTagTest < Test::Unit::TestCase
     # Example from the shopify forums
     code = %q({% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{% else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }})
     template = Liquid::Template.parse(code)
-    assert_equal "menswear",   template.render("collection" => {'handle' => 'menswear-jackets'})
-    assert_equal "menswear",   template.render("collection" => {'handle' => 'menswear-t-shirts'})
-    assert_equal "womenswear", template.render("collection" => {'handle' => 'x'})
-    assert_equal "womenswear", template.render("collection" => {'handle' => 'y'})
-    assert_equal "womenswear", template.render("collection" => {'handle' => 'z'})
+    assert_equal "menswear",   template.render!("collection" => {'handle' => 'menswear-jackets'})
+    assert_equal "menswear",   template.render!("collection" => {'handle' => 'menswear-t-shirts'})
+    assert_equal "womenswear", template.render!("collection" => {'handle' => 'x'})
+    assert_equal "womenswear", template.render!("collection" => {'handle' => 'y'})
+    assert_equal "womenswear", template.render!("collection" => {'handle' => 'z'})
   end
 
   def test_case_when_or
@@ -218,7 +218,7 @@ class StandardTagTest < Test::Unit::TestCase
   end
 
   def test_assign
-    assert_equal 'variable', Liquid::Template.parse( '{% assign a = "variable"%}{{a}}').render
+    assert_template_result 'variable', '{% assign a = "variable"%}{{a}}'
   end
 
   def test_assign_unassigned
@@ -227,12 +227,11 @@ class StandardTagTest < Test::Unit::TestCase
   end
 
   def test_assign_an_empty_string
-    assert_equal '', Liquid::Template.parse( '{% assign a = ""%}{{a}}'  ).render
+    assert_template_result '', '{% assign a = ""%}{{a}}'
   end
 
   def test_assign_is_global
-    assert_equal 'variable',
-                 Liquid::Template.parse( '{%for i in (1..2) %}{% assign a = "variable"%}{% endfor %}{{a}}'  ).render
+    assert_template_result 'variable', '{%for i in (1..2) %}{% assign a = "variable"%}{% endfor %}{{a}}'
   end
 
   def test_case_detects_bad_syntax

--- a/test/liquid/tags/statements_test.rb
+++ b/test/liquid/tags/statements_test.rb
@@ -4,93 +4,78 @@ class StatementsTest < Test::Unit::TestCase
   include Liquid
 
   def test_true_eql_true
-    text = %| {% if true == true %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if true == true %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text
   end
 
   def test_true_not_eql_true
-    text = %| {% if true != true %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if true != true %} true {% else %} false {% endif %} '
+    assert_template_result '  false  ', text
   end
 
   def test_true_lq_true
-    text = %| {% if 0 > 0 %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 0 > 0 %} true {% else %} false {% endif %} '
+    assert_template_result '  false  ', text
   end
 
   def test_one_lq_zero
-    text = %| {% if 1 > 0 %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 1 > 0 %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text
   end
 
   def test_zero_lq_one
-    text = %| {% if 0 < 1 %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 0 < 1 %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text
   end
 
   def test_zero_lq_or_equal_one
-    text = %| {% if 0 <= 0 %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 0 <= 0 %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text
   end
 
   def test_zero_lq_or_equal_one_involving_nil
-    text = %| {% if null <= 0 %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if null <= 0 %} true {% else %} false {% endif %} '
+    assert_template_result '  false  ', text
 
 
-    text = %| {% if 0 <= null %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 0 <= null %} true {% else %} false {% endif %} '
+    assert_template_result '  false  ', text
   end
 
   def test_zero_lqq_or_equal_one
-    text = %| {% if 0 >= 0 %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = ' {% if 0 >= 0 %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text
   end
 
   def test_strings
-    text = %| {% if 'test' == 'test' %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render
+    text = " {% if 'test' == 'test' %} true {% else %} false {% endif %} "
+    assert_template_result '  true  ', text
   end
 
   def test_strings_not_equal
-    text = %| {% if 'test' != 'test' %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render
+    text = " {% if 'test' != 'test' %} true {% else %} false {% endif %} "
+    assert_template_result '  false  ', text
   end
 
   def test_var_strings_equal
-    text = %| {% if var == "hello there!" %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 'hello there!')
+    text = ' {% if var == "hello there!" %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => 'hello there!'
   end
 
   def test_var_strings_are_not_equal
-    text = %| {% if "hello there!" == var %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 'hello there!')
+    text = ' {% if "hello there!" == var %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => 'hello there!'
   end
 
   def test_var_and_long_string_are_equal
-    text = %| {% if var == 'hello there!' %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 'hello there!')
+    text = " {% if var == 'hello there!' %} true {% else %} false {% endif %} "
+    assert_template_result '  true  ', text, 'var' => 'hello there!'
   end
 
 
   def test_var_and_long_string_are_equal_backwards
-    text = %| {% if 'hello there!' == var %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 'hello there!')
+    text = " {% if 'hello there!' == var %} true {% else %} false {% endif %} "
+    assert_template_result '  true  ', text, 'var' => 'hello there!'
   end
 
   #def test_is_nil
@@ -101,34 +86,28 @@ class StatementsTest < Test::Unit::TestCase
   #end
 
   def test_is_collection_empty
-    text = %| {% if array == empty %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('array' => [])
+    text = ' {% if array == empty %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'array' => []
   end
 
   def test_is_not_collection_empty
-    text = %| {% if array == empty %} true {% else %} false {% endif %} |
-    expected = %|  false  |
-    assert_equal expected, Template.parse(text).render('array' => [1,2,3])
+    text = ' {% if array == empty %} true {% else %} false {% endif %} '
+    assert_template_result '  false  ', text, 'array' => [1,2,3]
   end
 
   def test_nil
-    text = %| {% if var == nil %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => nil)
+    text = ' {% if var == nil %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => nil
 
-    text = %| {% if var == null %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => nil)
+    text = ' {% if var == null %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => nil
   end
 
   def test_not_nil
-    text = %| {% if var != nil %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 1 )
+    text = ' {% if var != nil %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => 1
 
-    text = %| {% if var != null %} true {% else %} false {% endif %} |
-    expected = %|  true  |
-    assert_equal expected, Template.parse(text).render('var' => 1 )
+    text = ' {% if var != null %} true {% else %} false {% endif %} '
+    assert_template_result '  true  ', text, 'var' => 1
   end
 end # StatementsTest

--- a/test/liquid/template_test.rb
+++ b/test/liquid/template_test.rb
@@ -47,57 +47,57 @@ class TemplateTest < Test::Unit::TestCase
 
   def test_instance_assigns_persist_on_same_template_object_between_parses
     t = Template.new
-    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render
-    assert_equal 'from instance assigns', t.parse("{{ foo }}").render
+    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render!
+    assert_equal 'from instance assigns', t.parse("{{ foo }}").render!
   end
 
   def test_instance_assigns_persist_on_same_template_parsing_between_renders
     t = Template.new.parse("{{ foo }}{% assign foo = 'foo' %}{{ foo }}")
-    assert_equal 'foo', t.render
-    assert_equal 'foofoo', t.render
+    assert_equal 'foo', t.render!
+    assert_equal 'foofoo', t.render!
   end
 
   def test_custom_assigns_do_not_persist_on_same_template
     t = Template.new
-    assert_equal 'from custom assigns', t.parse("{{ foo }}").render('foo' => 'from custom assigns')
-    assert_equal '', t.parse("{{ foo }}").render
+    assert_equal 'from custom assigns', t.parse("{{ foo }}").render!('foo' => 'from custom assigns')
+    assert_equal '', t.parse("{{ foo }}").render!
   end
 
   def test_custom_assigns_squash_instance_assigns
     t = Template.new
-    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render
-    assert_equal 'from custom assigns', t.parse("{{ foo }}").render('foo' => 'from custom assigns')
+    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render!
+    assert_equal 'from custom assigns', t.parse("{{ foo }}").render!('foo' => 'from custom assigns')
   end
 
   def test_persistent_assigns_squash_instance_assigns
     t = Template.new
-    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render
+    assert_equal 'from instance assigns', t.parse("{% assign foo = 'from instance assigns' %}{{ foo }}").render!
     t.assigns['foo'] = 'from persistent assigns'
-    assert_equal 'from persistent assigns', t.parse("{{ foo }}").render
+    assert_equal 'from persistent assigns', t.parse("{{ foo }}").render!
   end
 
   def test_lambda_is_called_once_from_persistent_assigns_over_multiple_parses_and_renders
     t = Template.new
     t.assigns['number'] = lambda { @global ||= 0; @global += 1 }
-    assert_equal '1', t.parse("{{number}}").render
-    assert_equal '1', t.parse("{{number}}").render
-    assert_equal '1', t.render
+    assert_equal '1', t.parse("{{number}}").render!
+    assert_equal '1', t.parse("{{number}}").render!
+    assert_equal '1', t.render!
     @global = nil
   end
 
   def test_lambda_is_called_once_from_custom_assigns_over_multiple_parses_and_renders
     t = Template.new
     assigns = {'number' => lambda { @global ||= 0; @global += 1 }}
-    assert_equal '1', t.parse("{{number}}").render(assigns)
-    assert_equal '1', t.parse("{{number}}").render(assigns)
-    assert_equal '1', t.render(assigns)
+    assert_equal '1', t.parse("{{number}}").render!(assigns)
+    assert_equal '1', t.parse("{{number}}").render!(assigns)
+    assert_equal '1', t.render!(assigns)
     @global = nil
   end
 
   def test_resource_limits_works_with_custom_length_method
     t = Template.parse("{% assign foo = bar %}")
     t.resource_limits = { :render_length_limit => 42 }
-    assert_equal "", t.render("bar" => SomethingWithLength.new)
+    assert_equal "", t.render!("bar" => SomethingWithLength.new)
   end
 
   def test_resource_limits_render_length
@@ -106,7 +106,7 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal "Liquid error: Memory limits exceeded", t.render()
     assert t.resource_limits[:reached]
     t.resource_limits = { :render_length_limit => 10 }
-    assert_equal "0123456789", t.render()
+    assert_equal "0123456789", t.render!()
     assert_not_nil t.resource_limits[:render_length_current]
   end
 
@@ -120,7 +120,7 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal "Liquid error: Memory limits exceeded", t.render()
     assert t.resource_limits[:reached]
     t.resource_limits = { :render_score_limit => 200 }
-    assert_equal (" foo " * 100), t.render()
+    assert_equal (" foo " * 100), t.render!()
     assert_not_nil t.resource_limits[:render_score_current]
   end
 
@@ -130,7 +130,7 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal "Liquid error: Memory limits exceeded", t.render()
     assert t.resource_limits[:reached]
     t.resource_limits = { :assign_score_limit => 2 }
-    assert_equal "", t.render()
+    assert_equal "", t.render!()
     assert_not_nil t.resource_limits[:assign_score_current]
   end
 
@@ -143,7 +143,7 @@ class TemplateTest < Test::Unit::TestCase
 
   def test_resource_limits_hash_in_template_gets_updated_even_if_no_limits_are_set
     t = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
-    t.render()
+    t.render!()
     assert t.resource_limits[:assign_score_current] > 0
     assert t.resource_limits[:render_score_current] > 0
     assert t.resource_limits[:render_length_current] > 0
@@ -153,9 +153,9 @@ class TemplateTest < Test::Unit::TestCase
     t = Template.new
     t.registers['lulz'] = 'haha'
     drop = TemplateContextDrop.new
-    assert_equal 'fizzbuzz', t.parse('{{foo}}').render(drop)
-    assert_equal 'bar', t.parse('{{bar}}').render(drop)
-    assert_equal 'haha', t.parse("{{baz}}").render(drop)
+    assert_equal 'fizzbuzz', t.parse('{{foo}}').render!(drop)
+    assert_equal 'bar', t.parse('{{bar}}').render!(drop)
+    assert_equal 'haha', t.parse("{{baz}}").render!(drop)
   end
 
   def test_sets_default_localization_in_document

--- a/test/liquid/variable_test.rb
+++ b/test/liquid/variable_test.rb
@@ -141,49 +141,49 @@ class VariableResolutionTest < Test::Unit::TestCase
 
   def test_simple_variable
     template = Template.parse(%|{{test}}|)
-    assert_equal 'worked', template.render('test' => 'worked')
-    assert_equal 'worked wonderfully', template.render('test' => 'worked wonderfully')
+    assert_equal 'worked', template.render!('test' => 'worked')
+    assert_equal 'worked wonderfully', template.render!('test' => 'worked wonderfully')
   end
 
   def test_simple_with_whitespaces
     template = Template.parse(%|  {{ test }}  |)
-    assert_equal '  worked  ', template.render('test' => 'worked')
-    assert_equal '  worked wonderfully  ', template.render('test' => 'worked wonderfully')
+    assert_equal '  worked  ', template.render!('test' => 'worked')
+    assert_equal '  worked wonderfully  ', template.render!('test' => 'worked wonderfully')
   end
 
   def test_ignore_unknown
     template = Template.parse(%|{{ test }}|)
-    assert_equal '', template.render
+    assert_equal '', template.render!
   end
 
   def test_hash_scoping
     template = Template.parse(%|{{ test.test }}|)
-    assert_equal 'worked', template.render('test' => {'test' => 'worked'})
+    assert_equal 'worked', template.render!('test' => {'test' => 'worked'})
   end
 
   def test_preset_assigns
     template = Template.parse(%|{{ test }}|)
     template.assigns['test'] = 'worked'
-    assert_equal 'worked', template.render
+    assert_equal 'worked', template.render!
   end
 
   def test_reuse_parsed_template
     template = Template.parse(%|{{ greeting }} {{ name }}|)
     template.assigns['greeting'] = 'Goodbye'
-    assert_equal 'Hello Tobi', template.render('greeting' => 'Hello', 'name' => 'Tobi')
-    assert_equal 'Hello ', template.render('greeting' => 'Hello', 'unknown' => 'Tobi')
-    assert_equal 'Hello Brian', template.render('greeting' => 'Hello', 'name' => 'Brian')
-    assert_equal 'Goodbye Brian', template.render('name' => 'Brian')
+    assert_equal 'Hello Tobi', template.render!('greeting' => 'Hello', 'name' => 'Tobi')
+    assert_equal 'Hello ', template.render!('greeting' => 'Hello', 'unknown' => 'Tobi')
+    assert_equal 'Hello Brian', template.render!('greeting' => 'Hello', 'name' => 'Brian')
+    assert_equal 'Goodbye Brian', template.render!('name' => 'Brian')
     assert_equal({'greeting'=>'Goodbye'}, template.assigns)
   end
 
   def test_assigns_not_polluted_from_template
     template = Template.parse(%|{{ test }}{% assign test = 'bar' %}{{ test }}|)
     template.assigns['test'] = 'baz'
-    assert_equal 'bazbar', template.render
-    assert_equal 'bazbar', template.render
-    assert_equal 'foobar', template.render('test' => 'foo')
-    assert_equal 'bazbar', template.render
+    assert_equal 'bazbar', template.render!
+    assert_equal 'bazbar', template.render!
+    assert_equal 'foobar', template.render!('test' => 'foo')
+    assert_equal 'bazbar', template.render!
   end
 
   def test_hash_with_default_proc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,13 +26,13 @@ module Test
       include Liquid
 
       def assert_template_result(expected, template, assigns = {}, message = nil)
-        assert_equal expected, Template.parse(template).render(assigns)
+        assert_equal expected, Template.parse(template).render!(assigns)
       end
 
       def assert_template_result_matches(expected, template, assigns = {}, message = nil)
         return assert_template_result(expected, template, assigns, message) unless expected.is_a? Regexp
 
-        assert_match expected, Template.parse(template).render(assigns)
+        assert_match expected, Template.parse(template).render!(assigns)
       end
 
       def assert_match_syntax_error(match, template, registers = {})


### PR DESCRIPTION
@fw42 or @arthurnn for review
## Problem

Previously it would be common to see an error like the following in the tests:

```
<"23"> expected but was
<"Liquid error: wrong number of arguments (1 for 2)">.
```

It would be nice to see the error name and whole backtrace in cases like this.
## Solution

Use Template#render! in the tests to prevent liquid from catching and rendering the errors.

Now we would see something like this instead:

```
ArgumentError: wrong number of arguments (1 for 2)
    /Users/dylansmith/src/liquid/lib/liquid/tags/for.rb:68:in `render'
    /Users/dylansmith/src/liquid/lib/liquid/block.rb:137:in `block in render_all'
    /Users/dylansmith/src/liquid/lib/liquid/block.rb:124:in `each'
    /Users/dylansmith/src/liquid/lib/liquid/block.rb:124:in `render_all'
    /Users/dylansmith/src/liquid/lib/liquid/block.rb:110:in `render'
    /Users/dylansmith/src/liquid/lib/liquid/template.rb:150:in `render'
    /Users/dylansmith/src/liquid/lib/liquid/template.rb:160:in `render!'
    /Users/dylansmith/src/liquid/test/test_helper.rb:29:in `assert_template_result'
    /Users/dylansmith/src/liquid/test/liquid/tags/unless_else_tag_test.rb:20:in `test_unless_in_loop'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1265:in `run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit/testcase.rb:17:in `run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:940:in `block in _run_suite'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:933:in `map'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:933:in `_run_suite'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:663:in `block in _run_suites'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:661:in `each'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:661:in `_run_suites'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:884:in `_run_anything'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1092:in `run_tests'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1079:in `block in _run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1078:in `each'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1078:in `_run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/minitest/unit.rb:1066:in `run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:27:in `run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:780:in `run'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:372:in `block (2 levels) in autorun'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:33:in `run_once'
    /Users/dylansmith/.rbenv/versions/2.1.0-github/lib/ruby/2.1.0/test/unit.rb:371:in `block in autorun'
```

and know that the Liquid::For#render has the wrong signature.
