### PR TITLE
Remove Liquid::FilterNotFoundError since it is never raised.

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -50,7 +50,6 @@ module Liquid
 
   class ArgumentError < Error; end
   class ContextError < Error; end
-  class FilterNotFound < Error; end
   class FileSystemError < Error; end
   class StandardError < Error; end
   class SyntaxError < Error; end

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -93,11 +93,7 @@ module Liquid
           end
         end
         filterargs << keyword_args unless keyword_args.empty?
-        begin
-          output = context.invoke(filter[0], output, *filterargs)
-        rescue FilterNotFound
-          raise FilterNotFound, "Error - filter '#{filter[0]}' in '#{@markup.strip}' could not be found."
-        end
+        output = context.invoke(filter[0], output, *filterargs)
       end
     end
   end


### PR DESCRIPTION
@Shopify/liquid 

In another issue it was metioned that the FilterNotFound exception was never raised.  A quick grep of the code shows that the only time it is raised is when rescuing the FilterNotFound.  Back in 2009 commit 01c25a11a3923d9f3a8a00b821c0aba2b586da23 tried to make it raise, but that was reverted by commit 0150067c40d86e126a2a898501797477c9c6ad9f, then it has just been dead confusing code since then.

This pull request just removes the unused code.
