### PR TITLE
Allow data keys to be symbols

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Allow data keys to be symbols [Daniel Gaiottino]
 * Add error messages for missing variables when :strict, see #352 [Daniel Gaiottino]
 * Properly set context rethrow_errors on render! #349 [Thierry Joyal, tjoyal]
 * Fix broken rendering of variables which are equal to false, see #345 [Florian Weingarten, fw42]

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -140,7 +140,7 @@ module Liquid
 
     # Only allow String, Numeric, Hash, Array, Proc, Boolean or <tt>Liquid::Drop</tt>
     def []=(key, value)
-      @scopes[0][key] = value
+      @scopes[0][key.to_s] = value
     end
 
     def [](key)
@@ -221,7 +221,7 @@ module Liquid
       #  assert_equal 'tobi', @context['hash.name']
       #  assert_equal 'tobi', @context['hash["name"]']
       def variable(markup)
-        parts = markup.scan(VariableParser)
+        parts = markup.to_s.scan(VariableParser)
         square_bracketed = /\A\[(.*)\]\z/m
 
         first_part = parts.shift
@@ -268,12 +268,20 @@ module Liquid
       end # variable
 
       def lookup_and_evaluate(obj, key)
-        if (value = obj[key]).is_a?(Proc) && obj.respond_to?(:[]=)
+        value = lookup_value(obj, key)
+        if value.is_a?(Proc) && obj.respond_to?(:[]=)
           obj[key] = (value.arity == 0) ? value.call : value.call(self)
         else
           value
         end
       end # lookup_and_evaluate
+
+      def lookup_value(obj, key)
+        return nil if key.nil?
+        value = obj[key]
+        value = obj[key.to_sym] if value.nil?
+        value
+      end
 
       def squash_instance_assigns_with_environments
         @scopes.last.each_key do |k|

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -98,6 +98,34 @@ class ContextUnitTest < Test::Unit::TestCase
     assert_equal nil, @context['nil']
   end
 
+  def test_symbol_variables
+    @context[:string] = 'string'
+    assert_equal 'string', @context[:string]
+
+    @context[:num] = 5
+    assert_equal 5, @context[:num]
+
+    @context[:time] = Time.parse('2006-06-06 12:00:00')
+    assert_equal Time.parse('2006-06-06 12:00:00'), @context[:time]
+
+    @context[:date] = Date.today
+    assert_equal Date.today, @context[:date]
+
+    now = DateTime.now
+    @context[:datetime] = now
+    assert_equal now, @context[:datetime]
+
+    @context[:bool] = true
+    assert_equal true, @context[:bool]
+
+    @context[:bool] = false
+    assert_equal false, @context[:bool]
+
+    @context[:nil] = nil
+    assert_equal nil, @context[:nil]
+    assert_equal nil, @context[:nil]
+  end
+
   def test_variables_not_existing
     assert_equal nil, @context['does_not_exist']
   end

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -16,4 +16,10 @@ class TemplateUnitTest < Test::Unit::TestCase
     assert_instance_of I18n, t.root.options[:locale]
     assert_equal fixture("en_locale.yml"), t.root.options[:locale].path
   end
+
+  def test_symbol_variables
+    t = Template.new
+    t.parse('{{foo}}')
+    assert_equal 'FOO!', t.render({foo: 'FOO!'})
+  end
 end


### PR DESCRIPTION
Small change that allows symbols to be used as keys in the data passed to `#render`.

``` ruby
t = Template.new
t.parse('{{foo}}')
t.render({foo: 'FOO!'})
```

produces the same result as

``` ruby
t = Template.new
t.parse('{{foo}}')
t.render({'foo' => 'FOO!'})
```
