### PR TITLE
Ensure For@reversed is a boolean

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -141,7 +141,7 @@ module Liquid
       if markup =~ Syntax
         @variable_name = $1
         collection_name = $2
-        @reversed = $3
+        @reversed = !!$3
         @name = "#{@variable_name}-#{collection_name}"
         @collection_name = Expression.parse(collection_name)
         markup.scan(TagAttributes) do |key, value|


### PR DESCRIPTION
Currently running some AST comparisons between the strict and lax parser, this is the one difference that appears in almost every template. Nice to keep one less string around as well.