### PR TITLE
Add Parser Comparison Test

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -130,7 +130,7 @@ module Liquid
         @variable_name = $1
         @collection_name = $2
         @name = "#{$1}-#{$2}"
-        @reversed = $3
+        @reversed = $3 || false
         @attributes = {}
         markup.scan(TagAttributes) do |key, value|
           @attributes[key] = value

--- a/test/integration/comparison_test.rb
+++ b/test/integration/comparison_test.rb
@@ -1,6 +1,3 @@
-require "pp"
-require "yaml"
-
 PERF_DIR = File.dirname(__FILE__) + '/../../performance/shopify'
 require PERF_DIR + '/comment_form'
 require PERF_DIR + '/paginate'
@@ -16,18 +13,22 @@ class BlankTest < Minitest::Test
     Liquid::Template.tags.delete('form')
   end
 
-  def compare_result(file)
+  def dump_template(t)
+    t.inspect.gsub(/:0x[a-f0-9]+/, "")
+  end
+
+  def compare_parsers(file)
     Liquid::Template.error_mode = :lax
     t = Liquid::Template.parse(file)
     Liquid::Template.error_mode = :strict
     t2 = Liquid::Template.parse(file)
-    assert_equal t.to_yaml, t2.to_yaml
+    assert_equal dump_template(t), dump_template(t2)
   end
 
   def test_template_comparison
     Dir[File.dirname(__FILE__) + "/../../performance/tests/**/*.liquid"].each do |template|
       content = IO.read(template)
-      compare_result(content)
+      compare_parsers(content)
     end
   end
 end

--- a/test/integration/comparison_test.rb
+++ b/test/integration/comparison_test.rb
@@ -1,3 +1,4 @@
+require "test_helper"
 PERF_DIR = File.dirname(__FILE__) + '/../../performance/shopify'
 require PERF_DIR + '/comment_form'
 require PERF_DIR + '/paginate'
@@ -18,10 +19,13 @@ class BlankTest < Minitest::Test
   end
 
   def compare_parsers(file)
-    Liquid::Template.error_mode = :lax
-    t = Liquid::Template.parse(file)
-    Liquid::Template.error_mode = :strict
-    t2 = Liquid::Template.parse(file)
+    t, t2 = nil
+    with_error_mode(:lax) do
+      t = Liquid::Template.parse(file)
+    end
+    with_error_mode(:strict) do
+      t2 = Liquid::Template.parse(file)
+    end
     assert_equal dump_template(t), dump_template(t2)
   end
 

--- a/test/integration/comparison_test.rb
+++ b/test/integration/comparison_test.rb
@@ -14,7 +14,7 @@ class BlankTest < Minitest::Test
   end
 
   def dump_template(t)
-    t.inspect.gsub(/:0x[a-f0-9]+/, "")
+    Marshal.dump(t)
   end
 
   def compare_parsers(file)

--- a/test/integration/comparison_test.rb
+++ b/test/integration/comparison_test.rb
@@ -1,0 +1,33 @@
+require "pp"
+require "yaml"
+
+PERF_DIR = File.dirname(__FILE__) + '/../../performance/shopify'
+require PERF_DIR + '/comment_form'
+require PERF_DIR + '/paginate'
+
+class BlankTest < Minitest::Test
+  def setup
+    Liquid::Template.register_tag 'paginate', Paginate
+    Liquid::Template.register_tag 'form', CommentForm
+  end
+
+  def teardown
+    Liquid::Template.tags.delete('paginate')
+    Liquid::Template.tags.delete('form')
+  end
+
+  def compare_result(file)
+    Liquid::Template.error_mode = :lax
+    t = Liquid::Template.parse(file)
+    Liquid::Template.error_mode = :strict
+    t2 = Liquid::Template.parse(file)
+    assert_equal t.to_yaml, t2.to_yaml
+  end
+
+  def test_template_comparison
+    Dir[File.dirname(__FILE__) + "/../../performance/tests/**/*.liquid"].each do |template|
+      content = IO.read(template)
+      compare_result(content)
+    end
+  end
+end


### PR DESCRIPTION
This adds a somewhat useful test that checks if the strict parser and the lax parser produce the same tag tree output. On its own this only useful to make sure the strict and lax parsers do the same thing, but the real fanciness comes from the implications of the fact that this can be done.

I did this as a proof of concept for how one could test that Shopify/liquid-c does the same thing as the existing lax parser. If one was to take this code and run it on a huge dataset of Shopify shop templates then one could be reasonably confident that the two parsers behave the same.

Previous attempts to compare parsers have tried to render templates with both parsers but this is difficult to do since rendering only really works in a production environment. However, this method only needs the template data, and the parsing code for any custom tags.

This method could solve the transition problem of how to be confident that a new parser works.

@fw42 @camilo @tonyzou 