### PR TITLE
Adds unicode support via unicode gem

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'bigdecimal'
+require 'unicode'
 
 module Liquid
 
@@ -20,17 +21,17 @@ module Liquid
 
     # convert an input string to DOWNCASE
     def downcase(input)
-      input.to_s.downcase
+      ::Unicode::downcase String(input)
     end
 
     # convert an input string to UPCASE
     def upcase(input)
-      input.to_s.upcase
+      ::Unicode::upcase String(input)
     end
 
     # capitalize words in the input centence
     def capitalize(input)
-      input.to_s.capitalize
+      ::Unicode::capitalize String(input)
     end
 
     def escape(input)

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = ["History.md", "README.md"]
 
   s.require_path = "lib"
+  s.add_dependency 'unicode'
 
   s.add_development_dependency 'rake'
 end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -54,12 +54,20 @@ class StandardFiltersTest < Test::Unit::TestCase
 
   def test_downcase
     assert_equal 'testing', @filters.downcase("Testing")
+    assert_equal 'æøå', @filters.downcase("Æøå")
     assert_equal '', @filters.downcase(nil)
   end
 
   def test_upcase
     assert_equal 'TESTING', @filters.upcase("Testing")
+    assert_equal 'ÆØÅ', @filters.upcase("æøå")
     assert_equal '', @filters.upcase(nil)
+  end
+
+  def test_capitalize
+    assert_equal 'Testing', @filters.capitalize("testing")
+    assert_equal 'Æøå', @filters.capitalize("æøå")
+    assert_equal '', @filters.capitalize(nil)
   end
 
   def test_truncate


### PR DESCRIPTION
In regular Ruby `String#upcase` doesn't take into account the special UTF-8 character in some languages. E.g. in Danish, we have three additional letters æ, ø, and å, which in uppercase is Æ, Ø, and Å.

The following aren't thus working:

``` ruby
str = "æøå"
str.upcase # => "æøå"
# but should have been "ÆØÅ"
```

The `unicode` gem solves this problem (Also, in Rails we have `ActiveSupport::Multibyte::Chars`)

With this, we can instead do

``` ruby
str = "æøå"
Unicode.upcase(str) # => "ÆØÅ"
# this is now correct
```
