### PR TITLE
Avoid modifying the default resources limits hash.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -21,7 +21,7 @@ module Liquid
       @scopes           = [(outer_scope || {})]
       @registers        = registers
       @errors           = []
-      @resource_limits  = resource_limits || Template.default_resource_limits
+      @resource_limits  = resource_limits || Template.default_resource_limits.dup
       @resource_limits[:render_score_current] = 0
       @resource_limits[:assign_score_current] = 0
       @parsed_expression = Hash.new{ |cache, markup| cache[markup] = Expression.parse(markup) }

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -135,6 +135,18 @@ class TemplateTest < Minitest::Test
     assert t.resource_limits[:render_length_current] > 0
   end
 
+  def test_default_resource_limits_unaffected_by_render_with_context
+    context = Context.new
+    t = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
+    t.render!(context)
+    assert context.resource_limits[:assign_score_current] > 0
+    assert context.resource_limits[:render_score_current] > 0
+    assert context.resource_limits[:render_length_current] > 0
+    refute Template.default_resource_limits.key?(:assign_score_current)
+    refute Template.default_resource_limits.key?(:render_score_current)
+    refute Template.default_resource_limits.key?(:render_length_current)
+  end
+
   def test_can_use_drop_as_context
     t = Template.new
     t.registers['lulz'] = 'haha'


### PR DESCRIPTION
@fw42 for review
## Problem

Template#initialize already duplicates the default_resource_limits hash, but if a Context is created directly, then it will use Template.default_resource_limits hash directly, causing it to get modified during rendering.
## Solution

Duplicate the `Template.default_resource_limits` before assigning it to an instance variable in Context#initialize
