### PR TITLE
Add line numbers to lexer errors

### DIFF
--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -1,8 +1,7 @@
 module Liquid
   class Parser
     def initialize(input)
-      l = Lexer.new(input)
-      @tokens = l.tokenize
+      tokenize(input)
       @p = 0 # pointer to current location
     end
 
@@ -85,6 +84,16 @@ module Liquid
         str << variable_signature
       end
       str
+    end
+
+    private
+
+    def tokenize(input)
+      l = Lexer.new(input)
+      @tokens = l.tokenize
+    rescue SyntaxError => e
+      e.set_line_number_from_token(input)
+      raise
     end
   end
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -100,6 +100,39 @@ class ErrorHandlingTest < Minitest::Test
     assert_equal Liquid::ArgumentError, template.errors.first.class
   end
 
+  def test_parsing_warn_with_line_numbers_adds_numbers_to_lexer_errors
+    template = Liquid::Template.parse(%q{
+        foobar
+
+        {% if 1 =! 2 %}ok{% endif %}
+
+        bla
+      },
+      :error_mode => :warn,
+      :line_numbers => true
+    )
+
+    assert_equal ['Liquid syntax error (line 4): Unexpected character = in "1 =! 2"'],
+      template.warnings.map(&:message)
+  end
+
+  def test_parsing_strict_with_line_numbers_adds_numbers_to_lexer_errors
+    err = assert_raises(SyntaxError) do
+      Liquid::Template.parse(%q{
+          foobar
+
+          {% if 1 =! 2 %}ok{% endif %}
+
+          bla
+        },
+        :error_mode => :strict,
+        :line_numbers => true
+      )
+    end
+
+    assert_equal 'Liquid syntax error (line 4): Unexpected character = in "1 =! 2"', err.message
+  end
+
   def test_strict_error_messages
     err = assert_raises(SyntaxError) do
       Liquid::Template.parse(' {% if 1 =! 2 %}ok{% endif %} ', :error_mode => :strict)


### PR DESCRIPTION
Follow up to https://github.com/Shopify/liquid/pull/419

This adds line numbers to lexer errors. There are still many other syntax errors left that don't have line numbers yet, but this PR at least makes it one less :-)

@dylanahsmith @jasonhl for review please
FYI @KnVerey @trishume 
