### PR TITLE
Allow newlines in tags and variables.

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Allow newlines in tags and variables
 * Tag#parse is called after initialize, which now takes options instead of tokens as the 3rd argument. See #321 [Dylan Thacker-Smith, dylanahsmith]
 * Raise `Liquid::ArgumentError` instead of `::ArgumentError` when filter has wrong number of arguments #309 [Bogdan Gusiev, bogdan]
 * Add a to_s default for liquid drops, see #306 [Adam Doeler, releod]

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -40,8 +40,8 @@ module Liquid
   Expression                  = /(?:#{QuotedFragment}(?:#{SpacelessFilter})*)/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/o
-  TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/o
+  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
+  TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 end
 

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -2,8 +2,8 @@ module Liquid
   class Block < Tag
     IsTag             = /\A#{TagStart}/o
     IsVariable        = /\A#{VariableStart}/o
-    FullToken         = /\A#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/o
-    ContentOfVariable = /\A#{VariableStart}(.*)#{VariableEnd}\z/o
+    FullToken         = /\A#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+    ContentOfVariable = /\A#{VariableStart}(.*)#{VariableEnd}\z/om
 
     def blank?
       @blank || false

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -171,9 +171,9 @@ module Liquid
           LITERALS[key]
         else
           case key
-          when /\A'(.*)'\z/ # Single quoted strings
+          when /\A'(.*)'\z/m # Single quoted strings
             $1
-          when /\A"(.*)"\z/ # Double quoted strings
+          when /\A"(.*)"\z/m # Double quoted strings
             $1
           when /\A(-?\d+)\z/ # Integer and floats
             $1.to_i
@@ -218,7 +218,7 @@ module Liquid
       #  assert_equal 'tobi', @context['hash["name"]']
       def variable(markup)
         parts = markup.scan(VariableParser)
-        square_bracketed = /\A\[(.*)\]\z/
+        square_bracketed = /\A\[(.*)\]\z/m
 
         first_part = parts.shift
 

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -9,7 +9,7 @@ module Liquid
   #  {{ foo }}
   #
   class Assign < Tag
-    Syntax = /(#{VariableSignature}+)\s*=\s*(.*)\s*/o
+    Syntax = /(#{VariableSignature}+)\s*=\s*(.*)\s*/om
 
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -1,7 +1,7 @@
 module Liquid
   class Case < Block
     Syntax     = /(#{QuotedFragment})/o
-    WhenSyntax = /(#{QuotedFragment})(?:(?:\s+or\s+|\s*\,\s*)(#{QuotedFragment}.*))?/o
+    WhenSyntax = /(#{QuotedFragment})(?:(?:\s+or\s+|\s*\,\s*)(#{QuotedFragment}.*))?/om
 
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -13,7 +13,7 @@ module Liquid
   #
   class Cycle < Tag
     SimpleSyntax = /\A#{QuotedFragment}+/o
-    NamedSyntax  = /\A(#{QuotedFragment})\s*\:\s*(.*)/o
+    NamedSyntax  = /\A(#{QuotedFragment})\s*\:\s*(.*)/om
 
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Raw < Block
-    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/o
+    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def parse(tokens)
       @nodelist ||= []

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -37,9 +37,9 @@ module Liquid
 
     def lax_parse(markup)
       @filters = []
-      if match = markup.match(/\s*(#{QuotedFragment})(.*)/o)
+      if match = markup.match(/\s*(#{QuotedFragment})(.*)/om)
         @name = match[1]
-        if match[2].match(/#{FilterSeparator}\s*(.*)/o)
+        if match[2].match(/#{FilterSeparator}\s*(.*)/om)
           filters = Regexp.last_match(1).scan(FilterParser)
           filters.each do |f|
             if matches = f.match(/\s*(\w+)/)

--- a/test/liquid/tags/standard_tag_test.rb
+++ b/test/liquid/tags/standard_tag_test.rb
@@ -297,4 +297,8 @@ class StandardTagTest < Test::Unit::TestCase
     assigns = {'array' => [ 1, 1, 1, 1] }
     assert_template_result('1','{%for item in array%}{%ifchanged%}{{item}}{% endifchanged %}{%endfor%}',assigns)
   end
+
+  def test_multiline_tag
+    assert_template_result '0 1 2 3', "0{%\nfor i in (1..3)\n%} {{\ni\n}}{%\nendfor\n%}"
+  end
 end # StandardTagTest

--- a/test/liquid/variable_test.rb
+++ b/test/liquid/variable_test.rb
@@ -197,4 +197,8 @@ class VariableResolutionTest < Test::Unit::TestCase
     }
     assert_equal "Unknown variable 'test'", e.message
   end
+
+  def test_multiline_variable
+    assert_equal 'worked', Template.parse("{{\ntest\n}}").render!('test' => 'worked')
+  end
 end # VariableTest


### PR DESCRIPTION
@shopify/liquid for review
cc @bgotink & @Phrogz
## Problem

It was brought up in issue https://github.com/Shopify/liquid/issues/216#issuecomment-33605401 that liquid wasn't allowing newlines in tags and variables.  This could be helpful as a way to avoid unnecessary spaces and newlines.

I don't see any reason why we wouldn't support this.

I found out that the reason this wasn't working properly was that we use `/./` to match any character, but ruby documents this metacharacter as follows (http://ruby-doc.org/core-2.1.1/Regexp.html)

> /./ - Any character except a newline.
> /./m - Any character (the m modifier enables multiline mode)
## Solution

Add the multiline modifier to any Regexps that contain the `/./` metacharacter, since they all seem to be used to match any character.
