### PR TITLE
sorting on nested properties

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/AbcSize:
 # Offense count: 16
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 314
+  Max: 350
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -158,6 +158,30 @@ class StandardFiltersTest < Minitest::Test
     assert_equal [{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }], @filters.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a")
   end
 
+  def prepare_test_nested_sort
+    ab = { "title" => "Harry Potter", "author" => "JK Rowling", "series" => [ 1, 2 ] }
+    bb = { "title" => "Lord of the Flies", "author" => "William Golding" }
+    cb = { "title" => "The Circle", "author" => "Dave Eggers" }
+    db = { "title" => "The Accidental Billionaires", "author" => "Ben Mezrich" }
+    am = { "title" => "Harry Potter", "distributor" => "Warner Brothers" }
+    bm = { "title" => "Lord of the Flies", "distributor" => "Columbia Pictures" }
+    cm = { "title" => "The Circle", "distributor" => "Devolver" }
+    dm = { "title" => "The Social Network", "distributor" => "Columbia Pictures" }
+    a = { "book" => ab, "movie" => am, "id" => 4 }
+    b = { "book" => bb, "movie" => bm, "id" => 3 }
+    c = { "book" => cb, "movie" => cm, "id" => 2 }
+    d = { "book" => db, "movie" => dm, "id" => 1 }
+    [ a, b, c, d ]
+  end
+
+  def test_nested_sort
+    collection = prepare_test_nested_sort
+    a, b, c, d = collection
+    assert_equal [d, c, b, a], @filters.sort(collection, "id")
+    assert_equal [d, c, a, b], @filters.sort(collection, "book.author")
+    assert_equal [d, b, c, a], @filters.sort(collection, "movie.distributor")
+  end
+
   def test_legacy_sort_hash
     assert_equal [{ a: 1, b: 2 }], @filters.sort({ a: 1, b: 2 })
   end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -166,7 +166,7 @@ class StandardFiltersTest < Minitest::Test
     am = { "title" => "Harry Potter", "distributor" => "Warner Brothers" }
     bm = { "title" => "Lord of the Flies", "distributor" => "Columbia Pictures" }
     cm = { "title" => "The Circle", "distributor" => "Devolver" }
-    dm = { "title" => "The Social Network", "distributor" => "Columbia Pictures" }
+    dm = { "title" => "The Social Network", "distributor" => "Big Pictures" }
     a = { "book" => ab, "movie" => am, "id" => 4 }
     b = { "book" => bb, "movie" => bm, "id" => 3 }
     c = { "book" => cb, "movie" => cm, "id" => 2 }


### PR DESCRIPTION
pr to provide support for sorting on nested properties in collections. Created to address [Jekyll #3351](https://github.com/jekyll/jekyll/issues/3351)

```
{% assign sorted_posts = filtered_posts | sort: 'book.author' %}
```

Comes with tests. @fw42 
