### PR TITLE
Fix flaky test which assumes total_render_time can't be 0.

### DIFF
--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -72,7 +72,7 @@ class RenderProfilingTest < Minitest::Test
     t = Template.parse("{% include 'a_template' %}", :profile => true)
     t.render!
 
-    assert t.profiler.total_render_time > 0, "Total render time was not calculated"
+    assert t.profiler.total_render_time >= 0, "Total render time was not calculated"
   end
 
   def test_profiling_uses_include_to_mark_children


### PR DESCRIPTION
@jasonroelofs & @fw42 for review
## Problem

The RenderProfilingTest #test_profiling_times_the_entire_render test was failing inconsistently on jruby due to Time.now having millisecond rather than microsecond precision.  As a result, the total_render_time can end up being 0 since render time can complete in less than a microsecond.
## Solution

Allow total_render_time to be 0 in the test.
