### PR TITLE
Excetion handling for humans (2)

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Add exception_handler feature, see #397 and #254 [Bogdan Gusiev, bogdan and Florian Weingarten, fw42]
 * Optimize variable parsing to avoid repeated regex evaluation during template rendering #383 [Jason Hiltz-Laforge, jasonhl]
 * Optimize checking for block interrupts to reduce object allocation #380 [Jason Hiltz-Laforge, jasonhl] 
 * Properly set context rethrow_errors on render! #349 [Thierry Joyal, tjoyal]

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -142,7 +142,11 @@ module Liquid
       context = case args.first
       when Liquid::Context
         c = args.shift
-        c.rethrow_errors = true if @rethrow_errors
+
+        if @rethrow_errors
+          c.exception_handler = ->(e) { true }
+        end
+
         c
       when Liquid::Drop
         drop = args.shift
@@ -167,6 +171,9 @@ module Liquid
           context.add_filters(options[:filters])
         end
 
+        if options[:exception_handler]
+          context.exception_handler = options[:exception_handler]
+        end
       when Module
         context.add_filters(args.pop)
       when Array

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -153,4 +153,18 @@ class TemplateTest < Test::Unit::TestCase
     end
     assert_equal 'ruby error in drop', e.message
   end
+
+  def test_exception_handler_doesnt_reraise_if_it_returns_false
+    exception = nil
+    Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; false })
+    assert exception.is_a?(ZeroDivisionError)
+  end
+
+  def test_exception_handler_does_reraise_if_it_returns_true
+    exception = nil
+    assert_raises(ZeroDivisionError) do
+      Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; true })
+    end
+    assert exception.is_a?(ZeroDivisionError)
+  end
 end


### PR DESCRIPTION
(More) backwards compatible version of https://github.com/Shopify/liquid/pull/254

The interface of Liquid::Context changes a little bit (there are no #rethrow_errors and #rethrow_errors= methods anymore), but the interface of Liquid::Template stays backwards compatible.

@bodgan @arthurnn @jasonhl 
