### PR TITLE
Add format filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -342,6 +342,30 @@ module Liquid
         input
       end
     end
+    
+        
+    # Format a string with Kernel::format
+    #
+    # input - The format string
+    # args - The arguments to input
+    #
+    # Returns the formatted string
+    def format(input, *args)
+      input.taint
+      args.taint
+      
+      args.each_index {|i| args[i] = (Hash[args[i].map {|k,v| [k.to_sym, v]}]) if args[i].instance_of?(Hash) }
+
+      begin
+        return Kernel::format(input, *args)
+      rescue => exception
+        return Kernel::format "%s: %s", exception.class, exception
+      end
+    end
+
+    def sprintf(input, *args)
+      format(input, *args)
+    end
 
     private
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -342,8 +342,7 @@ module Liquid
         input
       end
     end
-    
-        
+
     # Format a string with Kernel::format
     #
     # input - The format string
@@ -353,13 +352,13 @@ module Liquid
     def format(input, *args)
       input.taint
       args.taint
-      
-      args.each_index {|i| args[i] = (Hash[args[i].map {|k,v| [k.to_sym, v]}]) if args[i].instance_of?(Hash) }
+
+      args.each_index {|i| args[i] = (Hash[args[i].map { |k, v| [k.to_sym, v] }]) if args[i].instance_of?(Hash) }
 
       begin
-        return Kernel::format(input, *args)
+        return Kernel.format(input, *args)
       rescue => exception
-        return Kernel::format "%s: %s", exception.class, exception
+        return Kernel.format "%s: %s", exception.class, exception
       end
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -353,7 +353,7 @@ module Liquid
       input.taint
       args.taint
 
-      args.each_index {|i| args[i] = (Hash[args[i].map { |k, v| [k.to_sym, v] }]) if args[i].instance_of?(Hash) }
+      args.each_index { |i| args[i] = (Hash[args[i].map { |k, v| [k.to_sym, v] }]) if args[i].instance_of?(Hash) }
 
       begin
         return Kernel.format(input, *args)


### PR DESCRIPTION
Can't think of a use case for it, admittedly, but I wrote it last year and it'd be a shame to see it go to waste.  I suppose it's useful for edge cases where you need to output something in a format that can't be represented with current Liquid filters, but you can't write your own (either because you're in a constrained environment like GitHub Pages or you just don't know Ruby).

Also, fix #567
