### PR TITLE
Install libgmp3-dev in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ rvm:
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+    - libgmp3-dev
+
 matrix:
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
Fixes Liquid-C build. I'm not sure what happened to make this go missing.

cc @fw42 