### PR TITLE
Add taint warnings to the context rather than the template.

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -33,6 +33,10 @@ module Liquid
       @filters = []
     end
 
+    def warnings
+      @warnings ||= []
+    end
+
     def strainer
       @strainer ||= Strainer.create(self, @filters)
     end

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -107,20 +107,21 @@ module Liquid
     end
 
     def taint_check(context, obj)
-      if obj.tainted? && Template.taint_mode != :lax
-        @markup =~ QuotedFragment
-        name = Regexp.last_match(0)
+      return unless obj.tainted?
+      return if Template.taint_mode == :lax
 
-        error = TaintedError.new("variable '#{name}' is tainted and was not escaped")
-        error.line_number = line_number
-        error.template_name = context.template_name
+      @markup =~ QuotedFragment
+      name = Regexp.last_match(0)
 
-        case Template.taint_mode
-        when :warn
-          context.warnings << error
-        when :error
-          raise error
-        end
+      error = TaintedError.new("variable '#{name}' is tainted and was not escaped")
+      error.line_number = line_number
+      error.template_name = context.template_name
+
+      case Template.taint_mode
+      when :warn
+        context.warnings << error
+      when :error
+        raise error
       end
     end
   end

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -124,8 +124,10 @@ class DropsTest < Minitest::Test
   def test_rendering_warns_on_tainted_attr
     with_taint_mode(:warn) do
       tpl = Liquid::Template.parse('{{ product.user_input }}')
-      tpl.render!('product' => ProductDrop.new)
-      assert_match /tainted/, tpl.warnings.first
+      context = Context.new('product' => ProductDrop.new)
+      tpl.render!(context)
+      assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
+      assert_equal "variable 'product.user_input' is tainted and was not escaped", context.warnings.first.to_s(false)
     end
   end
 


### PR DESCRIPTION
@eapache & @fw42 for review

## Problem

The taint checking is adding warnings to the tag objects so that it can be retrieved from Template#warnings, but that should only be done for parse warnings, since Liquid::Template#warnings won't return warnings on included templates.

Also, Liquid::Template#warnings normally only contains exception objects, but the taint checker was adding the warnings as strings.  This makes code using the warnings fragile, and also prevents us from including line number and template name context to the errors.

Additionally, using Liquid::Template#warnings means that the whole template node graph needs to be walked to get the warnings.

## Solution

Add a warnings method to the Liquid::Context, and use it as a place to add the taint warnings.  The context is re-used for included templates, so will catch taint warnings from snippets.  A TaintedError exception object is added to the warnings array rather than just an error message.