### PR TITLE
Simplify Variable Parsing Regexes

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -41,8 +41,8 @@ module Liquid
         if Regexp.last_match(2) =~ /#{FilterSeparator}\s*(.*)/om
           filters = Regexp.last_match(1).scan(FilterParser)
           filters.each do |f|
-            if f =~ /\s*(\w+)/
-              filtername = Regexp.last_match(1)
+            if f =~ /\w+/
+              filtername = Regexp.last_match(0)
               filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*((?:\w+\s*\:\s*)?#{QuotedFragment})/o).flatten
               @filters << [filtername, filterargs]
             end


### PR DESCRIPTION
Simplifying some of the variable parser regexes to make it clear what it actually matches. The new regexes behave exactly the same as the old regex but are significantly simpler.

When looking only at the regex the only difference in what it matches is that the new one will not match `/#{FilterSeparator}/` but this regex is used under a scan that immediately discards any results that do not match `/\s*(\w+)/` so matching the filter separator does nothing.
### Liquid WAT

One implication of the fact that the filter separator is never actually matched when parsing filters is that you can use single and double quotes as filter separators in some circumstances since it is actually the `QuotedFragment` code that handles filter separation. This new regex makes it easier to see why this happens.

``` ruby
[7] pry(main)> Liquid::Template.parse("{{ 'X,Y' | downcase ' split: \",\" \" last }}").render
=> "y"
```
### Performance

These new regexes are consistently faster in the benchmarks, but only by a tiny bit.

@fw42 @tonyzou 
