### PR TITLE
Use start_with? instead of Regex

### DIFF
--- a/lib/liquid/file_system.rb
+++ b/lib/liquid/file_system.rb
@@ -65,7 +65,7 @@ module Liquid
         File.join(root, @pattern % template_path)
       end
 
-      raise FileSystemError, "Illegal template path '#{File.expand_path(full_path)}'" unless File.expand_path(full_path) =~ /\A#{File.expand_path(root)}/
+      raise FileSystemError, "Illegal template path '#{File.expand_path(full_path)}'" unless File.expand_path(full_path).start_with?(File.expand_path(root))
 
       full_path
     end


### PR DESCRIPTION
Performance is increased by doing this:
``` ruby
require 'benchmark'
require 'tempfile'

n = 50000
test = File.expand_path(Tempfile.new('foo'))
Benchmark.bm(20) do |x|
  x.report("Regex:") do
    n.times { test =~ /\A#{test}/ }
  end
  x.report("String#start_with?:") do
    n.times { test =~ test.start_with?(test) }
  end
end
```
Benchmark result:
```
                             user     system      total        real
  Regex:                 0.440000   0.010000   0.450000 (  0.447357)
  String#start_with?:    0.000000   0.000000   0.000000 (  0.006313)
```