### PR TITLE
render! will properly force rethrow of errors if context is passed as an argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
+  - 2.1.1
   - jruby-19mode
   - jruby-head
   - rbx-19mode

--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Properly set context rethrow_errors on render! #349 [Thierry Joyal, tjoyal]
 * Fix broken rendering of variables which are equal to false, see #345 [Florian Weingarten, fw42]
 * Remove ActionView template handler [Dylan Thacker-Smith, dylanahsmith]
 * Freeze lots of string literals for new Ruby 2.1 optimization, see #297 [Florian Weingarten, fw42]

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -15,6 +15,8 @@ module Liquid
   class Context
     attr_reader :scopes, :errors, :registers, :environments, :resource_limits
 
+    attr_accessor :rethrow_errors
+
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = {})
       @environments    = [environments].flatten
       @scopes          = [(outer_scope || {})]

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -113,7 +113,9 @@ module Liquid
 
       context = case args.first
       when Liquid::Context
-        args.shift
+        c = args.shift
+        c.rethrow_errors = true if @rethrow_errors
+        c
       when Liquid::Drop
         drop = args.shift
         drop.context = Context.new([drop, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits)
@@ -156,7 +158,8 @@ module Liquid
     end
 
     def render!(*args)
-      @rethrow_errors = true; render(*args)
+      @rethrow_errors = true
+      render(*args)
     end
 
     private

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -22,6 +22,12 @@ class SomethingWithLength
   liquid_methods :length
 end
 
+class ErroneousDrop < Liquid::Drop
+  def bad_method
+    raise 'ruby error in drop'
+  end
+end
+
 class TemplateTest < Test::Unit::TestCase
   include Liquid
 
@@ -136,5 +142,15 @@ class TemplateTest < Test::Unit::TestCase
     assert_equal 'fizzbuzz', t.parse('{{foo}}').render!(drop)
     assert_equal 'bar', t.parse('{{bar}}').render!(drop)
     assert_equal 'haha', t.parse("{{baz}}").render!(drop)
+  end
+
+  def test_render_bang_force_rethrow_errors_on_passed_context
+    context = Context.new({'drop' => ErroneousDrop.new})
+    t = Template.new.parse('{{ drop.bad_method }}')
+
+    e = assert_raises RuntimeError do
+      t.render!(context)
+    end
+    assert_equal 'ruby error in drop', e.message
   end
 end


### PR DESCRIPTION
It was possible to pass a context without `rethrow_errors` to the method `render!`. On error it would act as what the context passed dictate and not re-throw errors.

This was giving the impression it was safe for the parsed template to be exposed publicly where it could contain ruby error messages embedded at the location of the failing method call.
### Considering:

```
class TestDrop < Liquid::Drop
  def failing
    raise 'Ruby error in my code'
  end
end
```
### Before:

```
context = Liquid::Context.new({'test' => TestDrop.new}, {}, {}, false)
Liquid::Template.parse('{{ test.failing }}').render!(context)
=> "Liquid error: Ruby error in my code"

context = Liquid::Context.new({'test' => TestDrop.new}, {}, {}, true)
Liquid::Template.parse('{{ test.failing }}').render!(context)
=> RuntimeError: Ruby error in my code
```
### After:

```
context = Liquid::Context.new({'test' => TestDrop.new}, {}, {}, false)
Liquid::Template.parse('{{ test.failing }}').render!(context)
=> Liquid::ArgumentError: Unable to set re-throw error policy on the context provided as parameter

context = Liquid::Context.new({'test' => TestDrop.new}, {}, {}, true)
Liquid::Template.parse('{{ test.failing }}').render!(context)
=> RuntimeError: Ruby error in my code
```

What do you guys think? @fw42 @gmalette
