### PR TITLE
Lazily evaluate template name for context variable injection

### DIFF
--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -12,7 +12,7 @@ module Liquid
 
   class Include < Tag
     def render_with_profiling(context)
-      Profiler.profile_children(context.evaluate(@template_name).to_s) do
+      Profiler.profile_children(context.evaluate(@template_name_expr).to_s) do
         render_without_profiling(context)
       end
     end

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -45,8 +45,13 @@ module Liquid
       partial = load_cached_partial(context)
 
       template_name = context.evaluate(@template_name_expr)
-      variable = @variable_name_expr ? context.evaluate(@variable_name_expr) : context[template_name]
       context_variable_name = template_name.split('/'.freeze).last
+
+      variable = if @variable_name_expr
+        context.evaluate(@variable_name_expr)
+      else
+        context.find_variable(template_name)
+      end
 
       context.stack do
         @attributes.each do |key, value|

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -45,7 +45,7 @@ module Liquid
       partial = load_cached_partial(context)
 
       template_name = context.evaluate(@template_name_expr)
-      variable = context.evaluate(@variable_name_expr || Expression.parse(template_name))
+      variable = @variable_name_expr ? context.evaluate(@variable_name_expr) : context[template_name]
       context_variable_name = template_name.split('/'.freeze).last
 
       context.stack do

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -219,4 +219,12 @@ class IncludeTagTest < Minitest::Test
       assert_equal 'x', Template.parse("{% include template %}", error_mode: :strict, include_options_blacklist: [:error_mode]).render!("template" => '{{ "X" || downcase }}')
     end
   end
+
+  def test_including_via_variable_value
+    assert_template_result "from TestFileSystem", "{% assign page = 'pick_a_source' %}{% include page %}"
+
+    assert_template_result "Product: Draft 151cm ", "{% assign page = 'product' %}{% include page %}", "product" => {'title' => 'Draft 151cm'}
+
+    assert_template_result "Product: Draft 151cm ", "{% assign page = 'product' %}{% include page for foo %}", "foo" => {'title' => 'Draft 151cm'}
+  end
 end # IncludeTagTest


### PR DESCRIPTION
Fixes #461, as an alternative to #556. The added tests explain what this allows.