### PR TITLE
Parse expressions in Liquid::Variable#parse.

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -35,15 +35,16 @@ module Liquid
 
     def lax_parse(markup)
       @filters = []
-      if markup =~ /\s*(#{QuotedFragment})(.*)/om
-        @name = Regexp.last_match(1)
-        if Regexp.last_match(2) =~ /#{FilterSeparator}\s*(.*)/om
-          filters = Regexp.last_match(1).scan(FilterParser)
+      if markup =~ /(#{QuotedFragment})(.*)/om
+        name_markup, filter_markup = $1, $2
+        @name = Expression.parse(name_markup)
+        if filter_markup =~ /#{FilterSeparator}\s*(.*)/om
+          filters = $1.scan(FilterParser)
           filters.each do |f|
             if f =~ /\w+/
               filtername = Regexp.last_match(0)
               filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*((?:\w+\s*\:\s*)?#{QuotedFragment})/o).flatten
-              @filters << [filtername, filterargs]
+              @filters << parse_filter_expressions(filtername, filterargs)
             end
           end
         end
@@ -53,7 +54,7 @@ module Liquid
     def strict_parse(markup)
       # Very simple valid cases
       if markup =~ EasyParse
-        @name = $1
+        @name = Expression.parse($1)
         @filters = []
         return
       end
@@ -61,11 +62,11 @@ module Liquid
       @filters = []
       p = Parser.new(markup)
       # Could be just filters with no input
-      @name = p.look(:pipe) ? ''.freeze : p.expression
+      @name = p.look(:pipe) ? nil : Expression.parse(p.expression)
       while p.consume?(:pipe)
         filtername = p.consume(:id)
         filterargs = p.consume?(:colon) ? parse_filterargs(p) : []
-        @filters << [filtername, filterargs]
+        @filters << parse_filter_expressions(filtername, filterargs)
       end
       p.consume(:end_of_string)
     end
@@ -81,28 +82,52 @@ module Liquid
     end
 
     def render(context)
-      return ''.freeze if @name.nil?
-      @filters.inject(context[@name]) do |output, filter|
-        filterargs = []
-        keyword_args = {}
-        filter[1].to_a.each do |a|
-          if matches = a.match(/\A#{TagAttributes}\z/o)
-            keyword_args[matches[1]] = context[matches[2]]
-          else
-            filterargs << context[a]
-          end
+      return ''.freeze unless @name
+      @filters.inject(context.evaluate(@name)) do |output, (filter_name, filter_args, filter_kwargs)|
+        filter_args = evaluate_filter_expressions(context, filter_args, filter_kwargs)
+        output = context.invoke(filter_name, output, *filter_args)
+      end.tap{ |obj| taint_check(obj) }
+    end
+
+    private
+
+    def parse_filter_expressions(filter_name, unparsed_args)
+      filter_args = []
+      keyword_args = {}
+      unparsed_args.each do |a|
+        if matches = a.match(/\A#{TagAttributes}\z/o)
+          keyword_args[matches[1]] = Expression.parse(matches[2])
+        else
+          filter_args << Expression.parse(a)
         end
-        filterargs << keyword_args unless keyword_args.empty?
-        output = context.invoke(filter[0], output, *filterargs)
-      end.tap do |obj|
-        if obj.tainted?
-          case Template.taint_mode
-          when :warn
-            @warnings ||= []
-            @warnings << "variable '#{@name}' is tainted and was not escaped"
-          when :error
-            raise TaintedError, "Error - variable '#{@name}' is tainted and was not escaped"
-          end
+      end
+      result = [filter_name, filter_args]
+      result << keyword_args unless keyword_args.empty?
+      result
+    end
+
+    def evaluate_filter_expressions(context, filter_args, filter_kwargs)
+      parsed_args = filter_args.map{ |expr| context.evaluate(expr) }
+      if filter_kwargs
+        parsed_kwargs = {}
+        filter_kwargs.each do |key, expr|
+          parsed_kwargs[key] = context.evaluate(expr)
+        end
+        parsed_args << parsed_kwargs
+      end
+      parsed_args
+    end
+
+    def taint_check(obj)
+      if obj.tainted?
+        @markup =~ QuotedFragment
+        name = Regexp.last_match(0)
+        case Template.taint_mode
+        when :warn
+          @warnings ||= []
+          @warnings << "variable '#{name}' is tainted and was not escaped"
+        when :error
+          raise TaintedError, "Error - variable '#{name}' is tainted and was not escaped"
         end
       end
     end

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -64,5 +64,15 @@ module Liquid
 
       object
     end
+
+    def ==(other)
+      self.class == other.class && self.state == other.state
+    end
+
+    protected
+
+    def state
+      [@name, @lookup, @command_flags]
+    end
   end
 end

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -5,125 +5,123 @@ class VariableUnitTest < Minitest::Test
 
   def test_variable
     var = Variable.new('hello')
-    assert_equal 'hello', var.name
+    assert_equal VariableLookup.new('hello'), var.name
   end
 
   def test_filters
     var = Variable.new('hello | textileze')
-    assert_equal 'hello', var.name
-    assert_equal [["textileze",[]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['textileze',[]]], var.filters
 
     var = Variable.new('hello | textileze | paragraph')
-    assert_equal 'hello', var.name
-    assert_equal [["textileze",[]], ["paragraph",[]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['textileze',[]], ['paragraph',[]]], var.filters
 
     var = Variable.new(%! hello | strftime: '%Y'!)
-    assert_equal 'hello', var.name
-    assert_equal [["strftime",["'%Y'"]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['strftime',['%Y']]], var.filters
 
     var = Variable.new(%! 'typo' | link_to: 'Typo', true !)
-    assert_equal %!'typo'!, var.name
-    assert_equal [["link_to",["'Typo'", "true"]]], var.filters
+    assert_equal 'typo', var.name
+    assert_equal [['link_to',['Typo', true]]], var.filters
 
     var = Variable.new(%! 'typo' | link_to: 'Typo', false !)
-    assert_equal %!'typo'!, var.name
-    assert_equal [["link_to",["'Typo'", "false"]]], var.filters
+    assert_equal 'typo', var.name
+    assert_equal [['link_to',['Typo', false]]], var.filters
 
     var = Variable.new(%! 'foo' | repeat: 3 !)
-    assert_equal %!'foo'!, var.name
-    assert_equal [["repeat",["3"]]], var.filters
+    assert_equal 'foo', var.name
+    assert_equal [['repeat',[3]]], var.filters
 
     var = Variable.new(%! 'foo' | repeat: 3, 3 !)
-    assert_equal %!'foo'!, var.name
-    assert_equal [["repeat",["3","3"]]], var.filters
+    assert_equal 'foo', var.name
+    assert_equal [['repeat',[3,3]]], var.filters
 
     var = Variable.new(%! 'foo' | repeat: 3, 3, 3 !)
-    assert_equal %!'foo'!, var.name
-    assert_equal [["repeat",["3","3","3"]]], var.filters
+    assert_equal 'foo', var.name
+    assert_equal [['repeat',[3,3,3]]], var.filters
 
     var = Variable.new(%! hello | strftime: '%Y, okay?'!)
-    assert_equal 'hello', var.name
-    assert_equal [["strftime",["'%Y, okay?'"]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['strftime',['%Y, okay?']]], var.filters
 
     var = Variable.new(%! hello | things: "%Y, okay?", 'the other one'!)
-    assert_equal 'hello', var.name
-    assert_equal [["things",["\"%Y, okay?\"","'the other one'"]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['things',['%Y, okay?','the other one']]], var.filters
   end
 
   def test_filter_with_date_parameter
-
     var = Variable.new(%! '2006-06-06' | date: "%m/%d/%Y"!)
-    assert_equal "'2006-06-06'", var.name
-    assert_equal [["date",["\"%m/%d/%Y\""]]], var.filters
-
+    assert_equal '2006-06-06', var.name
+    assert_equal [['date',['%m/%d/%Y']]], var.filters
   end
 
   def test_filters_without_whitespace
     var = Variable.new('hello | textileze | paragraph')
-    assert_equal 'hello', var.name
-    assert_equal [["textileze",[]], ["paragraph",[]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['textileze',[]], ['paragraph',[]]], var.filters
 
     var = Variable.new('hello|textileze|paragraph')
-    assert_equal 'hello', var.name
-    assert_equal [["textileze",[]], ["paragraph",[]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['textileze',[]], ['paragraph',[]]], var.filters
 
     var = Variable.new("hello|replace:'foo','bar'|textileze")
-    assert_equal 'hello', var.name
-    assert_equal [["replace", ["'foo'", "'bar'"]], ["textileze", []]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['replace', ['foo', 'bar']], ['textileze', []]], var.filters
   end
 
   def test_symbol
     var = Variable.new("http://disney.com/logo.gif | image: 'med' ", :error_mode => :lax)
-    assert_equal "http://disney.com/logo.gif", var.name
-    assert_equal [["image",["'med'"]]], var.filters
+    assert_equal VariableLookup.new('http://disney.com/logo.gif'), var.name
+    assert_equal [['image',['med']]], var.filters
   end
 
   def test_string_to_filter
     var = Variable.new("'http://disney.com/logo.gif' | image: 'med' ")
-    assert_equal "'http://disney.com/logo.gif'", var.name
-    assert_equal [["image",["'med'"]]], var.filters
+    assert_equal 'http://disney.com/logo.gif', var.name
+    assert_equal [['image',['med']]], var.filters
   end
 
   def test_string_single_quoted
     var = Variable.new(%| "hello" |)
-    assert_equal '"hello"', var.name
+    assert_equal 'hello', var.name
   end
 
   def test_string_double_quoted
     var = Variable.new(%| 'hello' |)
-    assert_equal "'hello'", var.name
+    assert_equal 'hello', var.name
   end
 
   def test_integer
     var = Variable.new(%| 1000 |)
-    assert_equal "1000", var.name
+    assert_equal 1000, var.name
   end
 
   def test_float
     var = Variable.new(%| 1000.01 |)
-    assert_equal "1000.01", var.name
+    assert_equal 1000.01, var.name
   end
 
   def test_string_with_special_chars
     var = Variable.new(%| 'hello! $!@.;"ddasd" ' |)
-    assert_equal %|'hello! $!@.;"ddasd" '|, var.name
+    assert_equal 'hello! $!@.;"ddasd" ', var.name
   end
 
   def test_string_dot
     var = Variable.new(%| test.test |)
-    assert_equal 'test.test', var.name
+    assert_equal VariableLookup.new('test.test'), var.name
   end
 
   def test_filter_with_keyword_arguments
     var = Variable.new(%! hello | things: greeting: "world", farewell: 'goodbye'!)
-    assert_equal 'hello', var.name
-    assert_equal [['things',["greeting: \"world\"","farewell: 'goodbye'"]]], var.filters
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['things', [], { 'greeting' => 'world', 'farewell' => 'goodbye' }]], var.filters
   end
 
   def test_lax_filter_argument_parsing
     var = Variable.new(%! number_of_comments | pluralize: 'comment': 'comments' !, :error_mode => :lax)
-    assert_equal 'number_of_comments', var.name
-    assert_equal [['pluralize',["'comment'","'comments'"]]], var.filters
+    assert_equal VariableLookup.new('number_of_comments'), var.name
+    assert_equal [['pluralize',['comment','comments']]], var.filters
   end
 
   def test_strict_filter_argument_parsing


### PR DESCRIPTION
cc @camilo, @sunblaze, @grollest
## Problem

Right now we are doing the expression parsing during liquid rendering.  Since we memoize the result, this doesn't cause problems when always doing a parse followed by a render.  However, this reduce the benefits we can get from caching the parsed liquid template to re-use, since it won't include expression parsing.
## Solution

Pull #391 already separated `Context#[]` into `Expression.parse` and `context.evaluate`, so was just a matter of using these two new methods in the Variable class.
## Benchmarks

I used pull #442 to benchmark the results so that it is easier to see how this distributes the time spent parsing and rendering.

Using master code:

```
~/src/liquid(benchmark-load-render)$ bundle exec rake benchmark:run
Rehearsal ----------------------------------------------------------
parse:                   3.770000   0.050000   3.820000 (  3.819407)
marshal load:            1.320000   0.010000   1.330000 (  1.326707)
render:                  4.400000   0.040000   4.440000 (  4.447144)
marshal load & render:   5.780000   0.020000   5.800000 (  5.806654)
parse & render:          8.130000   0.030000   8.160000 (  8.154378)
------------------------------------------------ total: 23.550000sec

                             user     system      total        real
parse:                   3.600000   0.020000   3.620000 (  3.619495)
marshal load:            1.320000   0.010000   1.330000 (  1.331599)
render:                  4.260000   0.020000   4.280000 (  4.279742)
marshal load & render:   5.720000   0.020000   5.740000 (  5.748194)
parse & render:          8.320000   0.050000   8.370000 (  8.368795)
```

using code from this branch:

```
~/src/liquid(completely-parse-variables)$ bundle exec rake benchmark:run
Rehearsal ----------------------------------------------------------
parse:                   5.140000   0.040000   5.180000 (  5.186593)
marshal load:            1.680000   0.010000   1.690000 (  1.687120)
render:                  3.450000   0.030000   3.480000 (  3.482392)
marshal load & render:   5.200000   0.030000   5.230000 (  5.225160)
parse & render:          8.650000   0.040000   8.690000 (  8.690502)
------------------------------------------------ total: 24.270000sec

                             user     system      total        real
parse:                   5.070000   0.030000   5.100000 (  5.102806)
marshal load:            1.560000   0.000000   1.560000 (  1.560547)
render:                  3.340000   0.020000   3.360000 (  3.360897)
marshal load & render:   5.340000   0.030000   5.370000 (  5.367271)
parse & render:          8.810000   0.050000   8.860000 (  8.860455)
```

So these changes increase the time to parse and decrease the time to render as expected.

The reason parse & render takes longer now is that we no longer memoize expressions that appear multiple times in the source.  This could be done, but we don't really have a proper parse context, unlike rending which has a Liquid::Context object to store the cached expressions.
