### PR TITLE
Raise Liquid::ArugmentError when condition has wrong usage

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -94,12 +94,16 @@ module Liquid
 
       left, right = context[left], context[right]
 
-      operation = self.class.operators[op] || raise(ArgumentError.new("Unknown operator #{op}"))
+      operation = self.class.operators[op] || raise(Liquid::ArgumentError.new("Unknown operator #{op}"))
 
       if operation.respond_to?(:call)
         operation.call(self, left, right)
       elsif left.respond_to?(operation) and right.respond_to?(operation)
-        left.send(operation, right)
+        begin
+          left.send(operation, right)
+        rescue ::ArgumentError => e
+          raise Liquid::ArgumentError.new(e.message)
+        end
       else
         nil
       end

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -49,6 +49,17 @@ class ConditionUnitTest < Test::Unit::TestCase
     assert_evalutes_false "'bob'", 'contains', "'---'"
   end
 
+  def test_invalid_comparation_operator
+    assert_evaluates_argument_error "1", '~~', '0'
+  end
+
+  def test_comparation_of_int_and_str
+    assert_evaluates_argument_error "'1'", '>', '0'
+    assert_evaluates_argument_error "'1'", '<', '0'
+    assert_evaluates_argument_error "'1'", '>=', '0'
+    assert_evaluates_argument_error "'1'", '<=', '0'
+  end
+
   def test_contains_works_on_arrays
     @context = Liquid::Context.new
     @context['array'] = [1,2,3,4,5]
@@ -124,4 +135,11 @@ class ConditionUnitTest < Test::Unit::TestCase
       assert !Condition.new(left, op, right).evaluate(@context || Liquid::Context.new),
              "Evaluated true: #{left} #{op} #{right}"
     end
+
+    def assert_evaluates_argument_error(left, op, right)
+      assert_raises(Liquid::ArgumentError) do
+        Condition.new(left, op, right).evaluate(@context || Liquid::Context.new)
+      end
+    end
+
 end # ConditionTest


### PR DESCRIPTION
Condition now raises ::ArgumentError when built wrongly.
This patch make it raise Liquid::ArgumentError instead
to indicate a liquid markup error but not ruby error.
