### PR TITLE
Move the syntax error rescue for adding error line numbers.

### DIFF
--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -1,23 +1,26 @@
 module Liquid
   class Document < BlockBody
-    def self.parse(tokens, options)
+    def self.parse(tokens, parse_context)
       doc = new
-      doc.parse(tokens, options)
+      doc.parse(tokens, parse_context)
       doc
     end
 
-    def parse(tokens, options)
+    def parse(tokens, parse_context)
       super do |end_tag_name, end_tag_params|
-        unknown_tag(end_tag_name, options) if end_tag_name
+        unknown_tag(end_tag_name, parse_context) if end_tag_name
       end
+    rescue SyntaxError => e
+      e.line_number ||= parse_context.line_number
+      raise
     end
 
-    def unknown_tag(tag, options)
+    def unknown_tag(tag, parse_context)
       case tag
       when 'else'.freeze, 'end'.freeze
-        raise SyntaxError.new(options[:locale].t("errors.syntax.unexpected_outer_tag".freeze, tag: tag))
+        raise SyntaxError.new(parse_context.locale.t("errors.syntax.unexpected_outer_tag".freeze, tag: tag))
       else
-        raise SyntaxError.new(options[:locale].t("errors.syntax.unknown_tag".freeze, tag: tag))
+        raise SyntaxError.new(parse_context.locale.t("errors.syntax.unknown_tag".freeze, tag: tag))
       end
     end
   end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -120,9 +120,6 @@ module Liquid
       @root = Document.parse(tokenize(source), parse_context)
       @warnings = parse_context.warnings
       self
-    rescue SyntaxError => e
-      e.line_number ||= parse_context.line_number
-      raise
     end
 
     def registers


### PR DESCRIPTION
@pushrax for review

This allows us to use Liquid::Document directly without having to copy the rescue that adds line numbers.