### PR TITLE
Spaces between variable lookups ignore rest of variable

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -32,7 +32,8 @@ module Liquid
   VariableEnd                 = /\}\}/
   VariableIncompleteEnd       = /\}\}?/
   QuotedString                = /"[^"]*"|'[^']*'/
-  QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
+  NonSpecial                  = /[^\s,\|'"]/
+  QuotedFragment              = /#{QuotedString}|(?:\s*\.\s*#{NonSpecial}|#{NonSpecial}|#{QuotedString})+/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om

--- a/test/integration/tags/if_else_tag_test.rb
+++ b/test/integration/tags/if_else_tag_test.rb
@@ -25,6 +25,10 @@ class IfElseTagTest < Minitest::Test
     assert_template_result(' YES ','{% if var %} YES {% endif %}', 'var' => true)
   end
 
+  def test_if_with_spaces
+    assert_template_result(' YES ','{% if var . prop == 1 %} YES {% endif %}', 'var' => {'prop' => 1})
+  end
+
   def test_if_or
     assert_template_result(' YES ','{% if a or b %} YES {% endif %}', 'a' => true, 'b' => true)
     assert_template_result(' YES ','{% if a or b %} YES {% endif %}', 'a' => true, 'b' => false)

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -6,8 +6,10 @@ class VariableUnitTest < Minitest::Test
   def test_variable
     var = Variable.new('hello')
     assert_equal VariableLookup.new('hello'), var.name
+  end
 
-    var = Variable.new('hello. goodbye')
+  def test_spaces
+    var = Variable.new('hello. goodbye | filter')
     assert_equal VariableLookup.new('hello.goodbye'), var.name
   end
 


### PR DESCRIPTION
`{{ hello. goodbye }}` is parsed as `{{ hello }}`.
