### PR TITLE
Fix test leaking error_mode, fix equality check for VariableLookup

### DIFF
--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -72,7 +72,7 @@ module Liquid
     protected
 
     def state
-      [@name, @lookup, @command_flags]
+      [@name, @lookups, @command_flags]
     end
   end
 end

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -23,12 +23,10 @@ class ContextTest < Minitest::Test
   end
 
   def test_has_key_will_not_add_an_error_for_missing_keys
-    Template.error_mode = :strict
-
-    context = Context.new
-
-    context.has_key?('unknown')
-
-    assert_empty context.errors
+    with_error_mode :strict do
+      context = Context.new
+      context.has_key?('unknown')
+      assert_empty context.errors
+    end
   end
 end


### PR DESCRIPTION
This is from #471, I'm just PR'ing it separately as I have other dependent changes for other branches.
