### PR TITLE
Use node to refer to objects from the nodelist rather than token.

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -84,10 +84,10 @@ module Liquid
             break
           end
 
-          token_output = render_token(token, context)
+          node_output = render_node(token, context)
 
           unless token.is_a?(Block) && token.blank?
-            output << token_output
+            output << node_output
           end
         rescue MemoryError => e
           raise e
@@ -101,15 +101,15 @@ module Liquid
 
     private
 
-    def render_token(token, context)
-      token_output = (token.respond_to?(:render) ? token.render(context) : token)
-      token_str = token_output.is_a?(Array) ? token_output.join : token_output.to_s
+    def render_node(node, context)
+      node_output = (node.respond_to?(:render) ? node.render(context) : node)
+      node_output = node_output.is_a?(Array) ? node_output.join : node_output.to_s
 
-      context.resource_limits.render_length += token_str.length
+      context.resource_limits.render_length += node_output.length
       if context.resource_limits.reached?
         raise MemoryError.new("Memory limits exceeded".freeze)
       end
-      token_str
+      node_output
     end
 
     def create_variable(token, options)

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -19,7 +19,7 @@ module Liquid
   # inside of <tt>{% include %}</tt> tags.
   #
   #   profile.each do |node|
-  #     # Access to the token itself
+  #     # Access to the node itself
   #     node.code
   #
   #     # Which template and line number of this node.
@@ -46,15 +46,15 @@ module Liquid
     class Timing
       attr_reader :code, :partial, :line_number, :children
 
-      def initialize(token, partial)
-        @code        = token.respond_to?(:raw) ? token.raw : token
+      def initialize(node, partial)
+        @code        = node.respond_to?(:raw) ? node.raw : node
         @partial     = partial
-        @line_number = token.respond_to?(:line_number) ? token.line_number : nil
+        @line_number = node.respond_to?(:line_number) ? node.line_number : nil
         @children    = []
       end
 
-      def self.start(token, partial)
-        new(token, partial).tap(&:start)
+      def self.start(node, partial)
+        new(node, partial).tap(&:start)
       end
 
       def start
@@ -70,11 +70,11 @@ module Liquid
       end
     end
 
-    def self.profile_token_render(token)
-      if Profiler.current_profile && token.respond_to?(:render)
-        Profiler.current_profile.start_token(token)
+    def self.profile_node_render(node)
+      if Profiler.current_profile && node.respond_to?(:render)
+        Profiler.current_profile.start_node(node)
         output = yield
-        Profiler.current_profile.end_token(token)
+        Profiler.current_profile.end_node(node)
         output
       else
         yield
@@ -132,11 +132,11 @@ module Liquid
       @root_timing.children.length
     end
 
-    def start_token(token)
-      @timing_stack.push(Timing.start(token, current_partial))
+    def start_node(node)
+      @timing_stack.push(Timing.start(node, current_partial))
     end
 
-    def end_token(_token)
+    def end_node(_node)
       timing = @timing_stack.pop
       timing.finish
 

--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -1,13 +1,13 @@
 module Liquid
   class BlockBody
-    def render_token_with_profiling(token, context)
-      Profiler.profile_token_render(token) do
-        render_token_without_profiling(token, context)
+    def render_node_with_profiling(node, context)
+      Profiler.profile_node_render(node) do
+        render_node_without_profiling(node, context)
       end
     end
 
-    alias_method :render_token_without_profiling, :render_token
-    alias_method :render_token, :render_token_with_profiling
+    alias_method :render_node_without_profiling, :render_node
+    alias_method :render_node, :render_node_with_profiling
   end
 
   class Include < Tag


### PR DESCRIPTION
## Problem

The BlockBody code and profiling code was referring to nodes in the nodelist as tokens, which is inconsistent and confusing.

## Solution

The variables and methods appeared to be implementation details, so I went ahead and renamed token to node in the rendering code.