### PR TITLE
Fix "sort" filter on empty array to return empty array

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -116,6 +116,8 @@ module Liquid
       ary = InputIterator.new(input)
       if property.nil?
         ary.sort
+      elsif ary.empty? # The next two cases assume a non-empty array.
+        []
       elsif ary.first.respond_to?(:[]) && !ary.first[property].nil?
         ary.sort { |a, b| a[property] <=> b[property] }
       elsif ary.first.respond_to?(property)
@@ -130,6 +132,8 @@ module Liquid
 
       if property.nil?
         ary.sort { |a, b| a.casecmp(b) }
+      elsif ary.empty? # The next two cases assume a non-empty array.
+        []
       elsif ary.first.respond_to?(:[]) && !ary.first[property].nil?
         ary.sort { |a, b| a[property].casecmp(b[property]) }
       elsif ary.first.respond_to?(property)
@@ -144,6 +148,8 @@ module Liquid
 
       if property.nil?
         ary.uniq
+      elsif ary.empty? # The next two cases assume a non-empty array.
+        []
       elsif ary.first.respond_to?(:[])
         ary.uniq{ |a| a[property] }
       end
@@ -175,6 +181,8 @@ module Liquid
 
       if property.nil?
         ary.compact
+      elsif ary.empty? # The next two cases assume a non-empty array.
+        []
       elsif ary.first.respond_to?(:[])
         ary.reject{ |a| a[property].nil? }
       elsif ary.first.respond_to?(property)
@@ -372,6 +380,11 @@ module Liquid
 
       def compact
         to_a.compact
+      end
+
+      def empty?
+        @input.each { return false }
+        true
       end
 
       def each

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -158,6 +158,14 @@ class StandardFiltersTest < Minitest::Test
     assert_equal [{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }], @filters.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a")
   end
 
+  def test_sort_empty_array
+    assert_equal [], @filters.sort([], "a")
+  end
+
+  def test_sort_natural_empty_array
+    assert_equal [], @filters.sort_natural([], "a")
+  end
+
   def test_legacy_sort_hash
     assert_equal [{ a: 1, b: 2 }], @filters.sort({ a: 1, b: 2 })
   end
@@ -175,6 +183,14 @@ class StandardFiltersTest < Minitest::Test
     assert_equal [{ "a" => 1 }, { "a" => 3 }, { "a" => 2 }], @filters.uniq([{ "a" => 1 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a")
     testdrop = TestDrop.new
     assert_equal [testdrop], @filters.uniq([testdrop, TestDrop.new], 'test')
+  end
+
+  def test_uniq_empty_array
+    assert_equal [], @filters.uniq([], "a")
+  end
+
+  def test_compact_empty_array
+    assert_equal [], @filters.compact([], "a")
   end
 
   def test_reverse


### PR DESCRIPTION
Can we adjust the "sort" filter to return empty array?  This would allow it to be chained with other array-like filters.  Currently calling "sort" followed by "map" results in an array containing one nil, which seems very broken.

I've added a test and verified that the test fails without this fix (and passes with it).