### PR TITLE
Remove nil and empty string check in invoke_drop.

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -23,8 +23,6 @@ module Liquid
   class Drop
     attr_writer :context
 
-    EMPTY_STRING = ''.freeze
-
     # Catch all for the method
     def liquid_method_missing(_method)
       nil
@@ -32,7 +30,7 @@ module Liquid
 
     # called by liquid to invoke a drop
     def invoke_drop(method_or_key)
-      if method_or_key && method_or_key != EMPTY_STRING && self.class.invokable?(method_or_key)
+      if self.class.invokable?(method_or_key)
         send(method_or_key)
       else
         liquid_method_missing(method_or_key)


### PR DESCRIPTION
@tjoyal & @fw42 for review

The `method_or_key && method_or_key != EMPTY_STRING` checks aren't necessary in invoke_drop, since we now use `Set#include?` instead of `Object#respond_to?` to see if the method is invokable, which doesn't have any problems with `nil` or `""`