### PR TITLE
Remove block in favour of for loop to reduce temporary object allocation during variable context resolution

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -194,7 +194,12 @@ module Liquid
 
       # Fetches an object starting at the local scope and then moving up the hierachy
       def find_variable(key)
-        scope = @scopes.find { |s| s.has_key?(key) }
+
+        # This was changed from find() to find_index() because this is a very hot
+        # path and find_index() is optimized in MRI to reduce object allocation
+        index = @scopes.find_index { |s| s.has_key?(key) }
+        scope = @scopes[index] if index
+
         variable = nil
 
         if scope.nil?


### PR DESCRIPTION
Resolving variable values within their contexts is one of the more frequent operations that occurs during liquid template rendering.

This change simply alters the code which searches the scopes to use a for loop instead of find with a block. the gain is that the temporary objects passed to the block are no longer allocated.

No change in CPU benchmark from master.

Object allocation profile for master:

```
==================================
  Mode: object(1)
  Samples: 8171200 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   2185900  (26.8%)     1433400  (17.5%)     Liquid::Variable#lax_parse
  10194700 (124.8%)      806100   (9.9%)     Liquid::Block#parse
    752500   (9.2%)      752500   (9.2%)     block in Liquid::Variable#lax_parse
    625200   (7.7%)      625200   (7.7%)     Liquid::Context#variable_parse
   2944500  (36.0%)      521600   (6.4%)     Liquid::Block#create_variable
    438600   (5.4%)      438600   (5.4%)     Liquid::Template#tokenize
    480300   (5.9%)      433300   (5.3%)     Liquid::Context#find_variable
   1716000  (21.0%)      421100   (5.2%)     Liquid::Context#resolve
   2521700  (30.9%)      300600   (3.7%)     Liquid::Variable#render
   1053600  (12.9%)      295500   (3.6%)     block in Liquid::Variable#render
    289100   (3.5%)      289100   (3.5%)     Liquid::If#lax_parse
   2422900  (29.7%)      238800   (2.9%)     block in Liquid::Block#create_variable
    204800   (2.5%)      204800   (2.5%)     Liquid::StandardFilters#truncatewords
    146100   (1.8%)      143500   (1.8%)     Liquid::For#lax_parse
    131300   (1.6%)      131300   (1.6%)     block in Liquid::Context#variable
   7068300  (86.5%)      108700   (1.3%)     Liquid::Block#render_all
    600600   (7.4%)       98500   (1.2%)     Liquid::Context#invoke
     70700   (0.9%)       70700   (0.9%)     Liquid::Block#block_delimiter
     66300   (0.8%)       66000   (0.8%)     Liquid::Context#initialize
    683300   (8.4%)       58100   (0.7%)     block in Liquid::Context#initialize
```

Object allocation profile for this PR:

```
==================================
  Mode: object(1)
  Samples: 7835400 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   2185900  (27.9%)     1433400  (18.3%)     Liquid::Variable#lax_parse
  10194700 (130.1%)      806100  (10.3%)     Liquid::Block#parse
    752500   (9.6%)      752500   (9.6%)     block in Liquid::Variable#lax_parse
    625200   (8.0%)      625200   (8.0%)     Liquid::Context#variable_parse
   2944500  (37.6%)      521600   (6.7%)     Liquid::Block#create_variable
    438600   (5.6%)      438600   (5.6%)     Liquid::Template#tokenize
   1380200  (17.6%)      421100   (5.4%)     Liquid::Context#resolve
   2262900  (28.9%)      300600   (3.8%)     Liquid::Variable#render
   1046400  (13.4%)      295500   (3.8%)     block in Liquid::Variable#render
    289100   (3.7%)      289100   (3.7%)     Liquid::If#lax_parse
   2422900  (30.9%)      238800   (3.0%)     block in Liquid::Block#create_variable
    204800   (2.6%)      204800   (2.6%)     Liquid::StandardFilters#truncatewords
    146100   (1.9%)      143500   (1.8%)     Liquid::For#lax_parse
    131300   (1.7%)      131300   (1.7%)     block in Liquid::Context#variable
   6244900  (79.7%)      108700   (1.4%)     Liquid::Block#render_all
    600600   (7.7%)       98500   (1.3%)     Liquid::Context#invoke
     97500   (1.2%)       97500   (1.2%)     block in Liquid::Context#find_variable
     70700   (0.9%)       70700   (0.9%)     Liquid::Block#block_delimiter
     66300   (0.8%)       66000   (0.8%)     Liquid::Context#initialize
    683300   (8.7%)       58100   (0.7%)     block in Liquid::Context#initialize
```

Down 335,800 objects.

@Shopify/liquid 
