### PR TITLE
Explode invokable_methods method on Liquid::Drop

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -62,6 +62,10 @@ module Liquid
 
     # Check for method existence without invoking respond_to?, which creates symbols
     def self.invokable?(method_name)
+      self.invokable_methods.include?(method_name.to_s)
+    end
+
+    def self.invokable_methods
       unless @invokable_methods
         blacklist = Liquid::Drop.public_instance_methods + [:each]
         if include?(Enumerable)
@@ -71,7 +75,7 @@ module Liquid
         whitelist = [:to_liquid] + (public_instance_methods - blacklist)
         @invokable_methods = Set.new(whitelist.map(&:to_s))
       end
-      @invokable_methods.include?(method_name.to_s)
+      @invokable_methods
     end
   end
 end


### PR DESCRIPTION
Exploding the method in order to make it "re-usable".

I was not sure if I wanted it public or private. In my use case I wish to have access to the information in  `invokable_methods` in order to build some tests and maintenance task for docs so I do not care so much if I have to make a `send` call to get it.

On the other hand if I need it from the outside it would make sense to be a public method, but then a public method just for some test and maintenance task feels like it would not be appropriate.

Thoughts?