### PR TITLE
Avoid an exception from checking if a string contains a non-string.

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -16,7 +16,12 @@ module Liquid
       '>='.freeze => :>=,
       '<='.freeze => :<=,
       'contains'.freeze => lambda do |cond, left, right|
-        left && right && left.respond_to?(:include?) ? left.include?(right) : false
+        if left && right && left.respond_to?(:include?)
+          right = right.to_s if left.is_a?(String)
+          left.include?(right)
+        else
+          false
+        end
       end
     }
 

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -85,6 +85,11 @@ class ConditionUnitTest < Minitest::Test
     assert_evalutes_false 1, 'contains', 0
   end
 
+  def test_contains_with_string_left_operand_coerces_right_operand_to_string
+    assert_evalutes_true ' 1 ', 'contains', 1
+    assert_evalutes_false ' 1 ', 'contains', 2
+  end
+
   def test_or_condition
     condition = Condition.new(1, '==', 2)
 


### PR DESCRIPTION
@tjoyal & @fw42 for review

## Problem

The contains operator can raise an exception if the left operand is a string, but the right operand isn't.

`{% if string contains non_string %}`

because String#include? will raise a `TypeError: no implicit conversion of #{obj.class} into String` exception, which isn't a Liquid::Error despite being a template bug.

## Solution

If the left operand is a string, then convert the right operand to a string using `.to_s` to avoid exceptions.