### PR TITLE
Remove duplicate `index0` key in htmltags

### DIFF
--- a/lib/liquid/htmltags.rb
+++ b/lib/liquid/htmltags.rb
@@ -43,7 +43,6 @@ module Liquid
             'index0'  => index,
             'col'     => col + 1,
             'col0'    => col,
-            'index0'  => index,
             'rindex'  => length - index,
             'rindex0' => length - index - 1,
             'first'   => (index == 0),


### PR DESCRIPTION
Half of #502.
