### PR TITLE
Don't allow identifiers to end in a dash in strict parse mode.

### DIFF
--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -13,7 +13,7 @@ module Liquid
       '?'.freeze => :question,
       '-'.freeze => :dash
     }
-    IDENTIFIER = /[a-zA-Z_][\w-]*\??/
+    IDENTIFIER = /[a-zA-Z_](?:[\w-]*\w)?\??/
     SINGLE_STRING_LITERAL = /'[^\']*'/
     DOUBLE_STRING_LITERAL = /"[^\"]*"/
     NUMBER_LITERAL = /-?\d+(\.\d+)?/

--- a/test/unit/lexer_unit_test.rb
+++ b/test/unit/lexer_unit_test.rb
@@ -37,8 +37,8 @@ class LexerUnitTest < Minitest::Test
     tokens = Lexer.new('2foo').tokenize
     assert_equal [[:number, '2'], [:id, 'foo'], [:end_of_string]], tokens
 
-    tokens = Lexer.new('foo-bar-baz-').tokenize
-    assert_equal [[:id, 'foo-bar-baz'], [:dash, "-"], [:end_of_string]], tokens
+    tokens = Lexer.new('foo-bar--baz-').tokenize
+    assert_equal [[:id, 'foo-bar--baz'], [:dash, "-"], [:end_of_string]], tokens
   end
 
   def test_whitespace

--- a/test/unit/lexer_unit_test.rb
+++ b/test/unit/lexer_unit_test.rb
@@ -36,6 +36,9 @@ class LexerUnitTest < Minitest::Test
 
     tokens = Lexer.new('2foo').tokenize
     assert_equal [[:number, '2'], [:id, 'foo'], [:end_of_string]], tokens
+
+    tokens = Lexer.new('foo-bar-baz-').tokenize
+    assert_equal [[:id, 'foo-bar-baz'], [:dash, "-"], [:end_of_string]], tokens
   end
 
   def test_whitespace


### PR DESCRIPTION
@pushrax & @trishume for review

## Problem

We were allowing identifiers to end in a dash, but I don't think this was intended.  E.g. `foo-` would be a valid identifier in strict mode.

## Solution

Make sure identifiers end with a word character.