### PR TITLE
Fix to_number filter for negative float strings

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -50,7 +50,7 @@ module Liquid
       when Numeric
         obj
       when String
-        (obj.strip =~ /\A\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
+        (obj.strip =~ /\A-?\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
       else
         if obj.respond_to?(:to_number)
           obj.to_number

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -388,11 +388,10 @@ class StandardFiltersTest < Minitest::Test
   def test_times
     assert_template_result "12", "{{ 3 | times:4 }}"
     assert_template_result "0", "{{ 'foo' | times:4 }}"
-
     assert_template_result "6", "{{ '2.1' | times:3 | replace: '.','-' | plus:0}}"
-
     assert_template_result "7.25", "{{ 0.0725 | times:100 }}"
-
+    assert_template_result "-7.25", '{{ "-0.0725" | times:100 }}'
+    assert_template_result "7.25", '{{ "-0.0725" | times: -100 }}'
     assert_template_result "4", "{{ price | times:2 }}", 'price' => NumberLikeThing.new(2)
   end
 


### PR DESCRIPTION
## Before

`{{ "-6.5" | times: -1 }}` returns 6

## After

`{{ "-6.5" | times: -1 }}` returns 6.5.

@pushrax @dylanahsmith @admhlt @freakdesign 