### PR TITLE
Duck typed maths filters

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -52,7 +52,11 @@ module Liquid
       when String
         (obj.strip =~ /\A\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
       else
-        0
+        if obj.respond_to?(:to_number)
+          obj.to_number
+        else
+          0
+        end
       end
     end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -41,6 +41,16 @@ class TestEnumerable < Liquid::Drop
   end
 end
 
+class NumberLikeThing < Liquid::Drop
+  def initialize(amount)
+    @amount = amount
+  end
+
+  def to_number
+    @amount
+  end
+end
+
 class StandardFiltersTest < Minitest::Test
   include Liquid
 
@@ -391,6 +401,8 @@ class StandardFiltersTest < Minitest::Test
     assert_raises(Liquid::ZeroDivisionError) do
       assert_template_result "4", "{{ 1 | modulo: 0 }}"
     end
+
+    assert_template_result "5", "{{ price | divided_by:2 }}", 'price' => NumberLikeThing.new(10)
   end
 
   def test_modulo

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -374,11 +374,15 @@ class StandardFiltersTest < Minitest::Test
   def test_plus
     assert_template_result "2", "{{ 1 | plus:1 }}"
     assert_template_result "2.0", "{{ '1' | plus:'1.0' }}"
+
+    assert_template_result "5", "{{ price | plus:'2' }}", 'price' => NumberLikeThing.new(3)
   end
 
   def test_minus
     assert_template_result "4", "{{ input | minus:operand }}", 'input' => 5, 'operand' => 1
     assert_template_result "2.3", "{{ '4.3' | minus:'2' }}"
+
+    assert_template_result "5", "{{ price | minus:'2' }}", 'price' => NumberLikeThing.new(7)
   end
 
   def test_times
@@ -388,6 +392,8 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "6", "{{ '2.1' | times:3 | replace: '.','-' | plus:0}}"
 
     assert_template_result "7.25", "{{ 0.0725 | times:100 }}"
+
+    assert_template_result "4", "{{ price | times:2 }}", 'price' => NumberLikeThing.new(2)
   end
 
   def test_divided_by
@@ -410,6 +416,8 @@ class StandardFiltersTest < Minitest::Test
     assert_raises(Liquid::ZeroDivisionError) do
       assert_template_result "4", "{{ 1 | modulo: 0 }}"
     end
+
+    assert_template_result "1", "{{ price | modulo:2 }}", 'price' => NumberLikeThing.new(3)
   end
 
   def test_round
@@ -419,6 +427,9 @@ class StandardFiltersTest < Minitest::Test
     assert_raises(Liquid::FloatDomainError) do
       assert_template_result "4", "{{ 1.0 | divided_by: 0.0 | round }}"
     end
+
+    assert_template_result "5", "{{ price | round }}", 'price' => NumberLikeThing.new(4.6)
+    assert_template_result "4", "{{ price | round }}", 'price' => NumberLikeThing.new(4.3)
   end
 
   def test_ceil
@@ -427,6 +438,8 @@ class StandardFiltersTest < Minitest::Test
     assert_raises(Liquid::FloatDomainError) do
       assert_template_result "4", "{{ 1.0 | divided_by: 0.0 | ceil }}"
     end
+
+    assert_template_result "5", "{{ price | ceil }}", 'price' => NumberLikeThing.new(4.6)
   end
 
   def test_floor
@@ -435,6 +448,8 @@ class StandardFiltersTest < Minitest::Test
     assert_raises(Liquid::FloatDomainError) do
       assert_template_result "4", "{{ 1.0 | divided_by: 0.0 | floor }}"
     end
+
+    assert_template_result "5", "{{ price | floor }}", 'price' => NumberLikeThing.new(5.4)
   end
 
   def test_append


### PR DESCRIPTION
## What

Allow maths filters to work with objects that respond to `#to_number` as well as things that can be coerced into numbers.

## Why

So I can design my own complex types or Drops that can work with maths filters.

## How

If an object responds to `#to_number`, it will be used by `Utils.to_number` when coercing values.

An example:

```ruby
class PriceDrop < Liquid::Drop
  def initialize(amount, currency_symbol)
    @amount, @currency_symbol = product_price, currency_symbol
  end

  def formatted
    "#{@currency_symbol}#{@amount}"
  end

  # .. etc, other methods here

  # this makes it work with Liquid's maths filters
  def to_number
    @amount
  end
end
```

Now it can be used with maths filters

```ruby
price = PriceDrop.new(1000.0, '$')
template = Liquid::Template.parse("net total: {{ price.formatted }}. Tax: {{ price | times: 0.19 }}")
template.render('price' => price) # => "net total: $1000.0. Tax: 190"
```

## Notes / questions

* Standard text filters already use duck typing (by calling `#to_s` on the object), but `Utils.to_number`, used to coerce values in maths filters, does not. I am not sure whether or not this limitation is by design / security reasons, so I'm putting this here up for discussion.
* I went with `#to_number` instead of a more conventional `#to_i` or `#to_f` to avoid accidental coercion (as many types in Ruby-land implement those) and also to mirror `Utils.to_number`. Please advice if this is not a good idea.
