### PR TITLE
Fix exception from using an empty string for the table row collection.

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -76,9 +76,6 @@ module Liquid
       collection = context.evaluate(@collection_name)
       collection = collection.to_a if collection.is_a?(Range)
 
-      # Maintains Ruby 1.8.7 String#each behaviour on 1.9
-      return render_else(context) unless iterable?(collection)
-
       from = if @from == :continue
         for_offsets[@name].to_i
       else
@@ -188,10 +185,6 @@ module Liquid
 
     def render_else(context)
       @else_block ? @else_block.render(context) : ''.freeze
-    end
-
-    def iterable?(collection)
-      collection.respond_to?(:each) || Utils.non_blank_string?(collection)
     end
   end
 

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -17,7 +17,7 @@ module Liquid
       index = 0
 
       # Maintains Ruby 1.8.7 String#each behaviour on 1.9
-      return [collection] if non_blank_string?(collection)
+      return collection != ''.freeze ? [collection] : [] if collection.is_a?(String)
 
       collection.each do |item|
         if to && to <= index

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -17,7 +17,9 @@ module Liquid
       index = 0
 
       # Maintains Ruby 1.8.7 String#each behaviour on 1.9
-      return collection != ''.freeze ? [collection] : [] if collection.is_a?(String)
+      if collection.is_a?(String)
+        return collection.empty? ? [] : [collection]
+      end
 
       collection.each do |item|
         if to && to <= index

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -8,10 +8,6 @@ module Liquid
       end
     end
 
-    def self.non_blank_string?(collection)
-      collection.is_a?(String) && collection != ''.freeze
-    end
-
     def self.slice_collection_using_each(collection, from, to)
       segments = []
       index = 0
@@ -20,6 +16,7 @@ module Liquid
       if collection.is_a?(String)
         return collection.empty? ? [] : [collection]
       end
+      return [] unless collection.respond_to?(:each)
 
       collection.each do |item|
         if to && to <= index

--- a/test/integration/tags/table_row_test.rb
+++ b/test/integration/tags/table_row_test.rb
@@ -57,4 +57,8 @@ class TableRowTest < Minitest::Test
       '{% tablerow n in numbers cols:3 offset:1 limit:6%} {{n}} {% endtablerow %}',
       'numbers' => [0, 1, 2, 3, 4, 5, 6, 7])
   end
+
+  def test_blank_string_not_iterable
+    assert_template_result("<tr class=\"row1\">\n</tr>\n", "{% tablerow char in characters cols:3 %}I WILL NOT BE OUTPUT{% endtablerow %}", 'characters' => '')
+  end
 end


### PR DESCRIPTION
@fw42 & @tjoyal for review

## Problem

Liquid like `{% tablerow product in collections.frontpage.products cols:3  %}` was resulting in a `Liquid error: undefined method `each' for \"\":String` error when the shop doesn't have a frontpage collection.  This empty string was coming from an EmptyDrop that we returned when a collection couldn't be found.

This was inconsistent with the `for` tag, which would treat an empty string as an empty collection.  Both the `for` and `tablerow` tags will treat a non-empty string as a collection with a single item.  It is also inconsistent with how liquid worked with ruby 1.8.7, where String#each was the same as String#each_line.

## Solution

Treat an empty string the same as an empty collection.