### PR TITLE
Remove standard exception rescue in escape filter.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -33,7 +33,7 @@ module Liquid
     end
 
     def escape(input)
-      CGI.escapeHTML(input).untaint rescue input
+      CGI.escapeHTML(input).untaint
     end
     alias_method :h, :escape
 


### PR DESCRIPTION
@fw42 & @pushrax for review

Fixes #521

If there are exceptions happening, then they will likely result in a security vulnerability from returning the unescaped input.  Now that we report non-Liquid::Error exceptions in Shopify, we should be able to ship this without silently breaking things.