### PR TITLE
Removed context from read_template_file, fixed tests to match new arity

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 * Block parsing moved to BlockBody class (#458) [Dylan Thacker-Smith, dylanahsmith]
 * Add concat filter to concatenate arrays (#429) [Diogo Beato, dvbeato]
 * Ruby 1.9 support dropped (#491) [Justin Li, pushrax]
+* Liquid::Template.file_system's read_template_file method is no longer passed the context. (#441) [James Reid-Smith, sunblaze]
 
 ### Fixed
 * Fix capturing into variables with a hyphen in the name (#505) [Florian Weingarten, fw42]

--- a/lib/liquid/file_system.rb
+++ b/lib/liquid/file_system.rb
@@ -14,7 +14,7 @@ module Liquid
   # This will parse the template with a LocalFileSystem implementation rooted at 'template_path'.
   class BlankFileSystem
     # Called by Liquid to retrieve a template file
-    def read_template_file(template_path, context)
+    def read_template_file(template_path)
       raise FileSystemError, "This liquid context does not allow includes."
     end
   end
@@ -49,7 +49,7 @@ module Liquid
       @pattern = pattern
     end
 
-    def read_template_file(template_path, context)
+    def read_template_file(template_path)
       full_path = full_path(template_path)
       raise FileSystemError, "No such template '#{template_path}'" unless File.exists?(full_path)
 

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -81,15 +81,7 @@ module Liquid
       def read_template_from_file_system(context)
         file_system = context.registers[:file_system] || Liquid::Template.file_system
 
-        # make read_template_file call backwards-compatible.
-        case file_system.method(:read_template_file).arity
-        when 1
-          file_system.read_template_file(context.evaluate(@template_name))
-        when 2
-          file_system.read_template_file(context.evaluate(@template_name), context)
-        else
-          raise ArgumentError, "file_system.read_template_file expects two parameters: (template_name, context)"
-        end
+        file_system.read_template_file(context.evaluate(@template_name))
       end
 
       def pass_options

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -17,7 +17,7 @@ class ThemeRunner
     end
 
     # Called by Liquid to retrieve a template file
-    def read_template_file(template_path, context)
+    def read_template_file(template_path)
       File.read(@path + '/' + template_path + '.liquid')
     end
   end

--- a/test/integration/blank_test.rb
+++ b/test/integration/blank_test.rb
@@ -9,7 +9,7 @@ class FoobarTag < Liquid::Tag
 end
 
 class BlankTestFileSystem
-  def read_template_file(template_path, context)
+  def read_template_file(template_path)
     template_path
   end
 end

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -4,7 +4,7 @@ class RenderProfilingTest < Minitest::Test
   include Liquid
 
   class ProfilingFileSystem
-    def read_template_file(template_path, context)
+    def read_template_file(template_path)
       "Rendering template {% assign template_name = '#{template_path}'%}\n{{ template_name }}"
     end
   end

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class TestFileSystem
-  def read_template_file(template_path, context)
+  def read_template_file(template_path)
     case template_path
     when "product"
       "Product: {{ product.title }} "
@@ -37,14 +37,14 @@ class TestFileSystem
 end
 
 class OtherFileSystem
-  def read_template_file(template_path, context)
+  def read_template_file(template_path)
     'from OtherFileSystem'
   end
 end
 
 class CountingFileSystem
   attr_reader :count
-  def read_template_file(template_path, context)
+  def read_template_file(template_path)
     @count ||= 0
     @count += 1
     'from CountingFileSystem'
@@ -132,7 +132,7 @@ class IncludeTagTest < Minitest::Test
   def test_recursively_included_template_does_not_produce_endless_loop
 
     infinite_file_system = Class.new do
-      def read_template_file(template_path, context)
+      def read_template_file(template_path)
         "-{% include 'loop' %}"
       end
     end
@@ -143,18 +143,6 @@ class IncludeTagTest < Minitest::Test
       Template.parse("{% include 'loop' %}").render!
     end
 
-  end
-
-  def test_backwards_compatability_support_for_overridden_read_template_file
-    infinite_file_system = Class.new do
-      def read_template_file(template_path) # testing only one argument here.
-        "- hi mom"
-      end
-    end
-
-    Liquid::Template.file_system = infinite_file_system.new
-
-    Template.parse("{% include 'hi_mom' %}").render!
   end
 
   def test_dynamically_choosen_template

--- a/test/unit/file_system_unit_test.rb
+++ b/test/unit/file_system_unit_test.rb
@@ -5,7 +5,7 @@ class FileSystemUnitTest < Minitest::Test
 
   def test_default
     assert_raises(FileSystemError) do
-      BlankFileSystem.new.read_template_file("dummy", {'dummy'=>'smarty'})
+      BlankFileSystem.new.read_template_file("dummy")
     end
   end
 


### PR DESCRIPTION
We want to remove context from read_template_file so we can move parsing of partials to the time of parsing the template. This is to allow for better caching of parsed templates in the future.

New method signature for implementing your own liquid filesytem:
```ruby
def read_template_file(template_path)
```