### PR TITLE
Regression fix: Tag include in strict mode generating false errors

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -148,7 +148,9 @@ module Liquid
     end
 
     def has_key?(key)
-      resolve(key) != nil
+      with_error_mode(:lax) do
+        resolve(key) != nil
+      end
     end
 
     private
@@ -289,6 +291,17 @@ module Liquid
       def handle_not_found(variable)
         @errors << "Variable {{#{variable}}} not found" if Template.error_mode == :strict
       end
+
+      def with_error_mode(mode)
+        old_error_mode = Template.error_mode
+        begin
+          Template.error_mode = mode
+          yield
+        ensure
+          Template.error_mode = old_error_mode
+        end
+      end
+
   end # Context
 
 end # Liquid

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -44,14 +44,23 @@ module Liquid
 
     def render(context)
       partial = load_cached_partial(context)
-      variable = context[@variable_name || @template_name[1..-2]]
+
+      template_inner_name = @template_name[1..-2]
+
+      if @variable_name
+        variable = context[@variable_name]
+      elsif context.has_key?(template_inner_name)
+        variable = context[template_inner_name]
+      else
+        variable = nil
+      end
 
       context.stack do
         @attributes.each do |key, value|
           context[key] = context[value]
         end
 
-        context_variable_name = @template_name[1..-2].split('/'.freeze).last
+        context_variable_name = template_inner_name.split('/'.freeze).last
         if variable.is_a?(Array)
           variable.collect do |var|
             context[context_variable_name] = var

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -20,4 +20,14 @@ class ContextTest < Test::Unit::TestCase
     assert_equal 'Global test', Template.parse("{{'test' | notice }}").render!
     assert_equal 'Local test', Template.parse("{{'test' | notice }}").render!({}, :filters => [local])
   end
+
+  def test_has_key_will_not_add_an_error_for_missing_keys
+    Template.error_mode = :strict
+
+    context = Context.new
+
+    context.has_key?('unknown')
+
+    assert_empty context.errors
+  end
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -69,7 +69,7 @@ class ErrorHandlingTest < Test::Unit::TestCase
       end
     end
   end
-  
+
   def test_lax_unrecognized_operator
     assert_nothing_raised do
       template = Liquid::Template.parse(' {% if 1 =! 2 %}ok{% endif %} ', :error_mode => :lax)

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -205,4 +205,12 @@ class IncludeTagTest < Test::Unit::TestCase
       Liquid::Template.tags['include'] = original_tag
     end
   end
+
+  def test_does_not_add_error_in_strict_mode_for_missing_variable
+    Liquid::Template.file_system = TestFileSystem.new
+
+    a = Liquid::Template.parse(' {% include "nested_template" %}')
+    a.render!
+    assert_empty a.errors
+  end
 end # IncludeTagTest


### PR DESCRIPTION
Regression introduced by https://github.com/Shopify/liquid/commit/2bac6267f9fb6f341f77ee6aaf02cb17dd8e09cf

The specified commit introduced a regression on the include tag where when used add to error list mentioning the variable named after the snipped being included is absent. `"Variable {{nested_template}} not found"`

This is due to the include tag copying over variable from one context to the other AND the magic where if not specified the `with` parameter is defaulted to the template name.

The fix proposed it to check if the variable exists (via `has_key?`) before actually accessing it.

Side problem: `has_key?` added an error when the key was not available.... So the proposition is to run `has_key?` within `:lax` mode. Either it was that or passing an ignore_error flag down the method chain. Alternate propositions would be appreciated if any exists.

Either accepting this PR or rollbacking the specified commit would be in my mind an acceptable solution.

Thoughts?

cc: @sgnr @fw42 
