### PR TITLE
Fix divided_by behaviour when mathn is loaded

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -252,7 +252,13 @@ module Liquid
 
     # division
     def divided_by(input, operand)
-      apply_operation(input, operand, :/)
+      result = apply_operation(input, operand, :/)
+
+      if result.is_a?(Rational) && input.is_a?(Fixnum) && operand.is_a?(Fixnum)
+        result.to_i
+      else
+        result
+      end
     end
 
     def modulo(input, operand)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -307,6 +307,12 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "0.5", "{{ 2.0 | divided_by:4 }}"
   end
 
+  def test_divided_by_with_mathn_bullshit
+    with_mathn_behaviour do
+      assert_template_result "4", "{{ 14 | divided_by:3 }}"
+    end
+  end
+
   def test_modulo
     assert_template_result "1", "{{ 3 | modulo:2 }}"
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,5 +64,22 @@ module Minitest
     ensure
       Liquid::Template.error_mode = old_mode
     end
+
+    def with_mathn_behaviour
+      Fixnum.class_eval do
+        alias_method :old_division, :/
+        def /(other)
+          Rational(self.old_division(other))
+        end
+      end
+
+      yield
+    ensure
+      Fixnum.class_eval do
+        remove_method :/
+        alias_method :/, :old_division
+        remove_method :old_division
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/Shopify/liquid/issues/408, https://github.com/jekyll/jekyll/issues/2702

I don't think this is Liquid's fault, but this would be an easy way to "fix" it.

Not sure if this is a good idea. Maybe the "bug" is actually reasonable behaviour (if you include "mathn", this might be what you want). Thoughts?

@Shopify/liquid @parkr / cc @djacquel @albertogg
