### PR TITLE
Make Liquid::Block.new public

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -5,10 +5,14 @@ module Liquid
     TAGSTART = "{%".freeze
     VARSTART = "{{".freeze
 
+    class << self
+      public :new
+    end
+
     def initialize(tag_name, markup, options)
       super
       @block_delimiter = "end#{tag_name}"
-    end 
+    end
 
     def blank?
       @blank || false


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/321 introduced [this](https://github.com/Shopify/liquid/blob/d4ecaff8b839e7629090e238dd6bd5bff6c9e74c/lib/liquid/tag.rb#L13) line, which makes the Liquid::Tag initializer a private method. As a (probably unintended?) side-effect, this also made the Liquid::Block initializer a private method.

I'm just playing around with Jekyll and Liquid master right now, and this is the only thing that is breaking their tests when bumping Liquid (because they are instantiating a Liquid::Block subclass in one of their tests).

Not sure if this is the right way to fix this. It's not really important for Liquid itself that Liquid::Block.new is public. This could also be fixed in Jekyll instead.

@dylanahsmith, @arthurnn, thoughts?
cc @parkr
