### PR TITLE
Test mapping over procs

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -173,7 +173,8 @@ module Liquid
         if property == "to_liquid".freeze
           e
         elsif e.respond_to?(:[])
-          e[property]
+          r = e[property]
+          r.is_a?(Proc) ? r.call : r
         end
       end
     end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -249,6 +249,19 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "testfoo", templ, "procs" => [p]
   end
 
+  def test_map_over_drops_returning_procs
+    drops = [
+      {
+        "proc" => ->{ "foo" },
+      },
+      {
+        "proc" => ->{ "bar" },
+      },
+    ]
+    templ = '{{ drops | map: "proc" }}'
+    assert_template_result "foobar", templ, "drops" => drops
+  end
+
   def test_map_works_on_enumerables
     assert_template_result "123", '{{ foo | map: "foo" }}', "foo" => TestEnumerable.new
   end


### PR DESCRIPTION
Mapping over an array of drops that return procs will return an array of procs. Any other filter after that will operate on the proc. 

Without the patch, the template would render: 

```
"#<Proc:0xXXXXXX@/home/vagrant/src/liquid/test/integration/standard_filter_test.rb:255 (lambda)>#<Proc:0xXXXXXX@/home/vagrant/src/liquid/test/integration/standard_filter_test.rb:258 (lambda)>"
```