### PR TITLE
Fixed condition constains operator with wrong data type

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Fixed condition with wrong data types, see #423 [Bogdan Gusiev]
 * Add url_encode to standard filters, see #421 [Derrick Reimer, djreimer]
 * Add uniq to standard filters [Florian Weingarten, fw42]
 * Add exception_handler feature, see #397 and #254 [Bogdan Gusiev, bogdan and Florian Weingarten, fw42]

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -15,7 +15,9 @@ module Liquid
       '>'.freeze  => :>,
       '>='.freeze => :>=,
       '<='.freeze => :<=,
-      'contains'.freeze => lambda { |cond, left, right| left && right ? left.include?(right) : false }
+      'contains'.freeze => lambda { |cond, left, right|
+        left && right && left.respond_to?(:include?) ? left.include?(right) : false
+      }
     }
 
     def self.operators

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -80,6 +80,10 @@ class ConditionUnitTest < Minitest::Test
     assert_evalutes_false "0", 'contains', 'not_assigned'
   end
 
+  def test_contains_return_false_on_wrong_data_type
+    assert_evalutes_false "1", 'contains', '0'
+  end
+
   def test_or_condition
     condition = Condition.new('1', '==', '2')
 


### PR DESCRIPTION
"contains" operator on wrong data type should not cause NoMethodError. As it is right now.
