### PR TITLE
Remove unnecessary stack pushes

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -37,20 +37,18 @@ module Liquid
     end
 
     def render(context)
-      context.stack do
-        execute_else_block = true
+      execute_else_block = true
 
-        output = ''
-        @blocks.each do |block|
-          if block.else?
-            return block.attachment.render(context) if execute_else_block
-          elsif block.evaluate(context)
-            execute_else_block = false
-            output << block.attachment.render(context)
-          end
+      output = ''
+      @blocks.each do |block|
+        if block.else?
+          return block.attachment.render(context) if execute_else_block
+        elsif block.evaluate(context)
+          execute_else_block = false
+          output << block.attachment.render(context)
         end
-        output
       end
+      output
     end
 
     private

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -32,15 +32,13 @@ module Liquid
     def render(context)
       context.registers[:cycle] ||= Hash.new(0)
 
-      context.stack do
-        key = context.evaluate(@name)
-        iteration = context.registers[:cycle][key]
-        result = context.evaluate(@variables[iteration])
-        iteration += 1
-        iteration  = 0  if iteration >= @variables.size
-        context.registers[:cycle][key] = iteration
-        result
-      end
+      key = context.evaluate(@name)
+      iteration = context.registers[:cycle][key]
+      result = context.evaluate(@variables[iteration])
+      iteration += 1
+      iteration  = 0  if iteration >= @variables.size
+      context.registers[:cycle][key] = iteration
+      result
     end
 
     private

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -38,14 +38,12 @@ module Liquid
     end
 
     def render(context)
-      context.stack do
-        @blocks.each do |block|
-          if block.evaluate(context)
-            return block.attachment.render(context)
-          end
+      @blocks.each do |block|
+        if block.evaluate(context)
+          return block.attachment.render(context)
         end
-        ''.freeze
       end
+      ''.freeze
     end
 
     private

--- a/lib/liquid/tags/ifchanged.rb
+++ b/lib/liquid/tags/ifchanged.rb
@@ -1,15 +1,13 @@
 module Liquid
   class Ifchanged < Block
     def render(context)
-      context.stack do
-        output = super
+      output = super
 
-        if output != context.registers[:ifchanged]
-          context.registers[:ifchanged] = output
-          output
-        else
-          ''.freeze
-        end
+      if output != context.registers[:ifchanged]
+        context.registers[:ifchanged] = output
+        output
+      else
+        ''.freeze
       end
     end
   end

--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -7,22 +7,20 @@ module Liquid
   #
   class Unless < If
     def render(context)
-      context.stack do
-        # First condition is interpreted backwards ( if not )
-        first_block = @blocks.first
-        unless first_block.evaluate(context)
-          return first_block.attachment.render(context)
-        end
-
-        # After the first condition unless works just like if
-        @blocks[1..-1].each do |block|
-          if block.evaluate(context)
-            return block.attachment.render(context)
-          end
-        end
-
-        ''.freeze
+      # First condition is interpreted backwards ( if not )
+      first_block = @blocks.first
+      unless first_block.evaluate(context)
+        return first_block.attachment.render(context)
       end
+
+      # After the first condition unless works just like if
+      @blocks[1..-1].each do |block|
+        if block.evaluate(context)
+          return block.attachment.render(context)
+        end
+      end
+
+      ''.freeze
     end
   end
 


### PR DESCRIPTION
Either the tests should fail here, or these really aren't necessary (they don't seem necessary). If this is to keep tag-created variables scoped, then there should be a test for that.

@fw42 @dylanahsmith 