### PR TITLE
Drop Ruby 1.9 from CI, add Ruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 
 rvm:
-  - 1.9
   - 2.0
   - 2.1
-  - jruby-19mode
+  - ruby-head
   - jruby-head
   - rbx-2
 
@@ -12,7 +11,6 @@ sudo: false
 
 matrix:
   allow_failures:
-    - rvm: rbx-2
     - rvm: jruby-head
 
 script: "rake test"


### PR DESCRIPTION
@Shopify/liquid is everyone ok with this? The main motivation is that there are a few places that would benefit from keyword arguments, introduced in 2.0.

Also, rbx-2 has been passing lately, so I removed it from the allowed failure list.
