### PR TITLE
Nested square brackets are parsed incorrectly

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -37,7 +37,7 @@ module Liquid
   AnyStartingTag              = /\{\{|\{\%/
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
-  VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
+  VariableParser              = /\[[^\]]+\]+|#{VariableSegment}+\??/o
 
   singleton_class.send(:attr_accessor, :cache_classes)
   self.cache_classes = true

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -6,7 +6,9 @@ class VariableUnitTest < Minitest::Test
   def test_variable
     var = Variable.new('hello')
     assert_equal VariableLookup.new('hello'), var.name
+  end
 
+  def test_nested_square_brackets
     var = Variable.new('hello[hello[0]]')
     assert_equal VariableLookup.new('hello[0]'), var.name.instance_variable_get(:@lookups).first
   end

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -6,6 +6,9 @@ class VariableUnitTest < Minitest::Test
   def test_variable
     var = Variable.new('hello')
     assert_equal VariableLookup.new('hello'), var.name
+
+    var = Variable.new('hello[hello[0]]')
+    assert_equal VariableLookup.new('hello[0]'), var.name.instance_variable_get(:@lookups).first
   end
 
   def test_filters


### PR DESCRIPTION
Another bug in the lax parser found while asserting correctness of Liquid-C.

The cause is that the definition of the `VariableParser` regex will match `a[b[c[d]]]` as `a[b[c[d]`, thinking the closing bracket for the innermost nesting is actually closing the first bracket. This makes the rest of the `VariableLookup` code throw up and produce an incorrect result.

I'm not sure how this could be parsed cleanly with a just a regex. If the input is guaranteed to have no extraneous closing brackets it may be possible to just grab them all, but doing so seems sketchy to me.