### PR TITLE
Add Liquid::Tag#tag_name

### DIFF
--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -1,7 +1,7 @@
 module Liquid
   class Tag
     attr_accessor :options, :line_number
-    attr_reader :nodelist, :warnings
+    attr_reader :nodelist, :warnings, :tag_name
     include ParserSwitching
 
     class << self

--- a/test/unit/tag_unit_test.rb
+++ b/test/unit/tag_unit_test.rb
@@ -13,4 +13,9 @@ class TagUnitTest < Minitest::Test
     tag = Tag.parse("long_tag", "param1, param2, param3", [], {})
     assert_equal("long_tag param1, param2, param3", tag.raw)
   end
+
+  def test_tag_name_should_return_name_of_the_tag
+    tag = Tag.parse("some_tag", [], [], {})
+    assert_equal 'some_tag', tag.tag_name
+  end
 end


### PR DESCRIPTION
This has been needed a few times in Shopify, which ends up in `instance_variable_get` shittiness. Added to `attr_reader` list.

@fw42 @pushrax cc @quelledanielle 