### PR TITLE
Allow use of curlies in a properly quoted string

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -35,7 +35,7 @@ module Liquid
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
+  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}(?:(?:[^'"{}]+|#{QuotedString})*?|.*?)#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 

--- a/test/unit/tokenizer_unit_test.rb
+++ b/test/unit/tokenizer_unit_test.rb
@@ -11,6 +11,7 @@ class TokenizerTest < Minitest::Test
     assert_equal [' ', '{{funk}}', ' '], tokenize(' {{funk}} ')
     assert_equal [' ', '{{funk}}', ' ', '{{so}}', ' ', '{{brother}}', ' '], tokenize(' {{funk}} {{so}} {{brother}} ')
     assert_equal [' ', '{{  funk  }}', ' '], tokenize(' {{  funk  }} ')
+    assert_equal ['{{funk | replace: "}", \'}}\' }}'], tokenize('{{funk | replace: "}", \'}}\' }}')
   end
 
   def test_tokenize_blocks

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -70,6 +70,12 @@ class VariableUnitTest < Minitest::Test
     assert_equal [['replace', ['foo', 'bar']], ['textileze', []]], var.filters
   end
 
+  def test_filters_with_properly_quoted_curlies
+    var = create_variable("hello | replace: \"}\", '}}'")
+    assert_equal VariableLookup.new('hello'), var.name
+    assert_equal [['replace', ['}', '}}']]], var.filters
+  end
+
   def test_symbol
     var = create_variable("http://disney.com/logo.gif | image: 'med' ", error_mode: :lax)
     assert_equal VariableLookup.new('http://disney.com/logo.gif'), var.name


### PR DESCRIPTION
Currently Liquid does not even allow a closing curly brace to be put inside of a variable, but you sometimes need to deal with the character.