### PR TITLE
Include line numbers in included partials when profiling

### DIFF
--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -96,6 +96,10 @@ module Liquid
       Thread.current[:liquid_profiler]
     end
 
+    def self.profiling?
+      !current_profile.nil?
+    end
+
     def initialize
       @partial_stack = ["<root>"]
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -223,7 +223,7 @@ module Liquid
     end
 
     def calculate_line_numbers(raw_tokens)
-      return raw_tokens unless @profiling
+      return raw_tokens unless @profiling || Profiler.profiling?
 
       current_line = 1
       raw_tokens.map do |token|

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -48,6 +48,18 @@ class RenderProfilingTest < Minitest::Test
     assert_equal 2, t.profiler[1].line_number
   end
 
+  def test_profiling_includes_line_numbers_of_included_partials
+    t = Template.parse("{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    included_children = t.profiler[0].children
+
+    # {% assign template_name = 'a_template' %}
+    assert_equal 1, included_children[0].line_number
+    # {{ template_name }}
+    assert_equal 2, included_children[1].line_number
+  end
+
   def test_profiling_times_the_rendering_of_tokens
     t = Template.parse("{% include 'a_template' %}", :profile => true)
     t.render!


### PR DESCRIPTION
Realized in the original Profiling work that line numbers were not being
calculated for any template parsed and rendered via {% include %}. This
commit fixes that oversight.
