### PR TITLE
Add object profiling in addition to cpu profiling

### DIFF
--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -4,10 +4,14 @@ require File.dirname(__FILE__) + '/theme_runner'
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
 profiler = ThemeRunner.new
 profiler.run
-results = StackProf.run(mode: :cpu) do
-  100.times do
-    profiler.run
+
+[:cpu, :object].each do |profile_type|
+  puts "Profiling in #{profile_type.to_s} mode..."
+  results = StackProf.run(mode: profile_type) do
+    100.times do
+      profiler.run
+    end
   end
+  StackProf::Report.new(results).print_text(false, 20)
+  File.write(ENV['FILENAME'] + "." + profile_type.to_s, Marshal.dump(results)) if ENV['FILENAME']
 end
-StackProf::Report.new(results).print_text(false, 20)
-File.write(ENV['FILENAME'], Marshal.dump(results)) if ENV['FILENAME']


### PR DESCRIPTION
In #380, I used object profiling to find some unnecessary object allocations on a hot path. In the comments, it was requested that this profiling be enabled by default so that others can use the data to potentially optimize further as well as a quick check for regressions.

Modified the profile code to run both cpu and object benchmarks, writing results to separate files for further exploration.

Review: @Shopify/liquid
