### PR TITLE
Allow filters to redefine Object methods to make them invokable.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -44,21 +44,8 @@ module Liquid
     # for that
     def add_filters(filters)
       filters = [filters].flatten.compact
-      filters.each do |f|
-        raise ArgumentError, "Expected module but got: #{f.class}" unless f.is_a?(Module)
-        Strainer.add_known_filter(f)
-      end
-
-      # If strainer is already setup then there's no choice but to use a runtime
-      # extend call. If strainer is not yet created, we can utilize strainers
-      # cached class based API, which avoids busting the method cache.
-      if @strainer
-        filters.each do |f|
-          strainer.extend(f)
-        end
-      else
-        @filters.concat filters
-      end
+      @filters += filters
+      @strainer = nil
     end
 
     # are there any not handled interrupts?

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -25,6 +25,12 @@ end
 class FiltersTest < Minitest::Test
   include Liquid
 
+  module OverrideObjectMethodFilter
+    def tap(input)
+      "tap overridden"
+    end
+  end
+
   def setup
     @context = Context.new
   end
@@ -104,6 +110,13 @@ class FiltersTest < Minitest::Test
     @context.add_filters(SubstituteFilter)
     output = Variable.new(%! 'hello %{first_name}, %{last_name}' | substitute: first_name: surname, last_name: 'doe' !).render(@context)
     assert_equal 'hello john, doe', output
+  end
+
+  def test_override_object_method_in_filter
+    assert_equal "tap overridden", Template.parse("{{var | tap}}").render!({ 'var' => 1000 }, :filters => [OverrideObjectMethodFilter])
+
+    # tap still treated as a non-existent filter
+    assert_equal "1000", Template.parse("{{var | tap}}").render!({ 'var' => 1000 })
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,13 +49,19 @@ module Minitest
     end
 
     def with_global_filter(*globals)
-      original_filters = Array.new(Liquid::Strainer.class_variable_get(:@@filters))
+      original_global_strainer = Liquid::Strainer.class_variable_get(:@@global_strainer)
+      Liquid::Strainer.class_variable_set(:@@global_strainer, Class.new(Liquid::Strainer) do
+        @filter_methods = Set.new
+      end)
+      Liquid::Strainer.class_variable_get(:@@strainer_class_cache).clear
+
       globals.each do |global|
         Liquid::Template.register_filter(global)
       end
       yield
     ensure
-      Liquid::Strainer.class_variable_set(:@@filters, original_filters)
+      Liquid::Strainer.class_variable_get(:@@strainer_class_cache).clear
+      Liquid::Strainer.class_variable_set(:@@global_strainer, original_global_strainer)
     end
 
     def with_taint_mode(mode)

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -31,11 +31,11 @@ class StrainerUnitTest < Minitest::Test
 
   def test_strainer_only_invokes_public_filter_methods
     strainer = Strainer.create(nil)
-    assert_equal false, strainer.invokable?('__test__')
-    assert_equal false, strainer.invokable?('test')
-    assert_equal false, strainer.invokable?('instance_eval')
-    assert_equal false, strainer.invokable?('__send__')
-    assert_equal true, strainer.invokable?('size') # from the standard lib
+    assert_equal false, strainer.class.invokable?('__test__')
+    assert_equal false, strainer.class.invokable?('test')
+    assert_equal false, strainer.class.invokable?('instance_eval')
+    assert_equal false, strainer.class.invokable?('__send__')
+    assert_equal true, strainer.class.invokable?('size') # from the standard lib
   end
 
   def test_strainer_returns_nil_if_no_filter_method_found
@@ -63,9 +63,7 @@ class StrainerUnitTest < Minitest::Test
     assert_kind_of Strainer, strainer
     assert_kind_of a, strainer
     assert_kind_of b, strainer
-    Strainer.class_variable_get(:@@filters).each do |m|
-      assert_kind_of m, strainer
-    end
+    assert_kind_of Liquid::StandardFilters, strainer
   end
 
 end # StrainerTest


### PR DESCRIPTION
@arthurnn & @fw42 for review
cc @nickpearson
Fixes #518

## Problem

Strainer has been using Strainer.instance_methods as a blacklist of methods that couldn't be called.  This means that object like `.to_json` which rails declares on Object can't be used, which is a good default.  However, this blacklist also prevented a filter from having a custom `to_json` that is intended to be exposed.

## Solution

An empty module doesn't have any instance methods predefined on it, unlike a class, so we don't need to filter these methods with a blacklist.  However, I still needed to refactor the Strainer class so that there was a each set of filters had their own whitelist of methods that can be called.

I also simplified the code so that there is only one place where filters are added, which also means that `Liquid::Context#add_filter` now uses the strainer class cache.