### PR TITLE
Reorder constructor to avoid referencing uninitialized variable when environment contains a self-referencing proc

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -19,11 +19,12 @@ module Liquid
     SQUARE_BRACKETED = /\A\[(.*)\]\z/m
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = {})
-      @environments    = [environments].flatten
-      @scopes          = [(outer_scope || {})]
-      @registers       = registers
-      @errors          = []
-      @resource_limits = (resource_limits || {}).merge!({ :render_score_current => 0, :assign_score_current => 0 })
+      @environments     = [environments].flatten
+      @scopes           = [(outer_scope || {})]
+      @registers        = registers
+      @errors           = []
+      @resource_limits  = (resource_limits || {}).merge!({ :render_score_current => 0, :assign_score_current => 0 })
+      @parsed_variables = Hash.new{ |cache, markup| cache[markup] = variable_parse(markup) } 
       squash_instance_assigns_with_environments
 
       if rethrow_errors
@@ -32,7 +33,6 @@ module Liquid
 
       @interrupts = []
       @filters = []
-      @parsed_variables = Hash.new{ |cache, markup| cache[markup] = variable_parse(markup) } 
     end
 
     def increment_used_resources(key, obj)

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -483,4 +483,12 @@ class ContextUnitTest < Test::Unit::TestCase
     assert_equal 1, mock_scan.calls.size
   end
 
+  def test_context_initialization_with_a_proc_in_environment
+    contx = Context.new([:test => lambda { |c| c['poutine']}], {:test => :foo})
+
+    assert contx
+    assert_nil contx['poutine']
+  end
+
+
 end # ContextTest


### PR DESCRIPTION
Updating Shopify to use the latest liquid caused exceptions in production. Stack trace:

```
GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:244 → variable
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:193 → resolve
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:153 → []
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:289 → call
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:289 → lookup_and_evaluate
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:299 → block (2 levels) in squash_instance_assigns_with_environments
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:297 → each
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:297 → block in squash_instance_assigns_with_environments
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:296 → each_key
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:296 → squash_instance_assigns_with_environments
[GEM_ROOT]/bundler/gems/liquid-32e4f2d3b1f4/lib/liquid/context.rb:27 → initialize
...
```

The root of the issue is that `Context::squash_instance_assigns_with_environments` is called within `Context::initialize`. If the environment has a self-referential Proc, i.e. one which evaluates another variable in the environment, it ends up looking at the `parsed_variables` member. Unfortunately, due to the order in the `initialize` method, that member has not been initialized. Kaboom.

Added a test to cover this form of Context initialization and changed the order of the controller initialize.

@Shopify/liquid 
