### PR TITLE
Unfreeze version string

### DIFF
--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Liquid
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
It breaks gem installation on ruby 1.9.x (older rubygem?)

/review @christianblais @Sirupsen @fw42 @arthurnn 
