### PR TITLE
Avoid holding on to stale tag classes

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -38,6 +38,9 @@ module Liquid
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
+
+  singleton_class.send(:attr_accessor, :cache_classes)
+  self.cache_classes = true
 end
 
 require "liquid/version"

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -16,4 +16,54 @@ class TemplateUnitTest < Test::Unit::TestCase
     assert_instance_of I18n, t.root.options[:locale]
     assert_equal fixture("en_locale.yml"), t.root.options[:locale].path
   end
+
+  def test_with_cache_classes_tags_returns_the_same_class
+    original_cache_setting = Liquid.cache_classes
+    Liquid.cache_classes = true
+
+    original_klass = Class.new
+    Object.send(:const_set, :CustomTag, original_klass)
+    Template.register_tag('custom', CustomTag)
+
+    Object.send(:remove_const, :CustomTag)
+
+    new_klass = Class.new
+    Object.send(:const_set, :CustomTag, new_klass)
+
+    assert Template.tags['custom'].equal?(original_klass)
+  ensure
+    Object.send(:remove_const, :CustomTag)
+    Template.tags.delete('custom')
+    Liquid.cache_classes = original_cache_setting
+  end
+
+  def test_without_cache_classes_tags_reloads_the_class
+    original_cache_setting = Liquid.cache_classes
+    Liquid.cache_classes = false
+
+    original_klass = Class.new
+    Object.send(:const_set, :CustomTag, original_klass)
+    Template.register_tag('custom', CustomTag)
+
+    Object.send(:remove_const, :CustomTag)
+
+    new_klass = Class.new
+    Object.send(:const_set, :CustomTag, new_klass)
+
+    assert Template.tags['custom'].equal?(new_klass)
+  ensure
+    Object.send(:remove_const, :CustomTag)
+    Template.tags.delete('custom')
+    Liquid.cache_classes = original_cache_setting
+  end
+
+  class FakeTag; end
+
+  def test_tags_delete
+    Template.register_tag('fake', FakeTag)
+    assert_equal FakeTag, Template.tags['fake']
+
+    Template.tags.delete('fake')
+    assert_nil Template.tags['fake']
+  end
 end


### PR DESCRIPTION
Liquid's `Template.register_tag` keeps a reference to the class used for each tag in a hash. While this is fine for production use, Rails redefines constants when reloading classes which causes any reloaded tag classes to break.

Ping @byroot  
