### PR TITLE
Variable names should be able to start with digits

### DIFF
--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -14,7 +14,7 @@ module Liquid
     IDENTIFIER = /[\w\-?!]+/
     SINGLE_STRING_LITERAL = /'[^\']*'/
     DOUBLE_STRING_LITERAL = /"[^\"]*"/
-    NUMBER_LITERAL = /-?\d+(\.\d+)?/
+    NUMBER_LITERAL = /-?\d+(\.\d+)?\b/
     DOTDOT = /\.\./
     COMPARISON_OPERATOR = /==|!=|<>|<=?|>=?|contains/
 

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -13,6 +13,10 @@ class VariableUnitTest < Test::Unit::TestCase
     assert_equal 'hello', var.name
     assert_equal [["textileze",[]]], var.filters
 
+    var = Variable.new('42_meaning_of_life | textileze')
+    assert_equal '42_meaning_of_life', var.name
+    assert_equal [["textileze",[]]], var.filters
+
     var = Variable.new('hello | textileze | paragraph')
     assert_equal 'hello', var.name
     assert_equal [["textileze",[]], ["paragraph",[]]], var.filters


### PR DESCRIPTION
Contexts may have key names that start with digits, but liquid templates don't support identifier names that start with digits e.g. `{% if 2013_revenue > 100 %}`
This change to NUMBER_LITERAL regex checks that a number is on a word boundary. If not, it will be considered an identifier
