### PR TITLE
[RFC] Inject Liquid template name into Ruby backtrace

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -190,6 +190,10 @@ module Liquid
         if options[:exception_handler]
           context.exception_handler = options[:exception_handler]
         end
+
+        if options[:template_name]
+          context.template_name = options[:template_name]
+        end
       when Module
         context.add_filters(args.pop)
       when Array


### PR DESCRIPTION
Not intended to be merged, this is just a quick and dirty idea that I think might be useful and that I would like some feedback on.

We sometimes see Ruby exceptions coming from Liquid and it's often difficult to track down which piece of Liquid code triggered it, so it would be nice to have the template name and line number as part of the Ruby backtrace. This PR does that (in a super ugly way, but it's a proof of concept).

Example:

template
```
foo

bar

{{ boom }}

bla
```

test.rb
```
require 'liquid'

class Boom
  def to_liquid
    raise 'broken'
  end
end

template = Liquid::Template.parse(File.read('template'), line_numbers: true)

output = template.render(
  { 'boom' => Boom.new },
  {
    template_name: 'template.liquid',
    exception_handler: ->(e){ true }
  }
)

puts output
```

output:
```
test.rb:5:in `to_liquid': broken (RuntimeError)
	from /Users/flo/Projects/shopify/liquid/lib/liquid/context.rb:217:in `find_variable'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/variable_lookup.rb:36:in `evaluate'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/context.rb:192:in `evaluate'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/variable.rb:76:in `render'
	from template.liquid:5
	from /Users/flo/Projects/shopify/liquid/lib/liquid/block_body.rb:90:in `render_node'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/block_body.rb:72:in `block in render'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/block_body.rb:59:in `each'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/block_body.rb:59:in `render'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/template.rb:210:in `block in render'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/template.rb:244:in `with_profiling'
	from /Users/flo/Projects/shopify/liquid/lib/liquid/template.rb:209:in `render'
	from test.rb:11:in `<main>'
```

Thoughts? How can we make this better? Is this even useful?

@Shopify/liquid @trishume