### PR TITLE
make file system assignment thread-safe

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -16,8 +16,6 @@ module Liquid
     attr_accessor :root
     attr_reader :resource_limits, :warnings
 
-    @@file_system = BlankFileSystem.new
-
     class TagRegistry
       def initialize
         @tags  = {}
@@ -64,11 +62,11 @@ module Liquid
       attr_writer :taint_mode
 
       def file_system
-        @@file_system
+        Thread.current[:liquid_file_system] ||= BlankFileSystem.new
       end
 
       def file_system=(obj)
-        @@file_system = obj
+        Thread.current[:liquid_file_system] = obj
       end
 
       def register_tag(name, klass)


### PR DESCRIPTION
Had some weird issues with thread safety during multiple requests when assigning custom file system globally via class-level accessor. Solved it eventually by assigning it per instance level when rendering templates, which seems to be the most proper solution, but I think it's good to improve it anyway and make it thread-safe.

@fw42, could you review it?