### PR TITLE
Ensure raw tag has no arguments

### DIFF
--- a/lib/liquid/locales/en.yml
+++ b/lib/liquid/locales/en.yml
@@ -1,6 +1,7 @@
 ---
   errors:
     syntax:
+      tag_unexpected_args: "Syntax Error in '%{tag}' - Valid syntax: %{tag}"
       assign: "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"
       capture: "Syntax Error in 'capture' - Valid syntax: capture [var]"
       case: "Syntax Error in 'case' - Valid syntax: case [condition]"

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,15 @@
 module Liquid
   class Raw < Block
+    Syntax = /\A\s*\z/om
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+
+    def initialize(tag_name, markup, options)
+      super
+
+      unless markup =~ Syntax
+        raise SyntaxError.new(@options[:locale].t("errors.syntax.tag_unexpected_args".freeze, tag: tag_name))
+      end
+    end
 
     def parse(tokens)
       @body = ''

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Raw < Block
-    Syntax = /\A\s*\z/om
+    Syntax = /\A\s*\z/
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def initialize(tag_name, markup, options)

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -24,6 +24,7 @@ class RawTagTest < Minitest::Test
   end
 
   def test_invalid_raw
-    assert_match_syntax_error /tag was never closed/, '{% raw } foo {% endraw %}'
+    assert_match_syntax_error /tag was never closed/, '{% raw %} foo'
+    assert_match_syntax_error /Valid syntax/, '{% raw } foo %}{% endraw %}'
   end
 end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -25,6 +25,7 @@ class RawTagTest < Minitest::Test
 
   def test_invalid_raw
     assert_match_syntax_error /tag was never closed/, '{% raw %} foo'
+    assert_match_syntax_error /Valid syntax/, '{% raw } foo {% endraw %}'
     assert_match_syntax_error /Valid syntax/, '{% raw } foo %}{% endraw %}'
   end
 end


### PR DESCRIPTION
We usually don't enforce the lack of arguments to zero-argument tags (e.g. break, continue, etc), but I think it's a good practise.

cc @gauravmc 