### PR TITLE
Remove unnecessary blank? code

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -11,7 +11,7 @@ module Liquid
     end 
 
     def blank?
-      @blank || false
+      @blank
     end
 
     def parse(tokens)
@@ -49,7 +49,7 @@ module Liquid
             else
               raise SyntaxError.new(options[:locale].t("errors.syntax.tag_termination".freeze, :token => token, :tag_end => TagEnd.inspect))
             end
-          when token.start_with?(VARSTART) 
+          when token.start_with?(VARSTART)
             new_var = create_variable(token)
             @nodelist << new_var
             @children << new_var

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -31,7 +31,7 @@ module Liquid
     end
 
     def blank?
-      @blank || false
+      false
     end
 
     def parse_with_selected_parser(markup)
@@ -50,11 +50,12 @@ module Liquid
     end
 
     private
+
     def strict_parse_with_error_context(markup)
       strict_parse(markup)
     rescue SyntaxError => e
       e.message << " in \"#{markup.strip}\"" 
       raise e
     end
-  end # Tag
-end # Liquid
+  end
+end

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -1,5 +1,4 @@
 module Liquid
-
   # Capture stores the result of a block into a variable without rendering it inplace.
   #
   #   {% capture heading %}

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -43,11 +43,8 @@ module Liquid
       end
     end
 
-    def blank?
-      false
-    end
-
     private
+
     def variables_from_string(markup)
       markup.split(',').collect do |var|
         var =~ /\s*(#{QuotedFragment})\s*/o

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -38,10 +38,6 @@ module Liquid
     def parse(tokens)
     end
 
-    def blank?
-      false
-    end
-
     def render(context)
       partial = load_cached_partial(context)
       variable = context[@variable_name || @template_name[1..-2]]

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -25,10 +25,6 @@ module Liquid
       context.environments.first[@variable] = value + 1
       value.to_s
     end
-
-    def blank?
-      false
-    end
   end
 
   Template.register_tag('increment'.freeze, Increment)

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -60,10 +60,6 @@ class CustomInclude < Liquid::Tag
   def parse(tokens)
   end
 
-  def blank?
-    false
-  end
-
   def render(context)
     @template_name[1..-2]
   end


### PR DESCRIPTION
Since https://github.com/Shopify/liquid/commit/2efe809e11ee5db6feea5e62d6c6585471f9f8b5, Liquid::Tag#blank? defaults to false (for backwards compatibility), which means a lot of those overrides here are unnecessary (only need to overwrite if you want your tag to be blank, not if you don't).

@arthurnn 
