### PR TITLE
Reduce benchmark volatility by disabling GC

### DIFF
--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -4,14 +4,34 @@ require File.dirname(__FILE__) + '/theme_runner'
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
 profiler = ThemeRunner.new
 
-Benchmark.ips do |x|
-  x.time = 60
-  x.warmup = 5
+# This is kinda sketchy but reduces benchmark variation considerably
+def with_gc_disabled (&block)
+  GC.start
+  GC.disable
+  yield
+ensure
+  GC.enable
+end
 
-  puts
-  puts "Running benchmark for #{x.time} seconds (with #{x.warmup} seconds warmup)."
-  puts
+def run_benchmark(label, &block)
+  Benchmark.ips do |x|
+    # This length of time will consume 2-2.5GB of memory with GC disabled
+    # Experimenting with bumping it up or down didn't seem to substantially change the times or the variation
+    x.time = 10
+    x.warmup = 1
 
-  x.report("parse:") { profiler.compile }
-  x.report("parse & run:") { profiler.run }
+    puts
+    puts "Running #{label} benchmark for #{x.time} seconds (with #{x.warmup} seconds warmup)."
+    puts
+
+    x.report(label) { yield }
+  end
+end
+
+with_gc_disabled do
+  run_benchmark("parse:") { profiler.compile } 
+end
+
+with_gc_disabled do
+  run_benchmark("parse & run:") { profiler.run } 
 end


### PR DESCRIPTION
Sparked by https://github.com/Shopify/liquid/pull/415#issuecomment-51926314, I took a look at why the Liquid benchmark had a standard deviation of 15-20%. The answer appears to be GC. I can now get the standard deviation consistently down below 5%, and often in the 2-3% range.

Three back to back runs on my machine:

```
parse:       58.4 (±1.7%) i/s -        588 in  10.068657s
parse:       58.2 (±1.7%) i/s -        585 in  10.060376s
parse:       57.3 (±3.5%) i/s -        575 in  10.047092s

parse & run:       25.3 (±3.9%) i/s -        254 in  10.042037s  
parse & run:       24.9 (±4.0%) i/s -        248 in  10.004997s
parse & run:       25.1 (±4.0%) i/s -        252 in  10.060830s
```

Output now looks a bit different due to trying to reduce memory usage and volatility between runs:

```
/usr/lib/shopify-ruby/2.1.2-shopify1/bin/ruby ./performance/benchmark.rb lax

Running parse: benchmark for 10 seconds (with 1 seconds warmup).

Calculating -------------------------------------
              parse:         5 i/100ms
-------------------------------------------------
              parse:       57.3 (±3.5%) i/s -        575 in  10.047092s

Running parse & run: benchmark for 10 seconds (with 1 seconds warmup).

Calculating -------------------------------------
        parse & run:         2 i/100ms
-------------------------------------------------
        parse & run:       25.1 (±4.0%) i/s -        252 in  10.060830s
```

@Shopify/liquid 