### PR TITLE
[Liquid] Add round, ceil and floor standard filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -243,6 +243,21 @@ module Liquid
       apply_operation(input, operand, :%)
     end
 
+    def round(input, n = 0)
+      result = to_number(input).round(to_number(n))
+      result = result.to_f if result.is_a?(BigDecimal)
+      result = result.to_i if n == 0
+      result
+    end
+
+    def ceil(input)
+      to_number(input).ceil.to_i
+    end
+
+    def floor(input)
+      to_number(input).floor.to_i
+    end
+
     def default(input, default_value = "".freeze)
       is_blank = input.respond_to?(:empty?) ? input.empty? : !input
       is_blank ? default_value : input

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -273,6 +273,22 @@ class StandardFiltersTest < Test::Unit::TestCase
     assert_template_result "1", "{{ 3 | modulo:2 }}"
   end
 
+  def test_round
+    assert_template_result "5", "{{ input | round }}", 'input' => 4.6
+    assert_template_result "4", "{{ '4.3' | round }}"
+    assert_template_result "4.56", "{{ input | round: 2 }}", 'input' => 4.5612
+  end
+
+  def test_ceil
+    assert_template_result "5", "{{ input | ceil }}", 'input' => 4.6
+    assert_template_result "5", "{{ '4.3' | ceil }}"
+  end
+
+  def test_floor
+    assert_template_result "4", "{{ input | floor }}", 'input' => 4.6
+    assert_template_result "4", "{{ '4.3' | floor }}"
+  end
+
   def test_append
     assigns = {'a' => 'bc', 'b' => 'd' }
     assert_template_result('bcd',"{{ a | append: 'd'}}",assigns)


### PR DESCRIPTION
**Problem**

Rounding numbers has always been kinda hard in Liquid, and people came up with solutions such as;

``` javascript
$('.apply-round-to-this-div').html(function(index, oldhtml) {
    return Math.round( parseFloat(oldhtml);  );
 });
```

or

``` liquid
{% assign: perc = variant.compare_at_price | minus: variant.price | times: 100.0 | divided_by: variant.compare_at_price | plus: 0.5 %}
{% assign: perc = perc %}
{% capture perc %}{{ perc }}{% endcapture %}
{% assign: perc = perc | split: "." | first %}
```

Ref.: https://ecommerce.shopify.com/c/ecommerce-design/t/rounding-floats-using-liquid-filters-157565
Ref. : http://www.shopifyninjas.com/shopify-how-to-show-percentage-discount-saved/

**Solution**

This adds `round`, `ceil` and `floor` as standard filters in Liquid.

``` liquid
"You save {{ 74.65 | round }}%!" #=> "You save 75%!"
```

**Note**

It seems odd to me that these filters were not already there. Is there any reason not to have them?

@fw42 @tobi 
