### PR TITLE
Use super rather than render_all in single block render classes.

### DIFF
--- a/lib/liquid/tags/ifchanged.rb
+++ b/lib/liquid/tags/ifchanged.rb
@@ -4,7 +4,7 @@ module Liquid
     def render(context)
       context.stack do
 
-        output = render_all(@nodelist, context)
+        output = super
 
         if output != context.registers[:ifchanged]
           context.registers[:ifchanged] = output

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -54,7 +54,7 @@ module Liquid
 
           col += 1
 
-          result << "<td class=\"col#{col}\">" << render_all(@nodelist, context) << '</td>'
+          result << "<td class=\"col#{col}\">" << super << '</td>'
 
           if col == cols and (index != length - 1)
             col  = 0

--- a/performance/shopify/paginate.rb
+++ b/performance/shopify/paginate.rb
@@ -4,8 +4,6 @@ class Paginate < Liquid::Block
   def initialize(tag_name, markup, options)
     super
 
-    @nodelist = []
-
     if markup =~ Syntax
       @collection_name = $1
       @page_size = if $2
@@ -73,7 +71,7 @@ class Paginate < Liquid::Block
         end
       end
 
-      render_all(@nodelist, context)
+      super
     end
   end
 


### PR DESCRIPTION
@Shopify/liquid for review

Block#render does `render_all(@nodelist, context)` which we do in derived classes in the render method instead of calling `super`.  This is a bad practice, since we should try to keep code at a single layer of abstraction to avoid exposing the reader to implementation details in the base class.
