### PR TITLE
Add error messages for missing variables when :strict

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Add error messages for missing variables when :strict, see #352 [Daniel Gaiottino]
 * Fix broken rendering of variables which are equal to false, see #345 [Florian Weingarten, fw42]
 * Remove ActionView template handler [Dylan Thacker-Smith, dylanahsmith]
 * Freeze lots of string literals for new Ruby 2.1 optimization, see #297 [Florian Weingarten, fw42]

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -203,6 +203,7 @@ module Liquid
         end
 
         scope     ||= @environments.last || @scopes.last
+        handle_not_found(key) unless scope.has_key?(key)
         variable  ||= lookup_and_evaluate(scope, key)
 
         variable = variable.to_liquid
@@ -252,6 +253,7 @@ module Liquid
               # No key was present with the desired value and it wasn't one of the directly supported
               # keywords either. The only thing we got left is to return nil
             else
+              handle_not_found(markup)
               return nil
             end
 
@@ -281,6 +283,10 @@ module Liquid
           end
         end
       end # squash_instance_assigns_with_environments
+
+      def handle_not_found(variable)
+        @errors << "Variable {{#{variable}}} not found" if Template.error_mode == :strict
+      end
   end # Context
 
 end # Liquid

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -457,4 +457,22 @@ class ContextUnitTest < Test::Unit::TestCase
     assert_kind_of CategoryDrop, @context['category']
     assert_equal @context, @context['category'].context
   end
+
+  def test_strict_variables_not_found
+    with_error_mode(:strict) do
+      @context['does_not_exist']
+      assert(@context.errors.length == 1)
+      assert_equal(@context.errors[0], 'Variable {{does_not_exist}} not found')
+    end
+  end
+
+  def test_strict_nested_variables_not_found
+    with_error_mode(:strict) do
+      @context['hash'] = {'this' => 'exists'}
+      @context['hash.does_not_exist']
+      assert(@context.errors.length == 1)
+      assert_equal(@context.errors[0], 'Variable {{hash.does_not_exist}} not found')
+    end
+  end
+
 end # ContextTest


### PR DESCRIPTION
Hi,

This is a modification to an old pull request which never got merged. https://github.com/Shopify/liquid/pull/104

I felt that the original pull request was too extreme when a variable was missing by throwing an exception. If several variables were missing, then an exception was thrown for the first one but errors did not contain all the missing variables so you'd have to test it multiple times catching each exception.

My modified and simpler version populates the errors with messages for all missing variables and doesn't throw an exception.

Basically, I wanted an easy way to warn users about missing variables when creating of previewing a template.

Regards,
- Daniel
