### PR TITLE
Fix case sensitivity regression in date standard filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -307,7 +307,7 @@ module Liquid
       return obj if obj.respond_to?(:strftime)
 
       case obj
-      when 'now'.freeze, 'today'.freeze
+      when /\A(?:now|today)\z/i
         Time.now
       when /\A\d+\z/, Integer
         Time.at(obj.to_i)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -306,8 +306,10 @@ module Liquid
     def to_date(obj)
       return obj if obj.respond_to?(:strftime)
 
+      obj = obj.downcase if obj.is_a?(String)
+
       case obj
-      when /\A(?:now|today)\z/i
+      when 'now'.freeze, 'today'.freeze
         Time.now
       when /\A\d+\z/, Integer
         Time.at(obj.to_i)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -249,6 +249,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "07/16/2004", @filters.date("Fri Jul 16 01:00:00 2004", "%m/%d/%Y")
     assert_equal "#{Date.today.year}", @filters.date('now', '%Y')
     assert_equal "#{Date.today.year}", @filters.date('today', '%Y')
+    assert_equal "#{Date.today.year}", @filters.date('Today', '%Y')
 
     assert_equal nil, @filters.date(nil, "%B")
 


### PR DESCRIPTION
The to_date refactor on Apr 30 removed downcase from the obj switch, this patch adds back a case-insensitive regexp to check for 'now' and 'today' as well as a test for it.