### PR TITLE
Add a url_decode standard filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -45,6 +45,10 @@ module Liquid
       CGI.escape(input) rescue input
     end
 
+    def url_decode(input)
+      CGI.unescape(input) rescue input
+    end
+
     def slice(input, offset, length = nil)
       offset = Utils.to_integer(offset)
       length = length ? Utils.to_integer(length) : 1

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -130,6 +130,13 @@ class StandardFiltersTest < Minitest::Test
     assert_equal nil, @filters.url_encode(nil)
   end
 
+  def test_url_decode
+    assert_equal 'foo bar', @filters.url_decode('foo+bar')
+    assert_equal 'foo bar', @filters.url_decode('foo%20bar')
+    assert_equal 'foo+1@example.com', @filters.url_decode('foo%2B1%40example.com')
+    assert_equal nil, @filters.url_decode(nil)
+  end
+
   def test_truncatewords
     assert_equal 'one two three', @filters.truncatewords('one two three', 4)
     assert_equal 'one two...', @filters.truncatewords('one two three', 2)


### PR DESCRIPTION
I ran into a place where I wanted a `url_decode` filter while experimenting with Huginn. 

I found issue #259, where a `url_encode` and `url_decode` filters were discussed, but it doesn't look like that ever made it into Liquid core? And there was #421, which did add the `url_encode` filter, but no `url_decode`.

So here it is, `url_decode` -- just the inverse of `url_encode`, calls `CGI::unescape` instead of `escape`.