### PR TITLE
Remove duplicate `index0` key in TableRow tag

### DIFF
--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -42,7 +42,6 @@ module Liquid
             'index0'.freeze    => index,
             'col'.freeze       => col + 1,
             'col0'.freeze      => col,
-            'index0'.freeze    => index,
             'rindex'.freeze    => length - index,
             'rindex0'.freeze   => length - index - 1,
             'first'.freeze     => (index == 0),


### PR DESCRIPTION
The other (master) half of #502. The 2.6 half was submitted by @parkr in #503.
