### PR TITLE
Fix Tobi last name on gemspec

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = Liquid::VERSION
   s.platform    = Gem::Platform::RUBY
   s.summary     = "A secure, non-evaling end user template engine with aesthetic markup."
-  s.authors     = ["Tobias Luetke"]
+  s.authors     = ["Tobias Lütke"]
   s.email       = ["tobi@leetsoft.com"]
   s.homepage    = "http://www.liquidmarkup.org"
   s.license     = "MIT"


### PR DESCRIPTION
am I wrong?
Maybe it was wrong in the first place because rubygems would not accept non-ascii chars?

review @tobi 