### PR TITLE
Remove active_support from the development dependancies.

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'stackprof' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'activesupport'
 end

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'benchmark'
 require File.dirname(__FILE__) + '/theme_runner'
 

--- a/performance/shopify/database.rb
+++ b/performance/shopify/database.rb
@@ -1,6 +1,6 @@
 require 'yaml'
-module Database
 
+module Database
   # Load the standard vision toolkit database and re-arrage it to be simply exportable
   # to liquid as assigns. All this is based on Shopify
   def self.tables

--- a/performance/shopify/json_filter.rb
+++ b/performance/shopify/json_filter.rb
@@ -1,7 +1,9 @@
+require 'json'
+
 module JsonFilter
 
   def json(object)
-    object.reject {|k,v| k == "collections" }.to_json
+    JSON.dump(object.reject {|k,v| k == "collections" })
   end
 
 end

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -6,11 +6,6 @@
 # Shopify which is likely the biggest user of liquid in the world which something to the tune of several
 # million Template#render calls a day.
 
-require 'rubygems'
-require 'active_support'
-require 'active_support/json'
-require 'yaml'
-require 'digest/md5'
 require File.dirname(__FILE__) + '/shopify/liquid'
 require File.dirname(__FILE__) + '/shopify/database.rb'
 
@@ -81,6 +76,3 @@ class ThemeRunner
     end
   end
 end
-
-
-


### PR DESCRIPTION
@arthurnn for review
## Problem

When running the test suite with active_support 4.1 the test suite is failing with

```
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:1:in `require'
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:1:in `<top (required)>'
  /Users/dylansmith/src/liquid/test/test_helper.rb:3:in `require'
  /Users/dylansmith/src/liquid/test/test_helper.rb:3:in `<top (required)>'
  /Users/dylansmith/src/liquid/test/integration/assign_test.rb:1:in `require'
  /Users/dylansmith/src/liquid/test/integration/assign_test.rb:1:in `<top (required)>'
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:15:in `require'
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:4:in `select'
  /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:4:in `<main>'
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
/Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:676:in `<class:Runner>': undefined method `_run_suite' for class `Test::Unit::Runner' (NameError)
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:261:in `<module:Unit>'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:15:in `<module:Test>'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/2.1.0/test/unit.rb:7:in `<top (required)>'
    from /Users/dylansmith/src/liquid/test/test_helper.rb:3:in `require'
    from /Users/dylansmith/src/liquid/test/test_helper.rb:3:in `<top (required)>'
    from /Users/dylansmith/src/liquid/test/integration/assign_test.rb:1:in `require'
    from /Users/dylansmith/src/liquid/test/integration/assign_test.rb:1:in `<top (required)>'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:15:in `require'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:4:in `select'
    from /Users/dylansmith/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/rake-10.2.2/lib/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
```

It looks like rails 4.1 doesn't play nice with test-unit which is used by liquid.
## Solution

The only place active support was being used was in the benchmark, so I changed the benchmark to completely removed it as a development dependancy.
