### PR TITLE
blank and empty as variable names

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -78,17 +78,17 @@ module Liquid
     private
 
     def equal_variables(left, right)
-      if left.is_a?(Symbol)
-        if right.respond_to?(left)
-          return right.send(left.to_s)
+      if left.is_a?(Liquid::Expression::MethodLiteral)
+        if right.respond_to?(left.method_name)
+          return right.send(left.method_name)
         else
           return nil
         end
       end
 
-      if right.is_a?(Symbol)
-        if left.respond_to?(right)
-          return left.send(right.to_s)
+      if right.is_a?(Liquid::Expression::MethodLiteral)
+        if left.respond_to?(right.method_name)
+          return left.send(right.method_name)
         else
           return nil
         end

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -1,11 +1,24 @@
 module Liquid
   class Expression
+    class MethodLiteral
+      attr_reader :method_name, :to_s
+
+      def initialize(method_name, to_s)
+        @method_name = method_name
+        @to_s = to_s
+      end
+
+      def to_liquid
+        to_s
+      end
+    end
+
     LITERALS = {
       nil => nil, 'nil'.freeze => nil, 'null'.freeze => nil, ''.freeze => nil,
       'true'.freeze  => true,
       'false'.freeze => false,
-      'blank'.freeze => :blank?,
-      'empty'.freeze => :empty?
+      'blank'.freeze => MethodLiteral.new(:blank?, '').freeze,
+      'empty'.freeze => MethodLiteral.new(:empty?, '').freeze
     }
 
     def self.parse(markup)

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -24,6 +24,16 @@ class VariableTest < Minitest::Test
     assert_equal '', template.render!
   end
 
+  def test_using_blank_as_variable_name
+    template = Template.parse("{% assign foo = blank %}{{ foo }}")
+    assert_equal '', template.render!
+  end
+
+  def test_using_empty_as_variable_name
+    template = Template.parse("{% assign foo = empty %}{{ foo }}")
+    assert_equal '', template.render!
+  end
+
   def test_hash_scoping
     template = Template.parse(%({{ test.test }}))
     assert_equal 'worked', template.render!('test' => { 'test' => 'worked' })

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -110,4 +110,3 @@ class ErrorDrop < Liquid::Drop
     raise Exception, 'exception'
   end
 end
-


### PR DESCRIPTION
Fixes https://github.com/Shopify/liquid/issues/591.

Not sure if this is a good fix, feels kinda hacky, but seems to work.

@pushrax @dylanahsmith 