### PR TITLE
Abs filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -289,6 +289,12 @@ module Liquid
       array.last if array.respond_to?(:last)
     end
 
+    # absolute value
+    def abs(input)
+      result = Utils.to_number(input).abs
+      result.is_a?(BigDecimal) ? result.to_f : result
+    end
+
     # addition
     def plus(input, operand)
       apply_operation(input, operand, :+)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -385,6 +385,19 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "5", "{{ price | minus:'2' }}", 'price' => NumberLikeThing.new(7)
   end
 
+  def test_abs
+    assert_template_result "17", "{{ 17 | abs }}"
+    assert_template_result "17", "{{ -17 | abs }}"
+    assert_template_result "17", "{{ '17' | abs }}"
+    assert_template_result "17", "{{ '-17' | abs }}"
+    assert_template_result "0", "{{ 0 | abs }}"
+    assert_template_result "0", "{{ '0' | abs }}"
+    assert_template_result "17.42", "{{ 17.42 | abs }}"
+    assert_template_result "17.42", "{{ -17.42 | abs }}"
+    assert_template_result "17.42", "{{ '17.42' | abs }}"
+    assert_template_result "17.42", "{{ '-17.42' | abs }}"
+  end
+
   def test_times
     assert_template_result "12", "{{ 3 | times:4 }}"
     assert_template_result "0", "{{ 'foo' | times:4 }}"


### PR DESCRIPTION
The `abs` filter returns the absolute value of a number (i.e. the number itself if it's non-negative and -1 times the number if it's negative).

@pushrax @dylanahsmith @admhlt @freakdesign 