### PR TITLE
Cast input to string before spliting

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -75,7 +75,7 @@ module Liquid
     #   <div class="summary">{{ post | split '//' | first }}</div>
     #
     def split(input, pattern)
-      input.split(pattern)
+      input.to_s.split(pattern)
     end
 
     def strip(input)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -106,6 +106,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal ['A?Z'], @filters.split('A?Z', '~')
     # Regexp works although Liquid does not support.
     assert_equal ['A','Z'], @filters.split('AxZ', /x/)
+    assert_equal [], @filters.split(nil, ' ')
   end
 
   def test_escape


### PR DESCRIPTION
Most of the other string filter does it, like strip, upcase, downcase etc.

I don't think it would bring any backward compatibility issues either.

I noticed that via reddit: http://www.reddit.com/r/shopify/comments/2coacm/can_anyone_fix_this_error_liquid_error_undefined/

/review @fw42 @arthurnn 
