### PR TITLE
replace the regex sequence w with [[:word:]] to be more flexible

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -26,14 +26,14 @@ module Liquid
   VariableAttributeSeparator  = '.'.freeze
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
-  VariableSignature           = /\(?[\w\-\.\[\]]\)?/
-  VariableSegment             = /[\w\-]/
+  VariableSignature           = /\(?[[[:word:]]\-\.\[\]]\)?/
+  VariableSegment             = /[[[:word:]]\-]/
   VariableStart               = /\{\{/
   VariableEnd                 = /\}\}/
   VariableIncompleteEnd       = /\}\}?/
   QuotedString                = /"[^"]*"|'[^']*'/
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
-  TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
+  TagAttributes               = /([[:word:]]+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Block < Tag
-    FullToken         = /\A#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+    FullToken         = /\A#{TagStart}\s*([[:word:]]+)\s*(.*)?#{TagEnd}\z/om
     ContentOfVariable = /\A#{VariableStart}(.*)#{VariableEnd}\z/om
     TAGSTART = "{%".freeze
     VARSTART = "{{".freeze

--- a/lib/liquid/i18n.rb
+++ b/lib/liquid/i18n.rb
@@ -24,7 +24,7 @@ module Liquid
 
     private
     def interpolate(name, vars)
-      name.gsub(/%\{(\w+)\}/) {
+      name.gsub(/%\{([[:word:]]+)\}/) {
         # raise TranslationError, "Undefined key #{$1} for interpolation in translation #{name}"  unless vars[$1.to_sym]
         "#{vars[$1.to_sym]}"
       }

--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -13,7 +13,7 @@ module Liquid
       '?'.freeze => :question,
       '-'.freeze => :dash
     }
-    IDENTIFIER = /\w+/
+    IDENTIFIER = /[[:word:]]+/
     SINGLE_STRING_LITERAL = /'[^\']*'/
     DOUBLE_STRING_LITERAL = /"[^\"]*"/
     NUMBER_LITERAL = /-?\d+(\.\d+)?/

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -11,7 +11,7 @@ module Liquid
   # in a sidebar or footer.
   #
   class Capture < Block
-    Syntax = /(\w+)/
+    Syntax = /([[:word:]]+)/
 
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Raw < Block
-    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*([[:word:]]+)\s*(.*)?#{TagEnd}\z/om
 
     def parse(tokens)
       @nodelist ||= []

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -1,6 +1,6 @@
 module Liquid
   class TableRow < Block
-    Syntax = /(\w+)\s+in\s+(#{QuotedFragment}+)/o
+    Syntax = /([[:word:]]+)\s+in\s+(#{QuotedFragment}+)/o
 
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -12,7 +12,7 @@ module Liquid
   #
   class Variable
     FilterParser = /(?:\s+|#{QuotedFragment}|#{ArgumentSeparator})+/o
-    EasyParse = /\A *(\w+(?:\.\w+)*) *\z/
+    EasyParse = /\A *([[:word:]]+(?:\.[[:word:]]+)*) *\z/
     attr_accessor :filters, :name, :warnings
     attr_accessor :line_number
     include ParserSwitching
@@ -42,9 +42,9 @@ module Liquid
         if filter_markup =~ /#{FilterSeparator}\s*(.*)/om
           filters = $1.scan(FilterParser)
           filters.each do |f|
-            if f =~ /\w+/
+            if f =~ /[[:word:]]+/
               filtername = Regexp.last_match(0)
-              filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*((?:\w+\s*\:\s*)?#{QuotedFragment})/o).flatten
+              filterargs = f.scan(/(?:#{FilterArgumentSeparator}|#{ArgumentSeparator})\s*((?:[[:word:]]+\s*\:\s*)?#{QuotedFragment})/o).flatten
               @filters << parse_filter_expressions(filtername, filterargs)
             end
           end

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -18,7 +18,7 @@ end
 
 module SubstituteFilter
   def substitute(input, params={})
-    input.gsub(/%\{(\w+)\}/) { |match| params[$1] }
+    input.gsub(/%\{([[:word:]]+)\}/) { |match| params[$1] }
   end
 end
 


### PR DESCRIPTION
Make liquid more flexible in internationalized situations.

Before:
Markup was only rendered properly if the markup contained latin characters. 
i.e.  {{test}}

After:
Markup can contain non-latin characters, for example Japanese. 
i.e. {{テスト}}

@boourns, @fw42, @camilo, @dylanahsmith, or @arthurnn can you code review? 
