### PR TITLE
Sync History.md for Liquid 4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,18 @@
-# Liquid Version History
+# Liquid Change Log
 
 ## 4.0.0 / not yet released / branch "master"
-
-* ...
+### Changed
+* Add forloop.parentloop as a reference to the parent loop, see #520 [Justin Li, pushrax]
 * Block parsing moved to BlockBody class, see #458 [Dylan Thacker-Smith, dylanahsmith]
+* Add concat filter to concatenate arrays, see #429 [Diogo Beato, dvbeato]
+* Ruby 1.9 support dropped, see #491 [Justin Li, pushrax]
+
+### Fixed
+* Fix capturing into variables with a hyphen in the name, see #505 [Florian Weingarten, fw42]
+* Fix case sensitivity regression in date standard filter, see #499 [Kelley Reynolds, kreynolds]
+* Disallow filters with no variable in strict mode, see #475 [Justin Li, pushrax]
+* Disallow variable names in the strict parser that are not valid in the lax parser, see #463 [Justin Li, pushrax]
+* Fix BlockBody#warnings taking exponential time to compute, see #486 [Justin Li, pushrax]
 
 ## 3.0.0 / 2014-11-12 / branch "3-0-stable"
 

--- a/History.md
+++ b/History.md
@@ -1,9 +1,12 @@
 # Liquid Version History
 
-## 3.0.0 / not yet released / branch "master"
+## 4.0.0 / not yet released / branch "master"
 
 * ...
 * Block parsing moved to BlockBody class, see #458 [Dylan Thacker-Smith, dylanahsmith]
+
+## 3.0.0 / 2014-11-12 / branch "3-0-stable"
+
 * Removed Block#end_tag. Instead, override parse with `super` followed by your code. See #446 [Dylan Thacker-Smith, dylanahsmith]
 * Fixed condition with wrong data types, see #423 [Bogdan Gusiev]
 * Add url_encode to standard filters, see #421 [Derrick Reimer, djreimer]


### PR DESCRIPTION
As discussed in #527, History.md had gotten out of date. This adds most of the changes since 3.0.0, though I think there are many changes missed in the 3.0.0 list still.