### PR TITLE
Rename options instance variable in Variable and Tag.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :test do
   gem 'rubocop', '>=0.32.0'
 
   platform :mri do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: '35e9aee48d639ae1d3ac9ba77616aca9800eab7d'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: '2570693d8d03faa0df9160ec74348a7149436df3'
   end
 end

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -1,7 +1,7 @@
 module Liquid
   class Tag
-    attr_reader :nodelist, :tag_name, :line_number, :options
-    alias_method :parse_context, :options
+    attr_reader :nodelist, :tag_name, :line_number, :parse_context
+    alias_method :options, :parse_context
     include ParserSwitching
 
     class << self
@@ -17,7 +17,7 @@ module Liquid
     def initialize(tag_name, markup, parse_context)
       @tag_name   = tag_name
       @markup     = markup
-      @options    = parse_context
+      @parse_context = parse_context
       @line_number = parse_context.line_number
     end
 

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -12,14 +12,14 @@ module Liquid
   class Variable
     FilterParser = /(?:\s+|#{QuotedFragment}|#{ArgumentSeparator})+/o
     attr_accessor :filters, :name, :line_number
-    attr_reader :options
-    alias_method :parse_context, :options
+    attr_reader :parse_context
+    alias_method :options, :parse_context
     include ParserSwitching
 
     def initialize(markup, parse_context)
       @markup  = markup
       @name    = nil
-      @options = parse_context
+      @parse_context = parse_context
       @line_number = parse_context.line_number
 
       parse_with_selected_parser(markup)


### PR DESCRIPTION
@pushrax for review

Addresses pull request comment https://github.com/Shopify/liquid/pull/614#discussion_r33938850.

I updated liquid-c in https://github.com/Shopify/liquid-c/pull/24 to not use the `@options` instance variable directly.