### PR TITLE
Disable minitest expectation interface due to reckless modification of Object

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+ENV["MT_NO_EXPECTATIONS"] = "1"
 require 'minitest/autorun'
 require 'spy/integration'
 


### PR DESCRIPTION
This is fixed in https://github.com/seattlerb/minitest/commit/00268427a258d7565c57c0a4b625e459bc59e80b but since we don't use the spec interface we may as well disable it.

Fixes #549