### PR TITLE
Convert arguments to replace filters to strings to avoid exceptions.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -167,12 +167,12 @@ module Liquid
 
     # Replace occurrences of a string with another
     def replace(input, string, replacement = ''.freeze)
-      input.to_s.gsub(string, replacement.to_s)
+      input.to_s.gsub(string.to_s, replacement.to_s)
     end
 
     # Replace the first occurrences of a string with another
     def replace_first(input, string, replacement = ''.freeze)
-      input.to_s.sub(string, replacement.to_s)
+      input.to_s.sub(string.to_s, replacement.to_s)
     end
 
     # remove a substring

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -268,7 +268,9 @@ class StandardFiltersTest < Minitest::Test
 
   def test_replace
     assert_equal '2 2 2 2', @filters.replace('1 1 1 1', '1', 2)
+    assert_equal '2 2 2 2', @filters.replace('1 1 1 1', 1, 2)
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2)
+    assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2)
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
   end
 


### PR DESCRIPTION
@pushrax & @tjoyal for review

Similar to pull #578, stringifies the input to the replace filters to avoid exceptions.