### PR TITLE
Allow whitespace in square brackets

### DIFF
--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -72,7 +72,7 @@ module Liquid
     protected
 
     def state
-      [@name, @lookup, @command_flags]
+      [@name, @lookups, @command_flags]
     end
   end
 end

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -23,12 +23,10 @@ class ContextTest < Minitest::Test
   end
 
   def test_has_key_will_not_add_an_error_for_missing_keys
-    Template.error_mode = :strict
-
-    context = Context.new
-
-    context.has_key?('unknown')
-
-    assert_empty context.errors
+    with_error_mode :strict do
+      context = Context.new
+      context.has_key?('unknown')
+      assert_empty context.errors
+    end
   end
 end

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -6,6 +6,9 @@ class VariableUnitTest < Minitest::Test
   def test_variable
     var = Variable.new('hello')
     assert_equal VariableLookup.new('hello'), var.name
+
+    var = Variable.new('hello[goodbye ]')
+    assert_equal VariableLookup.new('hello[goodbye]'), var.name
   end
 
   def test_filters


### PR DESCRIPTION
The definition of `QuotedFragment` causes variables like `hello[goodbye ]` (notice the space) to get parsed in the same way as `hello.goodbye`. This is due to the name being parsed as `hello[goodbye` (with no closing `]`) and then `VariableLookup` interpreting that in a lax way.

I'm not really sure how to fix this in a clean way.

I also noticed that sometimes my broken tests were passing due to strict mode being turned on and leaked by a test, which is fixed in this PR.