### PR TITLE
Add very simple spaceless tag

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -105,6 +105,11 @@ module Liquid
       input.to_s.gsub(/\r?\n/, ''.freeze)
     end
 
+    # Remove whitespace between HTML tags
+    def strip_html_whitespace(input)
+      Spaceless.strip_html_whitespace(input.to_s)
+    end
+
     # Join elements of the array with certain character between them
     def join(input, glue = ' '.freeze)
       InputIterator.new(input).join(glue)

--- a/lib/liquid/tags/spaceless.rb
+++ b/lib/liquid/tags/spaceless.rb
@@ -1,0 +1,24 @@
+module Liquid
+  # The spaceless tag strips whitespace between HTML tags using a simple regex.
+  #
+  # == Usage:
+  #    {% spaceless %}
+  #      <h1>
+  #        Hello
+  #      </h1>
+  #    {% endspaceless %}
+  #
+  class Spaceless < Block
+    HTML_STRIP_SPACE_REGEXP = />\s+</
+
+    def render(context)
+      self.class.strip_html_whitespace(super)
+    end
+
+    def self.strip_html_whitespace(input)
+      input.gsub(HTML_STRIP_SPACE_REGEXP, '><')
+    end
+  end
+
+  Template.register_tag('spaceless'.freeze, Spaceless)
+end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -417,4 +417,9 @@ class StandardFiltersTest < Minitest::Test
   def test_cannot_access_private_methods
     assert_template_result('a', "{{ 'a' | to_number }}")
   end
+
+  def test_strip_html_whitespace
+    html = "<a>\n\n   <b>  \n  <c>a</c> \r\n   </b>   </a>"
+    assert_template_result('<a><b><c>a</c></b></a>', "{{ a | strip_html_whitespace }}", { 'a' => html })
+  end
 end # StandardFiltersTest

--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -293,4 +293,9 @@ class StandardTagTest < Minitest::Test
   def test_multiline_tag
     assert_template_result '0 1 2 3', "0{%\nfor i in (1..3)\n%} {{\ni\n}}{%\nendfor\n%}"
   end
+
+  def test_spaceless
+    html = "<a>\n\n   <b>  \n  <c>a</c> \r\n   </b>   </a>"
+    assert_template_result '<a><b><c>a</c></b></a>', "{% spaceless %}#{html}{% endspaceless %}"
+  end
 end # StandardTagTest


### PR DESCRIPTION
Based on Django's equivalent tag. https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#spaceless

Helps address #216