### PR TITLE
Add strict variable checking

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -13,7 +13,7 @@ module Liquid
   #   context['bob']  #=> nil  class Context
   class Context
     attr_reader :scopes, :errors, :registers, :environments, :resource_limits
-    attr_accessor :exception_handler, :template_name, :partial, :global_filter
+    attr_accessor :exception_handler, :template_name, :partial, :global_filter, :strict_variables
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil)
       @environments     = [environments].flatten
@@ -207,6 +207,8 @@ module Liquid
     def lookup_and_evaluate(obj, key)
       if (value = obj[key]).is_a?(Proc) && obj.respond_to?(:[]=)
         obj[key] = (value.arity == 0) ? value.call : value.call(self)
+      elsif @strict_variables && obj.is_a?(Hash) && !obj.has_key?(key)
+        raise UndefinedVariableError, "The variable '#{key}' is not defined"
       else
         value
       end

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -56,4 +56,5 @@ module Liquid
   MemoryError = Class.new(Error)
   ZeroDivisionError = Class.new(Error)
   FloatDomainError = Class.new(Error)
+  UndefinedVariableError = Class.new(Error)
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -187,7 +187,7 @@ module Liquid
 
         context.exception_handler = options[:exception_handler] if options[:exception_handler]
 
-        context.strict_variables = options[:strict_variables] if options[:strict_variables]
+        context.strict_variables = options[:strict_variables] if options[:strict_variables] && [:warn, :strict].include?(self.class.error_mode)
 
       when Module, Array
         context.add_filters(args.pop)

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -187,6 +187,8 @@ module Liquid
 
         context.exception_handler = options[:exception_handler] if options[:exception_handler]
 
+        context.strict_variables = options[:strict_variables] if options[:strict_variables]
+
       when Module, Array
         context.add_filters(args.pop)
       end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -14,20 +14,23 @@ class VariableTest < Minitest::Test
   end
 
   def test_undefined_variable_with_filter_and_strict_variables
-    template = Template.parse(%@X{{nonexistent|default: 'x'}}X@)
-    assert_raises(UndefinedVariableError) {
-      template.render!({}, strict_variables: true)
-    }
+    with_error_mode :warn do
+      template = Template.parse(%@X{{nonexistent|default: 'x'}}X@)
+      assert_raises(UndefinedVariableError) {
+        template.render!({}, strict_variables: true)
+      }
+    end
   end
 
   def test_undefined_variable_with_strict_variables
-    template = Template.parse(%|X{{nonexistent}}X|)
-    template.render!({'xxx' => 'this is xxx', 'nilvalue' => nil}, strict_variables: false)
+    with_error_mode :strict do
+      template = Template.parse(%@X{{nonexistent}}X@)
 
-    e = assert_raises(UndefinedVariableError) {
-      template.render!({}, strict_variables: true)
-    }
-    assert_equal "Liquid error: The variable 'nonexistent' is not defined", e.message
+      e = assert_raises(UndefinedVariableError) {
+        template.render!({}, strict_variables: true)
+      }
+      assert_equal "Liquid error: The variable 'nonexistent' is not defined", e.message
+    end
   end
 
   def test_simple_variable

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -3,6 +3,33 @@ require 'test_helper'
 class VariableTest < Minitest::Test
   include Liquid
 
+  def test_undefined_variable
+    template = Template.parse(%|X{{nonexistent}}X|)
+    assert_equal 'XX', template.render!
+  end
+
+  def test_undefined_variable_with_filter
+    template = Template.parse(%@X{{nonexistent|default: 'x'}}X@)
+    assert_equal 'XxX', template.render!
+  end
+
+  def test_undefined_variable_with_filter_and_strict_variables
+    template = Template.parse(%@X{{nonexistent|default: 'x'}}X@)
+    assert_raises(UndefinedVariableError) {
+      template.render!({}, strict_variables: true)
+    }
+  end
+
+  def test_undefined_variable_with_strict_variables
+    template = Template.parse(%|X{{nonexistent}}X|)
+    template.render!({'xxx' => 'this is xxx', 'nilvalue' => nil}, strict_variables: false)
+
+    e = assert_raises(UndefinedVariableError) {
+      template.render!({}, strict_variables: true)
+    }
+    assert_equal "Liquid error: The variable 'nonexistent' is not defined", e.message
+  end
+
   def test_simple_variable
     template = Template.parse(%({{test}}))
     assert_equal 'worked', template.render!('test' => 'worked')


### PR DESCRIPTION
Based on https://github.com/bluerail/liquid/tree/strict_variables.

When `Template#render` is called with the `strict_variables: true` option, it will raise an UndefinedVariableException.

It unfortunately does not respect Liquid's `error_mode` option, because Liquid has all its syntax error checking+handling done at parse-time, at which point no variables are define.