### PR TITLE
Fixing regression from block delimiter enhancement

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -5,11 +5,6 @@ module Liquid
     TAGSTART = "{%".freeze
     VARSTART = "{{".freeze
 
-    def initialize(tag_name, markup, options)
-      super
-      @block_delimiter = "end#{tag_name}"
-    end 
-
     def blank?
       @blank
     end
@@ -30,7 +25,7 @@ module Liquid
 
               # if we found the proper block delimiter just end parsing here and let the outer block
               # proceed
-              if @block_delimiter == $1
+              if block_delimiter == $1
                 end_tag
                 return
               end
@@ -98,6 +93,10 @@ module Liquid
 
     def block_name
       @tag_name
+    end
+
+    def block_delimiter
+      @block_delimiter ||= "end#{block_name}"
     end
 
     def create_variable(token)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -8,7 +8,7 @@ module Liquid
       while token = tokens.shift
         if token =~ FullTokenPossiblyInvalid
           @nodelist << $1 if $1 != "".freeze
-          if @block_delimiter == $2
+          if block_delimiter == $2
             end_tag
             return
           end

--- a/test/integration/parsing_quirks_test.rb
+++ b/test/integration/parsing_quirks_test.rb
@@ -84,4 +84,11 @@ class ParsingQuirksTest < Test::Unit::TestCase
       assert_template_result('',"{% if #{markup} %} YES {% endif %}")
     end
   end
+
+  def test_raise_on_invalid_tag_delimiter
+    assert_raise(Liquid::SyntaxError) do
+      Template.new.parse('{% end %}')
+    end
+  end
+
 end # ParsingQuirksTest


### PR DESCRIPTION
When I tried to bump Shopify to use the latest version of Liquid, a unit test failed. I took the test and moved it into the Liquid test suite and it failed there as well.

The block_delimiter enhancement I did in #384 was causing the failure. I reverted it to only create the delimiter on first encoutering it, but I memoized it so that we don't recreate it on every run through.

@Shopify/liquid 
