### PR TITLE
benchmark/ips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gem 'stackprof', platforms: :mri_21
 
 group :test do
   gem 'spy', '0.4.1'
+  gem 'benchmark-ips'
 end

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -1,11 +1,17 @@
-require 'benchmark'
+require 'benchmark/ips'
 require File.dirname(__FILE__) + '/theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
 profiler = ThemeRunner.new
 
-Benchmark.bmbm do |x|
-  x.report("parse:")   { 100.times { profiler.compile } }
-  x.report("parse & run:")   { 100.times { profiler.run } }
-end
+Benchmark.ips do |x|
+  x.time = 60
+  x.warmup = 5
 
+  puts
+  puts "Running benchmark for #{x.time} seconds (with #{x.warmup} seconds warmup)."
+  puts
+
+  x.report("parse:") { profiler.compile }
+  x.report("parse & run:") { profiler.run }
+end


### PR DESCRIPTION
@arthurnn @boourns @jasonhl 

Switches to the benchmark/ips gem (https://github.com/evanphx/benchmark-ips). Main idea being that instead of "run this whole thing 100 times and see how long it takes", you do "run this whole thing for 60 seconds and see how often you can do it".

I don't think it's that much better, our benchmarks still suck big time, but this approach still feels a bit nicer.

Output looks like this:

```
vagrant@vagrant ~/src/liquid $ be rake benchmark:run
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby ./performance/benchmark.rb lax

Running benchmark for 60 seconds (with 5 seconds warmup).

Calculating -------------------------------------
              parse:         3 i/100ms
        parse & run:         1 i/100ms
-------------------------------------------------
              parse:       31.0 (±22.6%) i/s -       1719 in  60.099286s
        parse & run:       14.6 (±20.5%) i/s -        817 in  60.005620s

Comparison:
              parse::       31.0 i/s
        parse & run::       14.6 i/s - 2.12x slower
```

Our standard deviation is pretty high (which basically means that many of our benchmark tests don't take the same amount of time each time they are run). So, that sucks... :-/
