### PR TITLE
Strainer#add_filter Raises on Private Override

### DIFF
--- a/History.md
+++ b/History.md
@@ -18,6 +18,7 @@
 * Ruby 1.9 support dropped (#491) [Justin Li]
 * Liquid::Template.file_system's read_template_file method is no longer passed the context. (#441) [James Reid-Smith]
 * Remove support for `liquid_methods`
+* Liquid::Template.register_filter raises when the module overrides registered public methods as private or protected (#705) [Gaurav Chande]
 
 ### Fixed
 * Fix map filter when value is a Proc (#672) [Guillaume Malette]

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -59,4 +59,5 @@ module Liquid
   UndefinedVariable = Class.new(Error)
   UndefinedDropMethod = Class.new(Error)
   UndefinedFilter = Class.new(Error)
+  MethodOverrideError = Class.new(Error)
 end

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -28,9 +28,9 @@ module Liquid
     def self.add_filter(filter)
       raise ArgumentError, "Expected module but got: #{filter.class}" unless filter.is_a?(Module)
       unless self.class.include?(filter)
-        invokable_private_methods = filter.private_instance_methods.select { |m| invokable?(m) }
-        if invokable_private_methods.any?
-          raise MethodOverrideError, "Filter overrides registered public methods as private: #{invokable_private_methods.join(', ')}"
+        invokable_non_public_methods = (filter.private_instance_methods + filter.protected_instance_methods).select { |m| invokable?(m) }
+        if invokable_non_public_methods.any?
+          raise MethodOverrideError, "Filter overrides registered public methods as non public: #{invokable_non_public_methods.join(', ')}"
         else
           send(:include, filter)
           @filter_methods.merge(filter.public_instance_methods.map(&:to_s))

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -28,8 +28,13 @@ module Liquid
     def self.add_filter(filter)
       raise ArgumentError, "Expected module but got: #{filter.class}" unless filter.is_a?(Module)
       unless self.class.include?(filter)
-        send(:include, filter)
-        @filter_methods.merge(filter.public_instance_methods.map(&:to_s))
+        invokable_private_methods = filter.private_instance_methods.select { |m| invokable?(m) }
+        if invokable_private_methods.any?
+          raise MethodOverrideError, "Filter overrides registered public methods as private: #{invokable_private_methods.join(', ')}"
+        else
+          send(:include, filter)
+          @filter_methods.merge(filter.public_instance_methods.map(&:to_s))
+        end
       end
     end
 

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -87,4 +87,33 @@ class StrainerUnitTest < Minitest::Test
       s.class.add_filter(wrong_filter)
     end
   end
+
+  module PrivateMethodOverrideFilter
+    private
+
+    def public_filter
+      "overriden as private"
+    end
+  end
+
+  def test_add_filter_raises_when_module_privately_overrides_registered_public_methods
+    strainer = Context.new.strainer
+
+    error = assert_raises(Liquid::MethodOverrideError) do
+      strainer.class.add_filter(PrivateMethodOverrideFilter)
+    end
+    assert_equal 'Liquid error: Filter overrides registered public methods as private: public_filter', error.message
+  end
+
+  module PublicMethodOverrideFilter
+    def public_filter
+      "public"
+    end
+  end
+
+  def test_add_filter_does_not_raise_when_module_overrides_previously_registered_method
+    strainer = Context.new.strainer
+    strainer.class.add_filter(PublicMethodOverrideFilter)
+    assert strainer.class.filter_methods.include?('public_filter')
+  end
 end # StrainerTest

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -102,7 +102,24 @@ class StrainerUnitTest < Minitest::Test
     error = assert_raises(Liquid::MethodOverrideError) do
       strainer.class.add_filter(PrivateMethodOverrideFilter)
     end
-    assert_equal 'Liquid error: Filter overrides registered public methods as private: public_filter', error.message
+    assert_equal 'Liquid error: Filter overrides registered public methods as non public: public_filter', error.message
+  end
+
+  module ProtectedMethodOverrideFilter
+    protected
+
+    def public_filter
+      "overriden as protected"
+    end
+  end
+
+  def test_add_filter_raises_when_module_overrides_registered_public_method_as_protected
+    strainer = Context.new.strainer
+
+    error = assert_raises(Liquid::MethodOverrideError) do
+      strainer.class.add_filter(ProtectedMethodOverrideFilter)
+    end
+    assert_equal 'Liquid error: Filter overrides registered public methods as non public: public_filter', error.message
   end
 
   module PublicMethodOverrideFilter


### PR DESCRIPTION
#### Issue

We had an issue [in Shopify core](https://github.com/Shopify/shopify/pull/65328#discussion_r53879658) wherein filter module `A` had a private method with the same name as a public method of a registered filter module `B`. `A` was registered after `B` so this meant that the public filter's definition changed internally. This is kind of scary so `Strainer` should protect against it.

#### Solution

This makes it so that a filter module cannot incorrectly override (`Strainer` raises `MethodOverrideError`) a registered method as private.

@fw42 @pushrax cc @Thibaut