### PR TITLE
Make liquid error rendering optional.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -13,7 +13,7 @@ module Liquid
   #   context['bob']  #=> nil  class Context
   class Context
     attr_reader :scopes, :errors, :registers, :environments, :resource_limits
-    attr_accessor :exception_handler
+    attr_accessor :exception_handler, :render_errors
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil)
       @environments     = [environments].flatten
@@ -22,6 +22,7 @@ module Liquid
       @errors           = []
       @resource_limits  = resource_limits || ResourceLimits.new(Template.default_resource_limits)
       squash_instance_assigns_with_environments
+      @render_errors    = true
 
       @this_stack_used = false
 
@@ -69,7 +70,7 @@ module Liquid
 
       errors.push(e)
       raise if exception_handler && exception_handler.call(e)
-      Liquid::Error.render(e)
+      render_errors ? Liquid::Error.render(e) : ''
     end
 
     def invoke(method, *args)

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -17,7 +17,7 @@ module Liquid
       locale: I18n.new
     }
 
-    attr_accessor :root
+    attr_accessor :root, :render_errors
     attr_reader :resource_limits
 
     @@file_system = BlankFileSystem.new
@@ -182,6 +182,8 @@ module Liquid
       else
         raise ArgumentError, "Expected Hash or Liquid::Context as parameter"
       end
+
+      context.render_errors = self.render_errors unless self.render_errors.nil?
 
       case args.last
       when Hash

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -185,4 +185,11 @@ class ErrorHandlingTest < Minitest::Test
       template.render('errors' => ErrorDrop.new)
     end
   end
+
+  def test_disabling_error_rendering
+    template = Liquid::Template.parse('This is an argument error: {{ errors.argument_error }}')
+    template.render_errors = false
+    assert_equal 'This is an argument error: ', template.render('errors' => ErrorDrop.new)
+    assert_equal [ArgumentError], template.errors.map(&:class)
+  end
 end


### PR DESCRIPTION
@shopify/liquid for review

## Problem

Errors that occur at render time make sense to show to theme authors for development, but it is probably not desirable to show them to the page visitor.

## Solution

If an error occurs when rendering a tag, then allow an empty string to be rendered instead of an error message.  After rendering the errors are still available on the template for error notifications and logging.