### PR TITLE
Allow first and last filters to take count argument

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -265,8 +265,10 @@ module Liquid
     # Example:
     #    {{ product.images | first | to_img }}
     #
-    def first(array)
-      array.first if array.respond_to?(:first)
+    def first(array, count = nil)
+      return unless array.respond_to?(:first)
+      return array.first if count.nil?
+      array.first(Utils.to_integer(count))
     end
 
     # Get the last element of the passed in array
@@ -274,8 +276,10 @@ module Liquid
     # Example:
     #    {{ product.images | last | to_img }}
     #
-    def last(array)
-      array.last if array.respond_to?(:last)
+    def last(array, count = nil)
+      return unless array.respond_to?(:last)
+      return array.last if count.nil?
+      array.last(Utils.to_integer(count))
     end
 
     # addition

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -238,6 +238,12 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result 'foobar', '{{ foo | last }}', 'foo' => [ThingWithToLiquid.new]
   end
 
+  def test_first_and_last_call_with_count_to_liquid
+    opts = { 'foo' => [ ThingWithToLiquid.new, TestThing.new, ThingWithToLiquid.new ] }
+    assert_template_result 'foobar,woot: 1', '{{ foo | first: 2 | join: "," }}', opts
+    assert_template_result 'woot: 2,foobar', '{{ foo | last: 2 | join: "," }}', opts
+  end
+
   def test_date
     assert_equal 'May', @filters.date(Time.parse("2006-05-05 10:00:00"), "%B")
     assert_equal 'June', @filters.date(Time.parse("2006-06-05 10:00:00"), "%B")


### PR DESCRIPTION
It seems to me that this functionality would be useful to many Liquid users. As may be obvious, use of the count argument with dot notation is not supported.

@fw42 could I trouble you for a code review at your convenience?