### PR TITLE
Fix offenses from the new version of rubocop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,6 +118,8 @@ Style/ClassVars:
 Style/PerlBackrefs:
   Enabled: false
 
+Style/TrivialAccessors:
+  AllowPredicates: true
+
 Style/WordArray:
   Enabled: false
-

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'stackprof', platforms: :mri_21
 group :test do
   gem 'spy', '0.4.1'
   gem 'benchmark-ips'
-  gem 'rubocop', '>=0.32.0'
+  gem 'rubocop', '0.34.2'
 
   platform :mri do
     gem 'liquid-c', github: 'Shopify/liquid-c', ref: '2570693d8d03faa0df9160ec74348a7149436df3'

--- a/lib/liquid/extensions.rb
+++ b/lib/liquid/extensions.rb
@@ -7,44 +7,44 @@ class String # :nodoc:
   end
 end
 
-class Array  # :nodoc:
+class Array # :nodoc:
   def to_liquid
     self
   end
 end
 
-class Hash  # :nodoc:
+class Hash # :nodoc:
   def to_liquid
     self
   end
 end
 
-class Numeric  # :nodoc:
+class Numeric # :nodoc:
   def to_liquid
     self
   end
 end
 
-class Time  # :nodoc:
+class Time # :nodoc:
   def to_liquid
     self
   end
 end
 
-class DateTime < Date  # :nodoc:
+class DateTime < Date # :nodoc:
   def to_liquid
     self
   end
 end
 
-class Date  # :nodoc:
+class Date # :nodoc:
   def to_liquid
     self
   end
 end
 
 class TrueClass
-  def to_liquid  # :nodoc:
+  def to_liquid # :nodoc:
     self
   end
 end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -42,7 +42,7 @@ module Liquid
     end
 
     def url_encode(input)
-      CGI.escape(input) rescue input
+      CGI.escape(input) unless input.nil?
     end
 
     def slice(input, offset, length = nil)

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -37,7 +37,7 @@ module Liquid
         iteration = context.registers[:cycle][key]
         result = context.evaluate(@variables[iteration])
         iteration += 1
-        iteration  = 0  if iteration >= @variables.size
+        iteration  = 0 if iteration >= @variables.size
         context.registers[:cycle][key] = iteration
         result
       end

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -152,7 +152,7 @@ module Liquid
     def strict_parse(markup)
       p = Parser.new(markup)
       @variable_name = p.consume(:id)
-      raise SyntaxError.new(options[:locale].t("errors.syntax.for_invalid_in".freeze))  unless p.id?('in'.freeze)
+      raise SyntaxError.new(options[:locale].t("errors.syntax.for_invalid_in".freeze)) unless p.id?('in'.freeze)
       collection_name = p.expression
       @name = "#{@variable_name}-#{collection_name}"
       @collection_name = Expression.parse(collection_name)

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files  = Dir.glob("{test}/**/*")
   s.files       = Dir.glob("{lib}/**/*") + %w(MIT-LICENSE README.md)
 
-  s.extra_rdoc_files  = ["History.md", "README.md"]
+  s.extra_rdoc_files = ["History.md", "README.md"]
 
   s.require_path = "lib"
 

--- a/test/integration/tags/if_else_tag_test.rb
+++ b/test/integration/tags/if_else_tag_test.rb
@@ -29,10 +29,10 @@ class IfElseTagTest < Minitest::Test
     assert_template_result(' YES ', '{% if a or b %} YES {% endif %}', 'a' => true, 'b' => true)
     assert_template_result(' YES ', '{% if a or b %} YES {% endif %}', 'a' => true, 'b' => false)
     assert_template_result(' YES ', '{% if a or b %} YES {% endif %}', 'a' => false, 'b' => true)
-    assert_template_result('',     '{% if a or b %} YES {% endif %}', 'a' => false, 'b' => false)
+    assert_template_result('',      '{% if a or b %} YES {% endif %}', 'a' => false, 'b' => false)
 
     assert_template_result(' YES ', '{% if a or b or c %} YES {% endif %}', 'a' => false, 'b' => false, 'c' => true)
-    assert_template_result('',     '{% if a or b or c %} YES {% endif %}', 'a' => false, 'b' => false, 'c' => false)
+    assert_template_result('',      '{% if a or b or c %} YES {% endif %}', 'a' => false, 'b' => false, 'c' => false)
   end
 
   def test_if_or_with_operators

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -267,7 +267,7 @@ class ContextUnitTest < Minitest::Test
 
   def test_access_hashes_with_hash_notation
     @context['products'] = { 'count' => 5, 'tags' => ['deepsnow', 'freestyle'] }
-    @context['product'] = { 'variants' => [ { 'title' => 'draft151cm' }, { 'title' => 'element151cm' }  ] }
+    @context['product'] = { 'variants' => [ { 'title' => 'draft151cm' }, { 'title' => 'element151cm' } ] }
 
     assert_equal 5, @context['products["count"]']
     assert_equal 'deepsnow', @context['products["tags"][0]']
@@ -305,7 +305,7 @@ class ContextUnitTest < Minitest::Test
   end
 
   def test_first_can_appear_in_middle_of_callchain
-    @context['product'] = { 'variants' => [ { 'title' => 'draft151cm' }, { 'title' => 'element151cm' }  ] }
+    @context['product'] = { 'variants' => [ { 'title' => 'draft151cm' }, { 'title' => 'element151cm' } ] }
 
     assert_equal 'draft151cm', @context['product.variants[0].title']
     assert_equal 'element151cm', @context['product.variants[1].title']


### PR DESCRIPTION
@fw42 for review

I noticed that CI is now picking up new rubocop offenses, since we don't lock the version in the Gemfile.  Should we be locking the version?

Either way, this should deal with these new offenses.