### PR TITLE
Properly rescue ::ArgumentError in the date filter

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -72,7 +72,7 @@ module Liquid
       when String
         Time.parse(obj)
       end
-    rescue ArgumentError
+    rescue ::ArgumentError
       nil
     end
   end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -420,6 +420,11 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result('a', "{{ 'a' | to_number }}")
   end
 
+  def test_date_raises_nothing
+    assert_template_result('', "{{ '' | date: '%D' }}")
+    assert_template_result('abc', "{{ 'abc' | date: '%D' }}")
+  end
+
   private
 
   def with_timezone(tz)


### PR DESCRIPTION
Currently Utils.to_date rescues `ArgumentError` which actually refers to `Liquid::ArgumentError`, and `::ArgumentError` raised by `Time.parse` will be leaked.