### PR TITLE
Add quirks test for variables with number prefixes

### DIFF
--- a/test/integration/parsing_quirks_test.rb
+++ b/test/integration/parsing_quirks_test.rb
@@ -110,4 +110,10 @@ class ParsingQuirksTest < Minitest::Test
     end
   end
 
+  def test_extra_dots_in_ranges
+    with_error_mode(:lax) do
+      assert_template_result('12345', "{% for i in (1...5) %}{{ i }}{% endfor %}")
+    end
+  end
+
 end # ParsingQuirksTest


### PR DESCRIPTION
I am sad that this passes, but am not sure what can be done – there are lots of templates making use of this feature. Add it to the spec?
