### PR TITLE
Coerce regex @blank output to a boolean

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -43,7 +43,7 @@ module Liquid
               @blank = false
             else
               @nodelist << token
-              @blank &&= (token =~ /\A\s*\z/)
+              @blank &&= !!(token =~ /\A\s*\z/)
             end
           end
         rescue SyntaxError => e


### PR DESCRIPTION
`=~` will return `nil` if there are no matches, but we want a boolean.

@dylanahsmith 
