### PR TITLE
Allow curly brackets and escaped quotes in Variables (2)

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -29,12 +29,13 @@ module Liquid
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
   VariableSegment             = /[\w\-]/
   VariableStart               = /\{\{/
+  VariableIncompleteEnd       = /\}\}?/
   VariableEnd                 = /\}\}/
   QuotedString                = /(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')/om
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}(?:#{QuotedString}|.*?)*#{TagEnd}|#{VariableStart}(?:#{QuotedString}|.*?)*#{VariableEnd}/om
+  PartialTemplateParser       = /#{TagStart}(?:#{QuotedString}|.*?)*#{TagEnd}|#{VariableStart}(?:#{QuotedString}|.*?)*#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -20,5 +20,6 @@ class RawTagTest < Test::Unit::TestCase
     assert_template_result ' Foobar {% invalid {% {% endraw ', '{% raw %} Foobar {% invalid {% {% endraw {% endraw %}'
     assert_template_result ' Foobar {% {% {% ', '{% raw %} Foobar {% {% {% {% endraw %}'
     assert_template_result ' test {% raw %} {% endraw %}', '{% raw %} test {% raw %} {% {% endraw %}endraw %}'
+    assert_template_result ' Foobar {{ invalid 1', '{% raw %} Foobar {{ invalid {% endraw %}{{ 1 }}'
   end
 end


### PR DESCRIPTION
The sequel to https://github.com/Shopify/liquid/pull/170

With this patch this should work now:

```
{{ '{\'message\': \'this should work now\', \'foo\': {\'bar\':\'rab\'}}' }}
```

the main idea was to use it for a i18n filter accepting json encoded strings as argument

```
{{ 'translation_string' | t:'{\'count\':10,\'custom_var\':\'hello world\'}' }}
```

the patch should also fix https://github.com/Shopify/liquid/pull/251

Benchmark result of the original current liquid master:

```
/Users/stefan/.rvm/rubies/ruby-2.1.1/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         2.180000   0.010000   2.190000 (  2.189993)
parse & run:   5.040000   0.010000   5.050000 (  5.046477)
--------------------------------------- total: 7.240000sec

                   user     system      total        real
parse:         2.140000   0.000000   2.140000 (  2.144717)
parse & run:   5.090000   0.010000   5.100000 (  5.097024)
```

Benchmark result with this patch:

```
/Users/stefan/.rvm/rubies/ruby-2.1.1/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         2.420000   0.010000   2.430000 (  2.429807)
parse & run:   5.220000   0.000000   5.220000 (  5.246784)
--------------------------------------- total: 7.650000sec

                   user     system      total        real
parse:         2.330000   0.000000   2.330000 (  2.335282)
parse & run:   5.410000   0.010000   5.420000 (  5.432291)
```
