### PR TITLE
Global filters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,3 +76,7 @@ desc "Run example"
 task :example do
   ruby "-w -d -Ilib example/server/server.rb"
 end
+
+task :console do
+  exec 'irb -I lib -r ./lib/liquid.rb'
+end

--- a/lib/liquid/locales/en.yml
+++ b/lib/liquid/locales/en.yml
@@ -1,6 +1,7 @@
 ---
   errors:
     syntax:
+      tag_unexpected_args: "Syntax Error in '%{tag}' - Valid syntax: %{tag}"
       assign: "Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"
       capture: "Syntax Error in 'capture' - Valid syntax: capture [var]"
       case: "Syntax Error in 'case' - Valid syntax: case [condition]"

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -167,12 +167,12 @@ module Liquid
 
     # Replace occurrences of a string with another
     def replace(input, string, replacement = ''.freeze)
-      input.to_s.gsub(string, replacement.to_s)
+      input.to_s.gsub(string.to_s, replacement.to_s)
     end
 
     # Replace the first occurrences of a string with another
     def replace_first(input, string, replacement = ''.freeze)
-      input.to_s.sub(string, replacement.to_s)
+      input.to_s.sub(string.to_s, replacement.to_s)
     end
 
     # remove a substring

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -323,7 +323,7 @@ module Liquid
       begin
         Integer(num)
       rescue ::ArgumentError
-        raise Liquid::ArgumentError, "invalid integer '#{num}'"
+        raise Liquid::ArgumentError, "invalid integer"
       end
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -46,8 +46,8 @@ module Liquid
     end
 
     def slice(input, offset, length = nil)
-      offset = Integer(offset)
-      length = length ? Integer(length) : 1
+      offset = to_integer(offset)
+      length = length ? to_integer(length) : 1
 
       if input.is_a?(Array)
         input.slice(offset, length) || []
@@ -316,6 +316,16 @@ module Liquid
     end
 
     private
+
+    def to_integer(num)
+      return num if num.is_a?(Integer)
+      num = num.to_s
+      begin
+        Integer(num)
+      rescue ::ArgumentError
+        raise Liquid::ArgumentError, "invalid integer '#{num}'"
+      end
+    end
 
     def to_number(obj)
       case obj

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,15 @@
 module Liquid
   class Raw < Block
+    Syntax = /\A\s*\z/om
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+
+    def initialize(tag_name, markup, options)
+      super
+
+      unless markup =~ Syntax
+        raise SyntaxError.new(@options[:locale].t("errors.syntax.tag_unexpected_args".freeze, tag: tag_name))
+      end
+    end
 
     def parse(tokens)
       @body = ''

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -1,6 +1,6 @@
 module Liquid
   class Raw < Block
-    Syntax = /\A\s*\z/om
+    Syntax = /\A\s*\z/
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def initialize(tag_name, markup, options)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -11,6 +11,8 @@ module Liquid
         end
         @body << token unless token.empty?
       end
+
+      raise SyntaxError.new(@options[:locale].t("errors.syntax.tag_never_closed".freeze, block_name: block_name))
     end
 
     def render(_context)

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -37,8 +37,11 @@ module Liquid
 
       name_markup = $1
       filter_markup = $2
+
+      global_filter_markup = add_global_filters(filter_markup)
+
       @name = Expression.parse(name_markup)
-      if filter_markup =~ /#{FilterSeparator}\s*(.*)/om
+      if global_filter_markup =~ /#{FilterSeparator}\s*(.*)/om
         filters = $1.scan(FilterParser)
         filters.each do |f|
           if f =~ /\w+/
@@ -52,7 +55,10 @@ module Liquid
 
     def strict_parse(markup)
       @filters = []
-      p = Parser.new(markup)
+
+      global_markup = add_global_filters(markup)
+
+      p = Parser.new(global_markup)
 
       @name = Expression.parse(p.expression)
       while p.consume?(:pipe)
@@ -79,6 +85,17 @@ module Liquid
     end
 
     private
+
+    def add_global_filters(filter_markup)
+      fm = filter_markup.dup
+      gf = @options[:global_filters]
+      if gf && gf.is_a?(Array)
+        gf.each do |filter|
+          fm += " | #{filter}"
+        end
+      end
+      fm
+    end
 
     def parse_filter_expressions(filter_name, unparsed_args)
       filter_args = []

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -76,6 +76,12 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '', @filters.slice(nil, 0)
     assert_equal '', @filters.slice('foobar', 100, 10)
     assert_equal '', @filters.slice('foobar', -100, 10)
+    assert_raises(Liquid::ArgumentError) do
+      @filters.slice('foobar', nil)
+    end
+    assert_raises(Liquid::ArgumentError) do
+      @filters.slice('foobar', 0, "")
+    end
   end
 
   def test_slice_on_arrays

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -268,7 +268,9 @@ class StandardFiltersTest < Minitest::Test
 
   def test_replace
     assert_equal '2 2 2 2', @filters.replace('1 1 1 1', '1', 2)
+    assert_equal '2 2 2 2', @filters.replace('1 1 1 1', 1, 2)
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2)
+    assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2)
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
   end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -76,6 +76,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '', @filters.slice(nil, 0)
     assert_equal '', @filters.slice('foobar', 100, 10)
     assert_equal '', @filters.slice('foobar', -100, 10)
+    assert_equal 'oob', @filters.slice('foobar', '1', '3')
     assert_raises(Liquid::ArgumentError) do
       @filters.slice('foobar', nil)
     end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -22,4 +22,8 @@ class RawTagTest < Minitest::Test
     assert_template_result ' test {% raw %} {% endraw %}', '{% raw %} test {% raw %} {% {% endraw %}endraw %}'
     assert_template_result ' Foobar {{ invalid 1', '{% raw %} Foobar {{ invalid {% endraw %}{{ 1 }}'
   end
+
+  def test_invalid_raw
+    assert_match_syntax_error /tag was never closed/, '{% raw } foo {% endraw %}'
+  end
 end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -24,6 +24,7 @@ class RawTagTest < Minitest::Test
   end
 
   def test_invalid_raw
-    assert_match_syntax_error /tag was never closed/, '{% raw } foo {% endraw %}'
+    assert_match_syntax_error /tag was never closed/, '{% raw %} foo'
+    assert_match_syntax_error /Valid syntax/, '{% raw } foo %}{% endraw %}'
   end
 end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -25,6 +25,7 @@ class RawTagTest < Minitest::Test
 
   def test_invalid_raw
     assert_match_syntax_error /tag was never closed/, '{% raw %} foo'
+    assert_match_syntax_error /Valid syntax/, '{% raw } foo {% endraw %}'
     assert_match_syntax_error /Valid syntax/, '{% raw } foo %}{% endraw %}'
   end
 end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -79,4 +79,10 @@ class VariableTest < Minitest::Test
   def test_multiline_variable
     assert_equal 'worked', Template.parse("{{\ntest\n}}").render!('test' => 'worked')
   end
+
+  def test_global_options_on_variable
+    template = Template.parse(%({{test}}), global_filters: ['truncate: 5'])
+    assert_equal 'wo...', template.render!('test' => 'worked')
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,7 @@ module Minitest
       assert_match expected, Template.parse(template).render!(assigns), message
     end
 
-    def assert_match_syntax_error(match, template, registers = {})
+    def assert_match_syntax_error(match, template, assigns = {})
       exception = assert_raises(Liquid::SyntaxError) {
         Template.parse(template).render(assigns)
       }

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -153,4 +153,17 @@ class VariableUnitTest < Minitest::Test
     assert_equal 'a', lookup.name
     assert_equal ['b', 'c'], lookup.lookups
   end
+
+  def test_global_filters
+    var = Variable.new(%( 'foo' ), global_filters: ['repeat: 3'])
+    assert_equal 'foo', var.name
+    assert_equal [['repeat', [3]]], var.filters
+  end
+
+  def test_global_filters_to_existing_filters
+    var = Variable.new(%( 'foo' | upcase ), global_filters: ['repeat: 3'])
+    assert_equal 'foo', var.name
+    assert_equal [['upcase', []],['repeat', [3]]], var.filters
+  end
+
 end


### PR DESCRIPTION
Allow Template.parse options to accept a "global_filters" array of filters that would be applied to every liquid variable.

Example:
```
template = Liquid::Template.parse("Apply filter to {{ one }} and {{ two }} and {{ three }}.", global_filters: ['truncate: 5'])
template.render({'one' => 'first variable', 'two' => 'second variable', 'three' => 'third variable'})
=> "Apply filter to fi... and se... and th...."
```