### PR TITLE
lazily create stacks

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -137,8 +137,13 @@ module Liquid
     #   context['var]  #=> nil
     def stack(new_scope=nil)
       old_stack_used = @this_stack_used
-      @this_stack_used = (new_scope != nil)
-      push(new_scope) if @this_stack_used
+      if new_scope
+        push(new_scope)
+        @this_stack_used = true
+      else
+        @this_stack_used = false
+      end
+
       yield
     ensure
       pop if @this_stack_used


### PR DESCRIPTION
@jasonhl @csfrancis what do you guys think?

preliminary benchmarking:

before:

``` bash
~/src/liquid  (lazy_stack*) ➜ git reset --hard HEAD~1
HEAD is now at d07b12d Update History log
~/src/liquid  (lazy_stack) ➜ bx rake benchmark:run
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         1.880000   0.010000   1.890000 (  1.896757)
parse & run:   4.310000   0.010000   4.320000 (  4.323054)
--------------------------------------- total: 6.210000sec

                   user     system      total        real
parse:         1.780000   0.000000   1.780000 (  1.782656)
parse & run:   4.330000   0.020000   4.350000 (  4.362625)
```

after:

``` bash
~/src/liquid  (lazy_stack) ➜ git pull
First, rewinding head to replay your work on top of it...
Fast-forwarded lazy_stack to ba6e3e3da62d0d5d654f163792554cf9da8c7e8e.
~/src/liquid  (lazy_stack) ➜ git log
commit ba6e3e3da62d0d5d654f163792554cf9da8c7e8e
Author: Tom Burns <tom.burns@jadedpixel.com>
Date:   Mon Jul 28 14:12:11 2014 +0000

    lazily create stacks
~/src/liquid  (lazy_stack) ➜ bx rake benchmark:run
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby ./performance/benchmark.rb lax
Rehearsal ------------------------------------------------
parse:         1.900000   0.000000   1.900000 (  1.907752)
parse & run:   4.160000   0.000000   4.160000 (  4.147444)
--------------------------------------- total: 6.060000sec

                   user     system      total        real
parse:         1.690000   0.000000   1.690000 (  1.690362)
parse & run:   4.070000   0.000000   4.070000 (  4.082147)
```
