### PR TITLE
Raise a Liquid::Error when a non-array is passed into the concat filter.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -216,6 +216,9 @@ module Liquid
     end
 
     def concat(input, array)
+      unless array.respond_to?(:to_ary)
+        raise ArgumentError.new("concat filter requires an array argument")
+      end
       InputIterator.new(input).concat(array)
     end
 
@@ -370,7 +373,7 @@ module Liquid
       end
 
       def concat(args)
-        to_a.concat args
+        to_a.concat(args)
       end
 
       def reverse

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -463,8 +463,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal [1, 2, 'a'],  @filters.concat([1, 2], ['a'])
     assert_equal [1, 2, 10],   @filters.concat([1, 2], [10])
 
-    assert_raises(TypeError) do
-      # no implicit conversion of Fixnum into Array
+    assert_raises(Liquid::ArgumentError, "concat filter requires an array argument") do
       @filters.concat([1, 2], 10)
     end
   end


### PR DESCRIPTION
@tjoyal & @pushrax for review

## Problem

Passing a non-array as an argument to the concat filter causes a TypeError to be raised, however, it should have been a Liquid::Error exceptions since it is a bug in the liquid template that shouldn't be reported as an internal error.

## Solution

Explicitly raise the error rather as a Liquid::ArgumentError.