### PR TITLE
Forgot an error message case

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -85,7 +85,7 @@ module Liquid
       when 'end'.freeze
         raise SyntaxError.new(options[:locale].t("errors.syntax.invalid_delimiter".freeze,
                                                  :block_name => block_name,
-                                                 :block_delimiter => @block_delimiter))
+                                                 :block_delimiter => block_delimiter))
       else
         raise SyntaxError.new(options[:locale].t("errors.syntax.unknown_tag".freeze, :tag => tag))
       end


### PR DESCRIPTION
Sigh... I forgot to remove one character in #393. Shopify asserts on the actual error message, which was off by two whole characters.

cc: @Shopify/liquid 
