### PR TITLE
Avoid parallel assignments

### DIFF
--- a/example/server/liquid_servlet.rb
+++ b/example/server/liquid_servlet.rb
@@ -11,7 +11,8 @@ class LiquidServlet < WEBrick::HTTPServlet::AbstractServlet
   private
 
   def handle(type, req, res)
-    @request, @response = req, res
+    @request = req
+    @response = res
 
     @request.path_info =~ /(\w+)\z/
     @action = $1 || 'index'

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -28,7 +28,9 @@ module Liquid
     attr_accessor :left, :operator, :right
 
     def initialize(left = nil, operator = nil, right = nil)
-      @left, @operator, @right = left, operator, right
+      @left = left
+      @operator = operator
+      @right = right
       @child_relation  = nil
       @child_condition = nil
     end
@@ -47,11 +49,13 @@ module Liquid
     end
 
     def or(condition)
-      @child_relation, @child_condition = :or, condition
+      @child_relation = :or
+      @child_condition = condition
     end
 
     def and(condition)
-      @child_relation, @child_condition = :and, condition
+      @child_relation = :and
+      @child_condition = condition
     end
 
     def attach(attachment)
@@ -94,7 +98,8 @@ module Liquid
       # return this as the result.
       return context[left] if op == nil
 
-      left, right = context[left], context[right]
+      left = context[left]
+      right = context[right]
 
       operation = self.class.operators[op] || raise(Liquid::ArgumentError.new("Unknown operator #{op}"))
 

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -36,7 +36,8 @@ module Liquid
     def lax_parse(markup)
       @filters = []
       if markup =~ /(#{QuotedFragment})(.*)/om
-        name_markup, filter_markup = $1, $2
+        name_markup = $1
+        filter_markup = $2
         @name = Expression.parse(name_markup)
         if filter_markup =~ /#{FilterSeparator}\s*(.*)/om
           filters = $1.scan(FilterParser)

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -57,7 +57,8 @@ class StrainerUnitTest < Minitest::Test
   end
 
   def test_strainer_uses_a_class_cache_to_avoid_method_cache_invalidation
-    a, b = Module.new, Module.new
+    a = Module.new
+    b = Module.new
     strainer = Strainer.create(nil, [a,b])
     assert_kind_of Strainer, strainer
     assert_kind_of a, strainer


### PR DESCRIPTION
Parallel assignments in Ruby should only be used when in-place swapping is required, they are usually slower.

Before:

```
              parse:       31.5 (±25.4%) i/s -       1695 in  60.046965s
        parse & run:       14.6 (±20.5%) i/s -        785 in  59.995508s
```

```
              parse:       30.6 (±26.1%) i/s -       1674 in  60.048244s
        parse & run:       14.0 (±21.4%) i/s -        769 in  60.029016s
```

After:

```
              parse:       35.1 (±17.1%) i/s -       1992 in  60.001341s
        parse & run:       14.1 (±21.2%) i/s -        779 in  60.020685s
```

```
              parse:       35.5 (±16.9%) i/s -       2046 in  60.057296s
        parse & run:       15.4 (±13.0%) i/s -        877 in  60.023074s
```

@dylanahsmith @jasonhl
