### PR TITLE
Allow for a block to be passed on liquid_methods that can transform…

### DIFF
--- a/test/unit/module_ex_unit_test.rb
+++ b/test/unit/module_ex_unit_test.rb
@@ -36,6 +36,39 @@ class TestClassC::LiquidDropClass
   end
 end
 
+class TestClassD
+  liquid_methods :allowedD, :chainedE do |object, method, value|
+    if value.is_a?(String)
+      value += "andtransformedD"
+    else
+      value
+    end
+  end
+
+  def allowedD
+    'allowedD'
+  end
+  def restrictedD
+    'restrictedD'
+  end
+  def chainedE
+    TestClassE.new
+  end
+end
+
+class TestClassE
+  liquid_methods :allowedE do |object, method, value|
+    if value.is_a?(String)
+      value += "andtransformedE"
+    else
+      value
+    end
+  end
+  def allowedE
+    'allowedE'
+  end
+end
+
 class ModuleExUnitTest < Minitest::Test
   include Liquid
 
@@ -43,24 +76,32 @@ class ModuleExUnitTest < Minitest::Test
     @a = TestClassA.new
     @b = TestClassB.new
     @c = TestClassC.new
+    @d = TestClassD.new
+    @e = TestClassE.new
   end
 
   def test_should_create_LiquidDropClass
     assert TestClassA::LiquidDropClass
     assert TestClassB::LiquidDropClass
     assert TestClassC::LiquidDropClass
+    assert TestClassD::LiquidDropClass
+    assert TestClassE::LiquidDropClass
   end
 
   def test_should_respond_to_liquid
     assert @a.respond_to?(:to_liquid)
     assert @b.respond_to?(:to_liquid)
     assert @c.respond_to?(:to_liquid)
+    assert @d.respond_to?(:to_liquid)
+    assert @e.respond_to?(:to_liquid)
   end
 
   def test_should_return_LiquidDropClass_object
     assert @a.to_liquid.is_a?(TestClassA::LiquidDropClass)
     assert @b.to_liquid.is_a?(TestClassB::LiquidDropClass)
     assert @c.to_liquid.is_a?(TestClassC::LiquidDropClass)
+    assert @d.to_liquid.is_a?(TestClassD::LiquidDropClass)
+    assert @e.to_liquid.is_a?(TestClassE::LiquidDropClass)
   end
 
   def test_should_respond_to_liquid_methods
@@ -70,10 +111,14 @@ class ModuleExUnitTest < Minitest::Test
     assert @b.to_liquid.respond_to?(:chainedC)
     assert @c.to_liquid.respond_to?(:allowedC)
     assert @c.to_liquid.respond_to?(:another_allowedC)
+    assert @d.to_liquid.respond_to?(:allowedD)
+    assert @d.to_liquid.respond_to?(:chainedE)
+    assert @e.to_liquid.respond_to?(:allowedE)
   end
 
   def test_should_not_respond_to_restricted_methods
-    assert ! @a.to_liquid.respond_to?(:restricted)
+    assert ! @a.to_liquid.respond_to?(:restrictedA)
+    assert ! @d.to_liquid.respond_to?(:restrictedD)
   end
 
   def test_should_use_regular_objects_as_drops
@@ -83,5 +128,10 @@ class ModuleExUnitTest < Minitest::Test
     assert_template_result 'another_allowedC', "{{ a.chainedB.chainedC.another_allowedC }}", 'a'=>@a
     assert_template_result '', "{{ a.restricted }}", 'a'=>@a
     assert_template_result '', "{{ a.unknown }}", 'a'=>@a
+  end
+
+  def test_that_block_succesfully_transforms_object_methods
+    assert_template_result 'allowedDandtransformedD', "{{ d.allowedD }}", 'd'=>@d
+    assert_template_result 'allowedEandtransformedE', "{{ d.chainedE.allowedE }}", 'd'=>@d
   end
 end # ModuleExTest


### PR DESCRIPTION
…the allowed methods return value. Useful for sanitization and dynamic content.

Added comment explains it best.

You may also pass a block that can be used to transform the method's returned value.

```ruby
class SomeClass
  liquid_methods :an_allowed_method do |object, method, value|
    if value.is_a?(String)
      value += ' that has been transformed'
    else
      value
    end
  end

  def an_allowed_method
    'this comes from an allowed method'
  end

end
```
usage:
```ruby
@something = SomeClass.new
```
template:
```ruby
{{something.an_allowed_method}}
```
output:
```ruby
'this comes from an allowed method that has been transformed'
```
@boourns, @fw42, @camilo, @dylanahsmith, or @arthurnn