### PR TITLE
Keep original stack trace in Liquid::ArgumentError

### DIFF
--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -52,7 +52,7 @@ module Liquid
         args.first
       end
     rescue ::ArgumentError => e
-      raise Liquid::ArgumentError.new(e.message)
+      raise Liquid::ArgumentError, e.message, e.backtrace
     end
   end
 end

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -29,6 +29,18 @@ class StrainerUnitTest < Minitest::Test
     end
   end
 
+  def test_stainer_argument_error_contains_backtrace
+    strainer = Strainer.create(nil)
+    begin
+      strainer.invoke("public_filter", 1)
+    rescue Liquid::ArgumentError => e
+      assert_match(
+        /\ALiquid error: wrong number of arguments \((1 for 0|given 1, expected 0)\)\z/,
+        e.message)
+      assert_equal e.backtrace[0].split(':')[0], __FILE__
+    end
+  end
+
   def test_strainer_only_invokes_public_filter_methods
     strainer = Strainer.create(nil)
     assert_equal false, strainer.class.invokable?('__test__')


### PR DESCRIPTION
By only reporting the original `ArgumentError`'s `message`, the original backtrace is lost, making it difficult to track down some application errors that sprout up in Liquid. (This happend to me with an error in a `to_liquid` method.)

Presently, the backtrace shows the call stack starting in `Liquid::Strainer#invoke` where `raise` is called inside the `rescue` rather than in the application code where the error actually occurs. This update passes the original backtrace along with the message so it's clear where an error is actually happening.

Ping @fw42 for review.