### PR TITLE
Ensure truncate is operating on a string

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -63,10 +63,11 @@ module Liquid
     # Truncate a string down to x characters
     def truncate(input, length = 50, truncate_string = "...".freeze)
       return if input.nil?
+      input_str = input.to_s
       length = Utils.to_integer(length)
       l = length - truncate_string.length
       l = 0 if l < 0
-      input.length > length ? input[0...l] + truncate_string : input
+      input_str.length > length ? input_str[0...l] + truncate_string : input_str
     end
 
     def truncatewords(input, words = 15, truncate_string = "...".freeze)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -262,6 +262,10 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result 'foobar', '{{ foo | last }}', 'foo' => [ThingWithToLiquid.new]
   end
 
+  def test_truncate_calls_to_liquid
+    assert_template_result "wo...", '{{ foo | truncate: 5 }}', "foo" => TestThing.new
+  end
+
   def test_date
     assert_equal 'May', @filters.date(Time.parse("2006-05-05 10:00:00"), "%B")
     assert_equal 'June', @filters.date(Time.parse("2006-06-05 10:00:00"), "%B")


### PR DESCRIPTION
@fw42 & @dylanahsmith for review

Adds a fix for the truncate filter when it's the first/only filter on a non-string.