### PR TITLE
Make it easy to set default resource limits.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -16,12 +16,14 @@ module Liquid
     attr_reader :scopes, :errors, :registers, :environments, :resource_limits
     attr_accessor :exception_handler
 
-    def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = {})
+    def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil)
       @environments     = [environments].flatten
       @scopes           = [(outer_scope || {})]
       @registers        = registers
       @errors           = []
-      @resource_limits  = (resource_limits || {}).merge!({ :render_score_current => 0, :assign_score_current => 0 })
+      @resource_limits  = resource_limits || Template.default_resource_limits
+      @resource_limits[:render_score_current] = 0
+      @resource_limits[:assign_score_current] = 0
       @parsed_expression = Hash.new{ |cache, markup| cache[markup] = Expression.parse(markup) }
       squash_instance_assigns_with_environments
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -86,6 +86,10 @@ module Liquid
         Strainer.global_filter(mod)
       end
 
+      def default_resource_limits
+        @default_resource_limits ||= {}
+      end
+
       # creates a new <tt>Template</tt> object from liquid source code
       # To enable profiling, pass in <tt>profile: true</tt> as an option.
       # See Liquid::Profiler for more information
@@ -95,9 +99,8 @@ module Liquid
       end
     end
 
-    # creates a new <tt>Template</tt> from an array of tokens. Use <tt>Template.parse</tt> instead
     def initialize
-      @resource_limits = {}
+      @resource_limits = self.class.default_resource_limits.dup
     end
 
     # Parse source code.


### PR DESCRIPTION
@fw42 & @camilo
cc @grollest & @sunblaze 
## Problem

Right now Shopify is monkey patching Liquid::Template#render in order to set default resource limits.  This seems quite brittle and could be simplified for us and others by providing a default_resource_limits hash.
## Solution

Add a Liquid::Template.default_resource_limits hash that gets used by when resource limits aren't explicitly provided to the context.
