### PR TITLE
Rename before_method as liquid_method_missing

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,6 +15,7 @@
 * Ruby 1.9 support dropped (#491) [Justin Li]
 * Liquid::Template.file_system's read_template_file method is no longer passed the context. (#441) [James Reid-Smith]
 * Remove support for `liquid_methods`
+* Rename Drop method `before_method` as `liquid_method_missing` (#661) [Thierry Joyal]
 
 ### Fixed
 * Fix sort filter behaviour with empty array input (#652) [Marcel Cary]

--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -18,15 +18,15 @@ module Liquid
   #   tmpl = Liquid::Template.parse( ' {% for product in product.top_sales %} {{ product.name }} {%endfor%} '  )
   #   tmpl.render('product' => ProductDrop.new ) # will invoke top_sales query.
   #
-  # Your drop can either implement the methods sans any parameters or implement the before_method(name) method which is a
-  # catch all.
+  # Your drop can either implement the methods sans any parameters
+  # or implement the liquid_method_missing(name) method which is a catch all.
   class Drop
     attr_writer :context
 
     EMPTY_STRING = ''.freeze
 
     # Catch all for the method
-    def before_method(_method)
+    def liquid_method_missing(_method)
       nil
     end
 
@@ -35,7 +35,7 @@ module Liquid
       if method_or_key && method_or_key != EMPTY_STRING && self.class.invokable?(method_or_key)
         send(method_or_key)
       else
-        before_method(method_or_key)
+        liquid_method_missing(method_or_key)
       end
     end
 

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -13,7 +13,7 @@ class ContextDrop < Liquid::Drop
     @context['forloop.index']
   end
 
-  def before_method(method)
+  def liquid_method_missing(method)
     @context[method]
   end
 end
@@ -30,8 +30,8 @@ class ProductDrop < Liquid::Drop
   end
 
   class CatchallDrop < Liquid::Drop
-    def before_method(method)
-      'method: ' << method.to_s
+    def liquid_method_missing(method)
+      'catchall_method: ' << method.to_s
     end
   end
 
@@ -59,7 +59,7 @@ class ProductDrop < Liquid::Drop
 end
 
 class EnumerableDrop < Liquid::Drop
-  def before_method(method)
+  def liquid_method_missing(method)
     method
   end
 
@@ -93,7 +93,7 @@ end
 class RealEnumerableDrop < Liquid::Drop
   include Enumerable
 
-  def before_method(method)
+  def liquid_method_missing(method)
     method
   end
 
@@ -157,14 +157,14 @@ class DropsTest < Minitest::Test
     assert_equal ' text1 ', output
   end
 
-  def test_unknown_method
+  def test_catchall_unknown_method
     output = Liquid::Template.parse(' {{ product.catchall.unknown }} ').render!('product' => ProductDrop.new)
-    assert_equal ' method: unknown ', output
+    assert_equal ' catchall_method: unknown ', output
   end
 
-  def test_integer_argument_drop
+  def test_catchall_integer_argument_drop
     output = Liquid::Template.parse(' {{ product.catchall[8] }} ').render!('product' => ProductDrop.new)
-    assert_equal ' method: 8 ', output
+    assert_equal ' catchall_method: 8 ', output
   end
 
   def test_text_array_drop
@@ -231,7 +231,7 @@ class DropsTest < Minitest::Test
     assert_equal '3', Liquid::Template.parse('{{collection.size}}').render!('collection' => EnumerableDrop.new)
   end
 
-  def test_enumerable_drop_will_invoke_before_method_for_clashing_method_names
+  def test_enumerable_drop_will_invoke_liquid_method_missing_for_clashing_method_names
     ["select", "each", "map", "cycle"].each do |method|
       assert_equal method.to_s, Liquid::Template.parse("{{collection.#{method}}}").render!('collection' => EnumerableDrop.new)
       assert_equal method.to_s, Liquid::Template.parse("{{collection[\"#{method}\"]}}").render!('collection' => EnumerableDrop.new)

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'timeout'
 
 class TemplateContextDrop < Liquid::Drop
-  def before_method(method)
+  def liquid_method_missing(method)
     method
   end
 


### PR DESCRIPTION
The method name `before_method` does not reflect the drop invocation behaviour. It will not be called "before" another method that already exists.

At first I wrote this with support for the previous method and fallback mechanism, but that added complexity for no obvious reasons. (we could backport to an earlier version once this is merged if we feel the need to. That would also require us to publish a gem update)