### PR TITLE
Allow variable and tag end characters to be quoted.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :test do
   gem 'rubocop', '>=0.32.0'
 
   platform :mri do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: '2570693d8d03faa0df9160ec74348a7149436df3'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: '11d38237d9f491588a58c83dc3d364a7d0d1d55b'
   end
 end

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -35,7 +35,8 @@ module Liquid
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
   AnyStartingTag              = /\{\{|\{\%/
-  PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
+  tag_contents                = /(?:#{QuotedString}|.)*?/m
+  PartialTemplateParser       = /#{TagStart}#{tag_contents}#{TagEnd}|#{VariableStart}#{tag_contents}#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 

--- a/test/integration/tags/assign_tag_test.rb
+++ b/test/integration/tags/assign_tag_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class AssignTagTest < Minitest::Test
+  include Liquid
+
+  def test_assign
+    assert_template_result('monkey', "{% assign foo = 'monkey' %}{{ foo }}")
+  end
+
+  def test_string_with_end_tag
+    assert_template_result("{% quoted %}", "{% assign string = '{% quoted %}' %}{{ string }}")
+  end
+end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -89,4 +89,9 @@ class VariableTest < Minitest::Test
   def test_multiline_variable
     assert_equal 'worked', Template.parse("{{\ntest\n}}").render!('test' => 'worked')
   end
+
+  def test_string_with_curly_brackets
+    json = '{ "key": { "nested": "value" }}'
+    assert_template_result(json, "{{ '#{json}' }}")
+  end
 end


### PR DESCRIPTION
@pushrax and @trishume for review
cc @knu

Closes #623
Depends on https://github.com/Shopify/liquid-c/pull/27

## Problem

Add support for quoting string string in variables and tags to contain end variable and tag characters.

## Solution

When encountering a quote character inside a variable or tag, the tokenizer will include everything up to the end quote character (if one is present) even if it includes the tag/variable end characters.

I tried to keep the tag contents regex as simple as possible.  I also added integration tests that fail without using the liquid-c without the same support for this case.