### PR TITLE
Raise Liquid::ZeroDivisionError instead of ZeroDivisionError.

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -57,4 +57,5 @@ module Liquid
   StackLevelError = Class.new(Error)
   TaintedError = Class.new(Error)
   MemoryError = Class.new(Error)
+  ZeroDivisionError = Class.new(Error)
 end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -279,6 +279,8 @@ module Liquid
     # division
     def divided_by(input, operand)
       apply_operation(input, operand, :/)
+    rescue ::ZeroDivisionError => e
+      raise Liquid::ZeroDivisionError, e.message
     end
 
     def modulo(input, operand)

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -201,14 +201,14 @@ class TemplateTest < Minitest::Test
   def test_exception_handler_doesnt_reraise_if_it_returns_false
     exception = nil
     Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; false })
-    assert exception.is_a?(ZeroDivisionError)
+    assert exception.is_a?(Liquid::ZeroDivisionError)
   end
 
   def test_exception_handler_does_reraise_if_it_returns_true
     exception = nil
-    assert_raises(ZeroDivisionError) do
+    assert_raises(Liquid::ZeroDivisionError) do
       Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; true })
     end
-    assert exception.is_a?(ZeroDivisionError)
+    assert exception.is_a?(Liquid::ZeroDivisionError)
   end
 end


### PR DESCRIPTION
@pushrax & @tjoyal for review

## Problem

We should be raising a Liquid::Error when there is an error in the template rather than a bug, so `{{ 1 | divided_by: 0 }}` should cause a ZeroDivisionError.

## Solution

Raise a `Liquid::ZeroDivisionError` instead of `::ZeroDivisionError` similar to how we raise Liquid::ArgumentError instead of ArgumentError for template errors.