### PR TITLE
Fixes syntax error in documentation for unless tag

### DIFF
--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/if'
 module Liquid
   # Unless is a conditional just like 'if' but works on the inverse logic.
   #
-  #   {% unless x < 0 %} x is greater than zero {% end %}
+  #   {% unless x < 0 %} x is greater than zero {% endunless %}
   #
   class Unless < If
     def render(context)


### PR DESCRIPTION
If you code according to the old documentation you will get an `Liquid::SyntaxError` with the message `'end' is not a valid delimiter for unless tags. use endunless`
