### PR TITLE
Include template name with line numbers in render errors.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -13,7 +13,7 @@ module Liquid
   #   context['bob']  #=> nil  class Context
   class Context
     attr_reader :scopes, :errors, :registers, :environments, :resource_limits
-    attr_accessor :exception_handler
+    attr_accessor :exception_handler, :template_name
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil)
       @environments     = [environments].flatten
@@ -64,6 +64,7 @@ module Liquid
 
     def handle_error(e, token = nil)
       if e.is_a?(Liquid::Error)
+        e.template_name = template_name
         e.set_line_number_from_token(token)
       end
 

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -1,6 +1,7 @@
 module Liquid
   class Error < ::StandardError
     attr_accessor :line_number
+    attr_accessor :template_name
     attr_accessor :markup_context
 
     def to_s(with_prefix = true)
@@ -41,7 +42,9 @@ module Liquid
       end
 
       if line_number
-        str << " (line #{line_number})"
+        str << " ("
+        str << template_name << " " if template_name
+        str << "line " << line_number.to_s << ")"
       end
 
       str << ": "


### PR DESCRIPTION
@Shopify/liquid for review

## Problem

Currently the error line numbers are ambiguous if templates are included, since there is no indication of what template they occur on.

## Solution

Add a `template_name` attribute to the context which is set and reset by the include tag's render method, then set the `template_name` on the Liquid::Error when handling the error.

Note that the main template doesn't have a name, but that name could be given by setting it on the context before rendering the template.

Also note that the name given to include the template might not reflect where the template is actually stored, since that would require more integration with the file system.  E.g. in Shopify the snippets are stored under a snippets directory, so `{% include 'product' %}` would actually use `snippets/product.liquid`.  This could be implemented later, if desired, by adding a `respond_to?` check for an optional method to get the name to display for a given template name that was passed to the include tag.