### PR TITLE
Allow the exception handler to convert exceptions to hide error messges

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -17,7 +17,7 @@ module Liquid
       locale: I18n.new
     }
 
-    attr_accessor :root, :render_errors
+    attr_accessor :root
     attr_reader :resource_limits
 
     @@file_system = BlankFileSystem.new
@@ -168,7 +168,7 @@ module Liquid
         c = args.shift
 
         if @rethrow_errors
-          c.exception_handler = ->(e) { true }
+          c.exception_handler = ->(e) { raise }
         end
 
         c
@@ -182,8 +182,6 @@ module Liquid
       else
         raise ArgumentError, "Expected Hash or Liquid::Context as parameter"
       end
-
-      context.render_errors = self.render_errors unless self.render_errors.nil?
 
       case args.last
       when Hash

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -197,10 +197,10 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   def test_exception_handler_with_exception_result
-    template = Liquid::Template.parse('This is a runtime error: {{ errors.runtime_error }}')
+    template = Liquid::Template.parse('This is a runtime error: {{ errors.runtime_error }}', line_numbers: true)
     handler = ->(e) { e.is_a?(Liquid::Error) ? e : InternalError.new('internal') }
     output = template.render({ 'errors' => ErrorDrop.new }, exception_handler: handler)
-    assert_equal 'This is a runtime error: Liquid error: internal', output
+    assert_equal 'This is a runtime error: Liquid error (line 1): internal', output
     assert_equal [InternalError], template.errors.map(&:class)
   end
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -186,10 +186,21 @@ class ErrorHandlingTest < Minitest::Test
     end
   end
 
-  def test_disabling_error_rendering
+  def test_exception_handler_with_string_result
     template = Liquid::Template.parse('This is an argument error: {{ errors.argument_error }}')
-    template.render_errors = false
-    assert_equal 'This is an argument error: ', template.render('errors' => ErrorDrop.new)
+    output = template.render({ 'errors' => ErrorDrop.new }, exception_handler: ->(e) { '' })
+    assert_equal 'This is an argument error: ', output
     assert_equal [ArgumentError], template.errors.map(&:class)
+  end
+
+  class InternalError < Liquid::Error
+  end
+
+  def test_exception_handler_with_exception_result
+    template = Liquid::Template.parse('This is a runtime error: {{ errors.runtime_error }}')
+    handler = ->(e) { e.is_a?(Liquid::Error) ? e : InternalError.new('internal') }
+    output = template.render({ 'errors' => ErrorDrop.new }, exception_handler: handler)
+    assert_equal 'This is a runtime error: Liquid error: internal', output
+    assert_equal [InternalError], template.errors.map(&:class)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,6 +102,10 @@ class ErrorDrop < Liquid::Drop
     raise Liquid::SyntaxError, 'syntax error'
   end
 
+  def runtime_error
+    raise RuntimeError, 'runtime error'
+  end
+
   def exception
     raise Exception, 'exception'
   end


### PR DESCRIPTION
@fw42, @pushrax for review
cc @arthurnn

## Problem

It should be possible to control what is output for non-Liquid::Error exceptions, since these exceptions might expose internal details of the application.

## Solution

Allow the exception handler to return a string, which will be output for the error, or an exception that the original exception will be replaced with.

https://github.com/Shopify/liquid/pull/573 made it possible to suppress the output of errors.  This can now be done with an exception handler that always returns `''`, so I removed that unreleased feature.

I kept the old behaviour of allowing `true` to be returned to re-raise the exception, although this could have been implemented with an exception handler that just called `raise`.  I changed the internal usage of that within liquid for clarity.