### PR TITLE
Profiling the rendering of a liquid template

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -70,3 +70,7 @@ require 'liquid/utils'
 # Load all the tags of the standard library
 #
 Dir[File.dirname(__FILE__) + '/liquid/tags/*.rb'].each { |f| require f }
+
+require 'liquid/profiler'
+require 'liquid/profiler/token'
+require 'liquid/profiler/hooks'

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -1,0 +1,159 @@
+module Liquid
+
+  # Profiler enables support for profiling template rendering to help track down performance issues.
+  #
+  # To enable profiling, pass the <tt>profile: true</tt> option to <tt>Liquid::Template.parse</tt>. Then, after
+  # <tt>Liquid::Template#render</tt> is called, the template object makes available an instance of this
+  # class via the <tt>Liquid::Template#profiler</tt> method.
+  #
+  #   template = Liquid::Template.parse(template_content, profile: true)
+  #   output  = template.render
+  #   profile = template.profiler
+  #
+  # This object contains all profiling information, containing information on what tags were rendered,
+  # where in the templates these tags live, and how long each tag took to render.
+  #
+  # This is a tree structure that is Enumerable all the way down, and keeps track of tags and rendering times
+  # inside of <tt>{% include %}</tt> tags.
+  #
+  #   profile.each do |node|
+  #     # Access to the token itself
+  #     node.code
+  #
+  #     # Which template and line number of this node.
+  #     # If top level, this will be "<root>".
+  #     node.partial
+  #     node.line_number
+  #
+  #     # Render time in seconds of this node
+  #     node.render_time
+  #
+  #     # If the template used {% include %}, this node will also have children.
+  #     node.children.each do |child2|
+  #       # ...
+  #     end
+  #   end
+  #
+  # Profiler also exposes the total time of the template's render in <tt>Liquid::Profiler#total_render_time</tt>.
+  #
+  # All render times are in seconds. There is a small performance hit when profiling is enabled.
+  #
+  class Profiler
+    include Enumerable
+
+    class Timing
+      attr_reader :code, :partial, :line_number, :children
+
+      def initialize(token, partial)
+        @code        = token.respond_to?(:raw) ? token.raw : token
+        @partial     = partial
+        @line_number = token.respond_to?(:line_number) ? token.line_number : nil
+        @children    = []
+      end
+
+      def self.start(token, partial)
+        new(token, partial).tap do |t|
+          t.start
+        end
+      end
+
+      def start
+        @start_time = Time.now
+      end
+
+      def finish
+        @end_time = Time.now
+      end
+
+      def render_time
+        @end_time - @start_time
+      end
+    end
+
+    def self.profile_token_render(token)
+      if Profiler.current_profile && token.respond_to?(:render)
+        Profiler.current_profile.start_token(token)
+        output = yield
+        Profiler.current_profile.end_token(token)
+        output
+      else
+        yield
+      end
+    end
+
+    def self.profile_children(template_name)
+      if Profiler.current_profile
+        Profiler.current_profile.push_partial(template_name)
+        output = yield
+        Profiler.current_profile.pop_partial
+        output
+      else
+        yield
+      end
+    end
+
+    def self.current_profile
+      Thread.current[:liquid_profiler]
+    end
+
+    def initialize
+      @partial_stack = ["<root>"]
+
+      @root_timing = Timing.new("", current_partial)
+      @timing_stack = [@root_timing]
+
+      @render_start_at = Time.now
+      @render_end_at = @render_start_at
+    end
+
+    def start
+      Thread.current[:liquid_profiler] = self
+      @render_start_at = Time.now
+    end
+
+    def stop
+      Thread.current[:liquid_profiler] = nil
+      @render_end_at = Time.now
+    end
+
+    def total_render_time
+      @render_end_at - @render_start_at
+    end
+
+    def each(&block)
+      @root_timing.children.each(&block)
+    end
+
+    def [](idx)
+      @root_timing.children[idx]
+    end
+
+    def length
+      @root_timing.children.length
+    end
+
+    def start_token(token)
+      @timing_stack.push(Timing.start(token, current_partial))
+    end
+
+    def end_token(token)
+      timing = @timing_stack.pop
+      timing.finish
+
+      @timing_stack.last.children << timing
+    end
+
+    def current_partial
+      @partial_stack.last
+    end
+
+    def push_partial(partial_name)
+      @partial_stack.push(partial_name)
+    end
+
+    def pop_partial
+      @partial_stack.pop
+    end
+
+  end
+end

--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -1,0 +1,23 @@
+module Liquid
+  class Block < Tag
+    def render_token_with_profiling(token, context)
+      Profiler.profile_token_render(token) do
+        render_token_without_profiling(token, context)
+      end
+    end
+
+    alias_method :render_token_without_profiling, :render_token
+    alias_method :render_token, :render_token_with_profiling
+  end
+
+  class Include < Tag
+    def render_with_profiling(context)
+      Profiler.profile_children(@template_name) do
+        render_without_profiling(context)
+      end
+    end
+
+    alias_method :render_without_profiling, :render
+    alias_method :render, :render_with_profiling
+  end
+end

--- a/lib/liquid/profiler/token.rb
+++ b/lib/liquid/profiler/token.rb
@@ -1,0 +1,16 @@
+module Liquid
+  class Token < String
+
+    attr_reader :line_number
+
+    def initialize(content, line_number)
+      super(content)
+      @line_number = line_number
+    end
+
+    def raw
+      "<raw>"
+    end
+
+  end
+end

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Tag
-    attr_accessor :options
+    attr_accessor :options, :line_number
     attr_reader :nodelist, :warnings
 
     class << self
@@ -20,6 +20,10 @@ module Liquid
     end
 
     def parse(tokens)
+    end
+
+    def raw
+      "#{@tag_name} #{@markup}"
     end
 
     def name

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -16,6 +16,7 @@ module Liquid
       if markup =~ Syntax
         @to = $1
         @from = Variable.new($2,options)
+        @from.line_number = line_number
       else
         raise SyntaxError.new options[:locale].t("errors.syntax.assign".freeze)
       end

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -14,6 +14,7 @@ module Liquid
     FilterParser = /(?:#{FilterSeparator}|(?:\s*(?:#{QuotedFragment}|#{ArgumentSeparator})\s*)+)/o
     EasyParse = /\A *(\w+(?:\.\w+)*) *\z/
     attr_accessor :filters, :name, :warnings
+    attr_accessor :line_number
 
     def initialize(markup, options = {})
       @markup  = markup
@@ -32,6 +33,10 @@ module Liquid
           lax_parse(markup)
         end
       end
+    end
+
+    def raw
+      @markup
     end
 
     def lax_parse(markup)

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -1,0 +1,142 @@
+require 'test_helper'
+
+class RenderProfilingTest < Minitest::Test
+  include Liquid
+
+  class ProfilingFileSystem
+    def read_template_file(template_path, context)
+      "Rendering template {% assign template_name = '#{template_path}'%}\n{{ template_name }}"
+    end
+  end
+
+  def setup
+    Liquid::Template.file_system = ProfilingFileSystem.new
+  end
+
+  def test_template_allows_flagging_profiling
+    t = Template.parse("{{ 'a string' | upcase }}")
+    t.render!
+
+    assert_nil t.profiler
+  end
+
+  def test_parse_makes_available_simple_profiling
+    t = Template.parse("{{ 'a string' | upcase }}", :profile => true)
+    t.render!
+
+    assert_equal 1, t.profiler.length
+
+    node = t.profiler[0]
+    assert_equal " 'a string' | upcase ", node.code
+  end
+
+  def test_render_ignores_raw_strings_when_profiling
+    t = Template.parse("This is raw string\nstuff\nNewline", :profile => true)
+    t.render!
+
+    assert_equal 0, t.profiler.length
+  end
+
+  def test_profiling_includes_line_numbers_of_liquid_nodes
+    t = Template.parse("{{ 'a string' | upcase }}\n{% increment test %}", :profile => true)
+    t.render!
+    assert_equal 2, t.profiler.length
+
+    # {{ 'a string' | upcase }}
+    assert_equal 1, t.profiler[0].line_number
+    # {{ increment test }}
+    assert_equal 2, t.profiler[1].line_number
+  end
+
+  def test_profiling_times_the_rendering_of_tokens
+    t = Template.parse("{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    node = t.profiler[0]
+    refute_nil node.render_time
+  end
+
+  def test_profiling_times_the_entire_render
+    t = Template.parse("{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    assert t.profiler.total_render_time > 0, "Total render time was not calculated"
+  end
+
+  def test_profiling_uses_include_to_mark_children
+    t = Template.parse("{{ 'a string' | upcase }}\n{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    include_node = t.profiler[1]
+    assert_equal 2, include_node.children.length
+  end
+
+  def test_profiling_marks_children_with_the_name_of_included_partial
+    t = Template.parse("{{ 'a string' | upcase }}\n{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    include_node = t.profiler[1]
+    include_node.children.each do |child|
+      assert_equal "'a_template'", child.partial
+    end
+  end
+
+  def test_profiling_supports_multiple_templates
+    t = Template.parse("{{ 'a string' | upcase }}\n{% include 'a_template' %}\n{% include 'b_template' %}", :profile => true)
+    t.render!
+
+    a_template = t.profiler[1]
+    a_template.children.each do |child|
+      assert_equal "'a_template'", child.partial
+    end
+
+    b_template = t.profiler[2]
+    b_template.children.each do |child|
+      assert_equal "'b_template'", child.partial
+    end
+  end
+
+  def test_profiling_supports_rendering_the_same_partial_multiple_times
+    t = Template.parse("{{ 'a string' | upcase }}\n{% include 'a_template' %}\n{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    a_template1 = t.profiler[1]
+    a_template1.children.each do |child|
+      assert_equal "'a_template'", child.partial
+    end
+
+    a_template2 = t.profiler[2]
+    a_template2.children.each do |child|
+      assert_equal "'a_template'", child.partial
+    end
+  end
+
+  def test_can_iterate_over_each_profiling_entry
+    t = Template.parse("{{ 'a string' | upcase }}\n{% increment test %}", :profile => true)
+    t.render!
+
+    timing_count = 0
+    t.profiler.each do |timing|
+      timing_count += 1
+    end
+
+    assert_equal 2, timing_count
+  end
+
+  def test_profiling_marks_children_of_if_blocks
+    t = Template.parse("{% if true %} {% increment test %} {{ test }} {% endif %}", :profile => true)
+    t.render!
+
+    assert_equal 1, t.profiler.length
+    assert_equal 2, t.profiler[0].children.length
+  end
+
+  def test_profiling_marks_children_of_for_blocks
+    t = Template.parse("{% for item in collection %} {{ item }} {% endfor %}", :profile => true)
+    t.render!({"collection" => ["one", "two"]})
+
+    assert_equal 1, t.profiler.length
+    # Will profile each invocation of the for block
+    assert_equal 2, t.profiler[0].children.length
+  end
+end

--- a/test/unit/tag_unit_test.rb
+++ b/test/unit/tag_unit_test.rb
@@ -8,4 +8,9 @@ class TagUnitTest < Minitest::Test
     assert_equal 'liquid::tag', tag.name
     assert_equal '', tag.render(Context.new)
   end
+
+  def test_return_raw_text_of_tag
+    tag = Tag.parse("long_tag", "param1, param2, param3", [], {})
+    assert_equal("long_tag param1, param2, param3", tag.raw)
+  end
 end

--- a/test/unit/tokenizer_unit_test.rb
+++ b/test/unit/tokenizer_unit_test.rb
@@ -21,6 +21,15 @@ class TokenizerTest < Minitest::Test
     assert_equal ['  ', '{% comment %}', ' ', '{% endcomment %}', ' '], tokenize("  {% comment %} {% endcomment %} ")
   end
 
+  def test_calculate_line_numbers_per_token_with_profiling
+    template = Liquid::Template.parse("", :profile => true)
+
+    assert_equal [1],       template.send(:tokenize, "{{funk}}").map(&:line_number)
+    assert_equal [1, 1, 1], template.send(:tokenize, " {{funk}} ").map(&:line_number)
+    assert_equal [1, 2, 2], template.send(:tokenize, "\n{{funk}}\n").map(&:line_number)
+    assert_equal [1, 1, 3], template.send(:tokenize, " {{\n funk \n}} ").map(&:line_number)
+  end
+
   private
 
   def tokenize(source)

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -133,4 +133,9 @@ class VariableUnitTest < Minitest::Test
       end
     end
   end
+
+  def test_output_raw_source_of_variable
+    var = Variable.new(%! name_of_variable | upcase !)
+    assert_equal " name_of_variable | upcase ", var.raw
+  end
 end


### PR DESCRIPTION
This is an improved version of what I originally put together in #361

This PR adds a simple profiling system to liquid rendering. Each liquid tag ({{ }} and {% %}) is processed through this profiling, keeping track of the partial name (in the case of {% include %}), line number, and the time it took to render the tag. In the case of {% include %} and any tag that requires blocks (like {% if %} and {% for %}), the tags inside of the partials and blocks are themselves marked as children in the final profiling structure, letting any user of this information view top level information and to dive down into more details. With this, it's now possible to track down exactly which tags are taking a long time to render.

Included in this PR are internal changes to parsing to calculate and keep track of the line numbers of individual tags and tokens in the source, as well as some specific tracking of the current partial, such that using the include tag will be tracked as a nested render. I initially looked into adding this information to error exceptions but that was proving more complicated and would require quite a few changes to how tags handle syntax errors.

I was able to hook profiling into Liquid through one small refactoring (`Block#render_token`) and alias method chain-like hooks into the appropriate classes, significantly reducing the code impact on the core Liquid code base. There are also changes to parsing to figure out the line numbers of the tokens, Template to start up a profiling pass, and to Tags and Variables for easier output of the contents of these items when printing out the profiled information, but otherwise the actual profiling is kept separate.  The hooks install and uninstall themselves as needed, which ensures that if profiling is turned off that there is no performance impact.

The current profiling runs for these changes can be found here: https://gist.github.com/jasonroelofs/79bde3d22ede168a5ae8

I've also put together an example template and resulting profiling output here: https://gist.github.com/jasonroelofs/c8148317ffb09e541633

If you prefer not to have this in the core I would love to discuss what changes Liquid does need for this functionality to live as its own gem and hooking into Liquid when needed.
