### PR TITLE
Add a lax warning mode to see where we can make the lax parser stricter.

### DIFF
--- a/lib/liquid/parser_switching.rb
+++ b/lib/liquid/parser_switching.rb
@@ -3,7 +3,7 @@ module Liquid
     def parse_with_selected_parser(markup)
       case parse_context.error_mode
       when :strict then strict_parse_with_error_context(markup)
-      when :lax    then lax_parse(markup)
+      when :lax, :lax_warn then lax_parse(markup)
       when :warn
         begin
           return strict_parse_with_error_context(markup)

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -16,9 +16,9 @@ module Liquid
     capture_filters = /(#{FilterSeparator}.*)/o
     VariableSyntax = /\A\s*#{capture_ignored_variable_prefix}\s*#{capture_expression}\s*(?:#{capture_ignored_filter_prefix}\s*#{capture_filters})?\z/om
 
-    capture_lax_seperator = /(['"\|]+?)/
+    capture_lax_separator = /(['"\|]+?)/
     capture_filter = /((?:\s+|#{QuotedFragment}|#{ArgumentSeparator})+)/o
-    FilterParser = /\s*(?:#{FilterSeparator}|#{capture_lax_seperator})\s*#{capture_filter}/o
+    FilterParser = /\s*(?:#{FilterSeparator}|#{capture_lax_separator})\s*#{capture_filter}/o
 
     attr_accessor :filters, :name, :line_number
     attr_reader :parse_context
@@ -48,12 +48,12 @@ module Liquid
 
       add_syntax_warning("variable prefixed with ignored characters: #{$1.inspect}") if $1
       name_markup = $2
-      add_syntax_warning("variable filter seperator prefixed with ignored characters: #{$3.inspect}") if $3
+      add_syntax_warning("variable filter separator prefixed with ignored characters: #{$3.inspect}") if $3
       filters_markup = $4
       @name = Expression.parse(name_markup)
       if filters_markup
         filters_markup.scan(FilterParser) do |lax_sep, f|
-          add_syntax_warning("unterminated quote or multiple pipe characters used as a filter seperator: #{lax_sep.inspect}") if lax_sep
+          add_syntax_warning("unterminated quote or multiple pipe characters used as a filter separator: #{lax_sep.inspect}") if lax_sep
           next unless f =~ /\A\s*(\W+)??(\w+)/
           add_syntax_warning("ignored characters before filter name: #{$1.inspect}") if $1
           filtername = $2

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -101,13 +101,13 @@ class VariableTest < Minitest::Test
     ignored_chars = ",wat? lax!"
     template = Liquid::Template.parse("{{ test#{ignored_chars} | noop }}", error_mode: :lax_warn)
     assert_equal "works", template.render!('test' => 'works')
-    assert_equal [Liquid::SyntaxError.new("variable filter seperator prefixed with ignored characters: #{ignored_chars.inspect}")], template.warnings
+    assert_equal [Liquid::SyntaxError.new("variable filter separator prefixed with ignored characters: #{ignored_chars.inspect}")], template.warnings
   end
 
   def test_lax_warnings_for_weird_filter_chars
     template = Liquid::Template.parse("{{ test | upcase \" prepend: 'it ' || append: ' surprisingly' }}", error_mode: :lax_warn)
     assert_equal "it WORKS surprisingly", template.render!('test' => 'works')
-    expected_warnings = ['"', '||'].map{ |sep| Liquid::SyntaxError.new("unterminated quote or multiple pipe characters used as a filter seperator: #{sep.inspect}") }
+    expected_warnings = ['"', '||'].map{ |sep| Liquid::SyntaxError.new("unterminated quote or multiple pipe characters used as a filter separator: #{sep.inspect}") }
     assert_equal expected_warnings, template.warnings
   end
 


### PR DESCRIPTION
@fw42 & @pushrax for review

## Problem

There are a lot of implicit liquid quirks due to not using anchored regexes, including things like unterminated quotes being used as a filter separator.  However, I suspect there are some quirks that actually don't happen in production or are rare enough to fix by hand.

## Solution

I decided we should log these edge cases when the happen in the lax parser, using warning messages that are specific enough to search the logs for, along with the relevant part of the markup.

We already have a warning mode, but the strict warnings aren't specific enough for this purpose, so I added a `:lax_warn` error_mode.  We could get rid of this error mode after making use of these warnings.

I anchored regexes that were used for a single match, and non-greedy captures to capture text at the start of regex scans.  I also tried to make sure `nil` is captured rather than an empty string for these edge cases, so avoid extra string allocations.

## Benchmark

on master

```
              parse:     18.673  (±16.1%) i/s -      1.075k
        parse & run:     12.302  (±16.3%) i/s -    720.000
```

on this branch

```
              parse:     18.792  (±16.0%) i/s -      1.077k
        parse & run:     12.453  (±16.1%) i/s -    729.000
```