### PR TITLE
Benchmark marshal load and render against parse and render.

### DIFF
--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -1,17 +1,14 @@
-require 'benchmark/ips'
+require 'benchmark'
 require File.dirname(__FILE__) + '/theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
 profiler = ThemeRunner.new
 
-Benchmark.ips do |x|
-  x.time = 60
-  x.warmup = 5
-
-  puts
-  puts "Running benchmark for #{x.time} seconds (with #{x.warmup} seconds warmup)."
-  puts
-
-  x.report("parse:") { profiler.compile }
-  x.report("parse & run:") { profiler.run }
+N = 100
+Benchmark.bmbm do |x|
+  x.report("parse:")                 { N.times { profiler.parse } }
+  x.report("marshal load:")          { N.times { profiler.marshal_load } }
+  x.report("render:")                { N.times { profiler.render } }
+  x.report("marshal load & render:") { N.times { profiler.load_and_render } }
+  x.report("parse & render:")        { N.times { profiler.parse_and_render } }
 end

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -3,13 +3,13 @@ require File.dirname(__FILE__) + '/theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
 profiler = ThemeRunner.new
-profiler.run
+profiler.parse_and_render
 
 [:cpu, :object].each do |profile_type|
   puts "Profiling in #{profile_type.to_s} mode..."
   results = StackProf.run(mode: profile_type) do
     100.times do
-      profiler.run
+      profiler.parse_and_render
     end
   end
   StackProf::Report.new(results).print_text(false, 20)


### PR DESCRIPTION
cc @camilo, @sunblaze, @grollest 

I modified the benchmarks to show how much time we could spend by saving a Marshal.dump of the parsed liquid template by comparing a Marshal.load against Template.parse.  I found the results from benchmark/ips harder to compare with each other than just using benchmark from the standard library.

Here are the results:

```
~/src/liquid(benchmark-load-render)$ bundle exec rake benchmark:run
/Users/dylansmith/.rbenv/versions/2.1.2/bin/ruby ./performance/benchmark.rb lax
Rehearsal ----------------------------------------------------------
parse:                   3.770000   0.050000   3.820000 (  3.819407)
marshal load:            1.320000   0.010000   1.330000 (  1.326707)
render:                  4.400000   0.040000   4.440000 (  4.447144)
marshal load & render:   5.780000   0.020000   5.800000 (  5.806654)
parse & render:          8.130000   0.030000   8.160000 (  8.154378)
------------------------------------------------ total: 23.550000sec

                             user     system      total        real
parse:                   3.600000   0.020000   3.620000 (  3.619495)
marshal load:            1.320000   0.010000   1.330000 (  1.331599)
render:                  4.260000   0.020000   4.280000 (  4.279742)
marshal load & render:   5.720000   0.020000   5.740000 (  5.748194)
parse & render:          8.320000   0.050000   8.370000 (  8.368795)
```

Note that the Marshal.dump of the parsed template was twice as big as the source in the benchmark themes.