### PR TITLE
Use VariableSignature as Syntax for Capture tag to allow hyphens in variable names

### DIFF
--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -11,7 +11,7 @@ module Liquid
   # in a sidebar or footer.
   #
   class Capture < Block
-    Syntax = /(\w+)/
+    Syntax = /(#{VariableSignature}+)/o
 
     def initialize(tag_name, markup, options)
       super

--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -3,6 +3,16 @@ require 'test_helper'
 class AssignTest < Minitest::Test
   include Liquid
 
+  def test_assign_with_hyphen_in_variable_name
+    template_source = <<-END_TEMPLATE
+    {% assign this-thing = 'Print this-thing' %}
+    {{ this-thing }}
+    END_TEMPLATE
+    template = Template.parse(template_source)
+    rendered = template.render!
+    assert_equal "Print this-thing", rendered.strip
+  end
+
   def test_assigned_variable
     assert_template_result('.foo.',
                            '{% assign foo = values %}.{{ foo[0] }}.',

--- a/test/integration/capture_test.rb
+++ b/test/integration/capture_test.rb
@@ -7,6 +7,16 @@ class CaptureTest < Minitest::Test
     assert_template_result("test string", "{% capture 'var' %}test string{% endcapture %}{{var}}", {})
   end
 
+  def test_capture_with_hyphen_in_variable_name
+    template_source = <<-END_TEMPLATE
+    {% capture this-thing %}Print this-thing{% endcapture %}
+    {{ this-thing }}
+    END_TEMPLATE
+    template = Template.parse(template_source)
+    rendered = template.render!
+    assert_equal "Print this-thing", rendered.strip
+  end
+
   def test_capture_to_variable_from_outer_scope_if_existing
     template_source = <<-END_TEMPLATE
     {% assign var = '' %}


### PR DESCRIPTION
Fixes https://github.com/Shopify/liquid/issues/505

@arthurnn @dylanahsmith @davidrleonard 