### PR TITLE
Use custom stack for forloop references

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -177,7 +177,18 @@ module Liquid
       variable = variable.to_liquid
       variable.context = self if variable.respond_to?(:context=)
 
-      return variable
+      variable
+    end
+
+    def find_own_variable(key)
+      index = @scopes.find_index { |s| s.has_key?(key) }
+      return unless index
+
+      scope = @scopes[index]
+      variable = lookup_and_evaluate(@scopes[index], key).to_liquid
+      variable.context = self if variable.respond_to?(:context=)
+
+      variable
     end
 
     def lookup_and_evaluate(obj, key)

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -177,18 +177,7 @@ module Liquid
       variable = variable.to_liquid
       variable.context = self if variable.respond_to?(:context=)
 
-      variable
-    end
-
-    def find_own_variable(key)
-      index = @scopes.find_index { |s| s.has_key?(key) }
-      return unless index
-
-      scope = @scopes[index]
-      variable = lookup_and_evaluate(@scopes[index], key).to_liquid
-      variable.context = self if variable.respond_to?(:context=)
-
-      variable
+      return variable
     end
 
     def lookup_and_evaluate(obj, key)

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -99,7 +99,7 @@ module Liquid
       # Store our progress through the collection for the continue flag
       context.registers[:for][@name] = from + segment.length
 
-      parent_loop = context.find_variable('forloop'.freeze)
+      parent_loop = context.find_own_variable('forloop'.freeze)
 
       context.stack do
         segment.each_with_index do |item, index|

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -69,7 +69,8 @@ module Liquid
     end
 
     def render(context)
-      context.registers[:for] ||= Hash.new(0)
+      for_offsets = context.registers[:for] ||= Hash.new(0)
+      for_stack = context.registers[:for_stack] ||= []
 
       collection = context.evaluate(@collection_name)
       collection = collection.to_a if collection.is_a?(Range)
@@ -78,7 +79,7 @@ module Liquid
       return render_else(context) unless iterable?(collection)
 
       from = if @from == :continue
-        context.registers[:for][@name].to_i
+        for_offsets[@name].to_i
       else
         context.evaluate(@from).to_i
       end
@@ -97,14 +98,15 @@ module Liquid
       length = segment.length
 
       # Store our progress through the collection for the continue flag
-      context.registers[:for][@name] = from + segment.length
+      for_offsets[@name] = from + segment.length
 
-      parent_loop = context.find_own_variable('forloop'.freeze)
+      parent_loop = for_stack.last
+      for_stack.push(nil)
 
       context.stack do
         segment.each_with_index do |item, index|
           context[@variable_name] = item
-          context['forloop'.freeze] = {
+          loop_vars = {
             'name'.freeze       => @name,
             'length'.freeze     => length,
             'index'.freeze      => index + 1,
@@ -116,6 +118,9 @@ module Liquid
             'parentloop'.freeze => parent_loop
           }
 
+          context['forloop'.freeze] = loop_vars
+          for_stack[-1] = loop_vars
+
           result << @for_block.render(context)
 
           # Handle any interrupts if they exist.
@@ -126,6 +131,8 @@ module Liquid
           end
         end
       end
+
+      for_stack.pop
       result
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -99,7 +99,7 @@ module Liquid
       # Store our progress through the collection for the continue flag
       context.registers[:for][@name] = from + segment.length
 
-      parent_loop = context['forloop'.freeze]
+      parent_loop = context.find_variable('forloop'.freeze)
 
       context.stack do
         segment.each_with_index do |item, index|

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -132,8 +132,9 @@ module Liquid
         end
       end
 
-      for_stack.pop
       result
+    ensure
+      for_stack.pop
     end
 
     protected

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -1,24 +1,5 @@
 require 'test_helper'
 
-class ErrorDrop < Liquid::Drop
-  def standard_error
-    raise Liquid::StandardError, 'standard error'
-  end
-
-  def argument_error
-    raise Liquid::ArgumentError, 'argument error'
-  end
-
-  def syntax_error
-    raise Liquid::SyntaxError, 'syntax error'
-  end
-
-  def exception
-    raise Exception, 'exception'
-  end
-
-end
-
 class ErrorHandlingTest < Minitest::Test
   include Liquid
 

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -388,4 +388,14 @@ HERE
     assert_template_result(expected, template, loader_assigns)
     assert_template_result(expected, template, array_assigns)
   end
+
+  def test_for_cleans_up_registers
+    context = Context.new(ErrorDrop.new)
+
+    assert_raises(StandardError) do
+      Liquid::Template.parse('{% for i in (1..2) %}{{ standard_error }}{% endfor %}').render!(context)
+    end
+
+    assert context.registers[:for_stack].empty?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,3 +88,22 @@ class ThingWithToLiquid
     'foobar'
   end
 end
+
+class ErrorDrop < Liquid::Drop
+  def standard_error
+    raise Liquid::StandardError, 'standard error'
+  end
+
+  def argument_error
+    raise Liquid::ArgumentError, 'argument error'
+  end
+
+  def syntax_error
+    raise Liquid::SyntaxError, 'syntax error'
+  end
+
+  def exception
+    raise Exception, 'exception'
+  end
+end
+


### PR DESCRIPTION
There is some strange code in Shopify that handles references to undefined drop methods, which causes an exception to be thrown on `context['forloop']`.

This method is faster and more accurate for finding the parent for loop (prevents overwriting, for example).