### PR TITLE
Pass options through on include

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -69,7 +69,7 @@ module Liquid
           return cached
         end
         source = read_template_from_file_system(context)
-        partial = Liquid::Template.parse(source)
+        partial = Liquid::Template.parse(source, pass_options)
         cached_partials[template_name] = partial
         context.registers[:cached_partials] = cached_partials
         partial
@@ -87,6 +87,16 @@ module Liquid
         else
           raise ArgumentError, "file_system.read_template_file expects two parameters: (template_name, context)"
         end
+      end
+
+      def pass_options
+        dont_pass = @options[:include_options_blacklist]
+        return {locale: @options[:locale]} if dont_pass == true
+        opts = @options.merge(included: true, include_options_blacklist: false)
+        if dont_pass.is_a?(Array)
+          dont_pass.each {|o| opts.delete(o)}
+        end
+        opts
       end
   end
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -103,7 +103,8 @@ module Liquid
     # Parse source code.
     # Returns self for easy chaining
     def parse(source, options = {})
-      @profiling = options.delete(:profile)
+      @options = options
+      @profiling = options[:profile]
       @root = Document.parse(tokenize(source), DEFAULT_OPTIONS.merge(options))
       @warnings = nil
       self
@@ -234,7 +235,7 @@ module Liquid
     end
 
     def with_profiling
-      if @profiling
+      if @profiling && !@options[:included]
         @profiler = Profiler.new
         @profiler.start
 

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -48,6 +48,18 @@ class RenderProfilingTest < Minitest::Test
     assert_equal 2, t.profiler[1].line_number
   end
 
+  def test_profiling_includes_line_numbers_of_included_partials
+    t = Template.parse("{% include 'a_template' %}", :profile => true)
+    t.render!
+
+    included_children = t.profiler[0].children
+
+    # {% assign template_name = 'a_template' %}
+    assert_equal 1, included_children[0].line_number
+    # {{ template_name }}
+    assert_equal 2, included_children[1].line_number
+  end
+
   def test_profiling_times_the_rendering_of_tokens
     t = Template.parse("{% include 'a_template' %}", :profile => true)
     t.render!

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -209,4 +209,19 @@ class IncludeTagTest < Minitest::Test
     a.render!
     assert_empty a.errors
   end
+
+  def test_passing_options_to_included_templates
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse("{% include template %}", error_mode: :strict).render!("template" => '{{ "X" || downcase }}')
+    end
+    with_error_mode(:lax) do
+      assert_equal 'x', Template.parse("{% include template %}", error_mode: :strict, include_options_blacklist: true).render!("template" => '{{ "X" || downcase }}')
+    end
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse("{% include template %}", error_mode: :strict, include_options_blacklist: [:locale]).render!("template" => '{{ "X" || downcase }}')
+    end
+    with_error_mode(:lax) do
+      assert_equal 'x', Template.parse("{% include template %}", error_mode: :strict, include_options_blacklist: [:error_mode]).render!("template" => '{{ "X" || downcase }}')
+    end
+  end
 end # IncludeTagTest


### PR DESCRIPTION
Pass template parse options down through include tags. This will make them use the correct parser, as well as respect profiling and (eventually) line number options.

This PR can supersede #420 since it solves the same problem (I also included the test from there). It solves it in a way that is more general and also is easier to integrate with #419.

@fw42 @jasonroelofs 
