### PR TITLE
Rename 'has_key?' and 'has_interrupt?'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Lint/UnusedBlockArgument:
 Lint/EndAlignment:
   AlignWith: variable
 
+Lint/UnusedMethodArgument:
+  Enabled: false
+
 Style/SingleLineBlockParams:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,11 +5,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 11
-# Cop supports --auto-correct.
-Lint/UnusedMethodArgument:
-  Enabled: false
-
 # Offense count: 51
 Metrics/AbcSize:
   Max: 58
@@ -68,11 +63,6 @@ Style/MultilineBlockChain:
 # Offense count: 2
 # Configuration parameters: EnforcedStyle, MinBodyLength, SupportedStyles.
 Style/Next:
-  Enabled: false
-
-# Offense count: 3
-# Configuration parameters: NamePrefix, NamePrefixBlacklist.
-Style/PredicateName:
   Enabled: false
 
 # Offense count: 7

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -73,7 +73,7 @@ module Liquid
 
       @nodelist.each do |token|
         # Break out if we have any unhanded interrupts.
-        break if context.has_interrupt?
+        break if context.interrupt?
 
         begin
           # If we get an Interrupt that means the block must stop processing. An

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -48,7 +48,7 @@ module Liquid
     end
 
     # are there any not handled interrupts?
-    def has_interrupt?
+    def interrupt?
       !@interrupts.empty?
     end
 
@@ -154,7 +154,7 @@ module Liquid
       evaluate(Expression.parse(expression))
     end
 
-    def has_key?(key)
+    def key?(key)
       self[key] != nil
     end
 
@@ -166,7 +166,7 @@ module Liquid
     def find_variable(key)
       # This was changed from find() to find_index() because this is a very hot
       # path and find_index() is optimized in MRI to reduce object allocation
-      index = @scopes.find_index { |s| s.has_key?(key) }
+      index = @scopes.find_index { |s| s.key?(key) }
       scope = @scopes[index] if index
 
       variable = nil
@@ -203,7 +203,7 @@ module Liquid
     def squash_instance_assigns_with_environments
       @scopes.last.each_key do |k|
         @environments.each do |env|
-          if env.has_key?(k)
+          if env.key?(k)
             scopes.last[k] = lookup_and_evaluate(env, k)
             break
           end

--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -39,7 +39,7 @@ module Liquid
       end
     end
 
-    def has_key?(_name)
+    def key?(_name)
       true
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -119,7 +119,7 @@ module Liquid
           result << @for_block.render(context)
 
           # Handle any interrupts if they exist.
-          if context.has_interrupt?
+          if context.interrupt?
             interrupt = context.pop_interrupt
             break if interrupt.is_a? BreakInterrupt
             next if interrupt.is_a? ContinueInterrupt

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -25,7 +25,7 @@ module Liquid
       end
 
       def [](tag_name)
-        return nil unless @tags.has_key?(tag_name)
+        return nil unless @tags.key?(tag_name)
         return @cache[tag_name] if Liquid.cache_classes
 
         lookup_class(@tags[tag_name]).tap { |o| @cache[tag_name] = o }

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -41,7 +41,7 @@ module Liquid
         # If object is a hash- or array-like object we look for the
         # presence of the key and if its available we return it
         if object.respond_to?(:[]) &&
-            ((object.respond_to?(:has_key?) && object.has_key?(key)) ||
+            ((object.respond_to?(:key?) && object.key?(key)) ||
              (object.respond_to?(:fetch) && key.is_a?(Integer)))
 
           # if its a proc we will replace the entry with the proc

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -25,7 +25,7 @@ class ContextTest < Minitest::Test
   def test_has_key_will_not_add_an_error_for_missing_keys
     with_error_mode :strict do
       context = Context.new
-      context.has_key?('unknown')
+      context.key?('unknown')
       assert_empty context.errors
     end
   end

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -454,7 +454,7 @@ class ContextUnitTest < Minitest::Test
     mock_any = Spy.on_instance_method(Array, :any?)
     mock_empty = Spy.on_instance_method(Array, :empty?)
 
-    @context.has_interrupt?
+    @context.interrupt?
 
     refute mock_any.has_been_called?
     assert mock_empty.has_been_called?


### PR DESCRIPTION
rubocop doesn't like `has_bla?` and `is_bla?` etc. and me neither... Should be safe to change, right?

@pushrax @dylanahsmith 