### PR TITLE
Adds hmac_sha256

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'bigdecimal'
+require 'openssl'
 
 module Liquid
   module StandardFilters
@@ -333,6 +334,12 @@ module Liquid
       Utils.to_number(input).floor.to_i
     rescue ::FloatDomainError => e
       raise Liquid::FloatDomainError, e.message
+    end
+
+    def hmac_sha256(input, secret)
+      return nil if input.nil? || secret.nil?
+      digest = OpenSSL::Digest.new('sha256')
+      OpenSSL::HMAC.hexdigest(digest, secret, input)
     end
 
     def default(input, default_value = ''.freeze)

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -131,6 +131,12 @@ class FiltersTest < Minitest::Test
     assert_equal "Blub", Template.parse("{{ var | capitalize }}").render(@context)
   end
 
+  def test_hmac_sha256
+    @context['var'] = "foo"
+
+    assert_equal "773ba44693c7553d6ee20f61ea5d2757a9a4f4a44d2841ae4e95b52e4cd62db4", Template.parse("{{ var | hmac_sha256: 'secret' }}").render(@context)
+  end
+
   def test_nonexistent_filter_is_ignored
     @context['var'] = 1000
 


### PR DESCRIPTION
We would like to use Shopify proxies to generate authentication codes as a security feature.