### PR TITLE
Remove unused Block#end_tag method.

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 3.0.0 / not yet released / branch "master"
 
 * ...
+* Removed Block#end_tag. Instead, override parse with `super` followed by your code. See #446 [Dylan Thacker-Smith, dylanahsmith]
 * Fixed condition with wrong data types, see #423 [Bogdan Gusiev]
 * Add url_encode to standard filters, see #421 [Derrick Reimer, djreimer]
 * Add uniq to standard filters [Florian Weingarten, fw42]

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -23,10 +23,7 @@ module Liquid
 
                 # if we found the proper block delimiter just end parsing here and let the outer block
                 # proceed
-                if block_delimiter == $1
-                  end_tag
-                  return
-                end
+                return if block_delimiter == $1
 
                 # fetch the tag from registered blocks
                 if tag = Template.tags[$1]
@@ -75,9 +72,6 @@ module Liquid
       end
 
       all_warnings
-    end
-
-    def end_tag
     end
 
     def unknown_tag(tag, params, tokens)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -8,10 +8,7 @@ module Liquid
       while token = tokens.shift
         if token =~ FullTokenPossiblyInvalid
           @nodelist << $1 if $1 != "".freeze
-          if block_delimiter == $2
-            end_tag
-            return
-          end
+          return if block_delimiter == $2
         end
         @nodelist << token if not token.empty?
       end


### PR DESCRIPTION
@Shopify/liquid for review

There is an empty end_tag method defined on the Block class.  I assume the purpose is for extensibility, although I don't see any uses of it in Shopify or Jekyll.  However, the same thing can be done by overriding the parse method with `super` followed by whatever was previously in the `end_tag` method.

I think we should consider removing the `end_tag` method to simplify the code.  Since we already have a liquid 3 release candidate, I am fine with this waiting until we start working on liquid 4.
