### PR TITLE
Use to_integer for truncatewords filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -67,7 +67,7 @@ module Liquid
     def truncatewords(input, words = 15, truncate_string = "...".freeze)
       return if input.nil?
       wordlist = input.to_s.split
-      l = words.to_i - 1
+      l = to_integer(words) - 1
       l = 0 if l < 0
       wordlist.length > l ? wordlist[0..l].join(" ".freeze) + truncate_string : input
     end


### PR DESCRIPTION
This makes the `truncatefilter` raise a proper `Liquid::ArgumentError` if someone passes something as argument that is not an integer.

@dylanahsmith @pushrax 