### PR TITLE
Raise a Liquid::ArgumentError in slice filter for invalid integers.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -323,7 +323,7 @@ module Liquid
       begin
         Integer(num)
       rescue ::ArgumentError
-        raise Liquid::ArgumentError, "invalid integer '#{num}'"
+        raise Liquid::ArgumentError, "invalid integer"
       end
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -46,8 +46,8 @@ module Liquid
     end
 
     def slice(input, offset, length = nil)
-      offset = Integer(offset)
-      length = length ? Integer(length) : 1
+      offset = to_integer(offset)
+      length = length ? to_integer(length) : 1
 
       if input.is_a?(Array)
         input.slice(offset, length) || []
@@ -316,6 +316,16 @@ module Liquid
     end
 
     private
+
+    def to_integer(num)
+      return num if num.is_a?(Integer)
+      num = num.to_s
+      begin
+        Integer(num)
+      rescue ::ArgumentError
+        raise Liquid::ArgumentError, "invalid integer '#{num}'"
+      end
+    end
 
     def to_number(obj)
       case obj

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -76,6 +76,12 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '', @filters.slice(nil, 0)
     assert_equal '', @filters.slice('foobar', 100, 10)
     assert_equal '', @filters.slice('foobar', -100, 10)
+    assert_raises(Liquid::ArgumentError) do
+      @filters.slice('foobar', nil)
+    end
+    assert_raises(Liquid::ArgumentError) do
+      @filters.slice('foobar', 0, "")
+    end
   end
 
   def test_slice_on_arrays

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -76,6 +76,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '', @filters.slice(nil, 0)
     assert_equal '', @filters.slice('foobar', 100, 10)
     assert_equal '', @filters.slice('foobar', -100, 10)
+    assert_equal 'oob', @filters.slice('foobar', '1', '3')
     assert_raises(Liquid::ArgumentError) do
       @filters.slice('foobar', nil)
     end


### PR DESCRIPTION
@tjoyal & @fw42 for review

If an invalid integer is passed to slice for the offset of length arguments, then raise a Liquid::ArgumentError instead of a non-Liquid::Error, since this is a template bug.