### PR TITLE
Add quirks test for unanchored filter args

### DIFF
--- a/test/integration/parsing_quirks_test.rb
+++ b/test/integration/parsing_quirks_test.rb
@@ -87,4 +87,17 @@ class ParsingQuirksTest < Minitest::Test
     end
   end
 
+  def test_unanchored_filter_arguments
+    with_error_mode(:lax) do
+      assert_template_result('hi',"{{ 'hi there' | split$$$:' ' | first }}")
+
+      var = Variable.new("('x' | downcase)")
+      assert_equal [['downcase',[]]], var.filters
+      assert_equal "('x'", var.name
+
+      var = Variable.new("variant.title | escape | remove:\"\"\" | remove: \"'\"")
+      assert_equal [["escape", []], ["remove", ["\"\""]]], var.filters
+    end
+  end
+
 end # ParsingQuirksTest


### PR DESCRIPTION
@fw42 

Added a quirks test for the unanchored parsing of filter arguments. This caused problems with `liquid/c` in Shopify/shopify#25531

This behaviour is super messed up and stems from the regex `scan` which is not anchored to match things that are adjacent and starting from the beginning of the string.

``` ruby
# Variable#lax_parse
filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*((?:\w+\s*\:\s*)?#{QuotedFragment})/o).flatten
```
