### PR TITLE
Improve BlockBody#render performance

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -53,7 +53,7 @@ module Liquid
     end
 
     def render(context)
-      output = []
+      output = ""
       context.resource_limits.render_score += @nodelist.length
 
       @nodelist.each do |token|
@@ -64,7 +64,7 @@ module Liquid
           # If we get an Interrupt that means the block must stop processing. An
           # Interrupt is any command that stops block execution such as {% break %}
           # or {% continue %}
-          if token.is_a?(Continue) || token.is_a?(Break)
+          if token.class == Continue || token.class == Break
             context.push_interrupt(token.interrupt)
             break
           end
@@ -78,13 +78,12 @@ module Liquid
           raise e
         rescue UndefinedVariable, UndefinedDropMethod, UndefinedFilter => e
           context.handle_error(e, token.line_number)
-          output << nil
         rescue ::StandardError => e
           output << context.handle_error(e, token.line_number)
         end
       end
 
-      output.join
+      output
     end
 
     private
@@ -97,6 +96,7 @@ module Liquid
       if context.resource_limits.reached?
         raise MemoryError.new("Memory limits exceeded".freeze)
       end
+
       node_output
     end
 


### PR DESCRIPTION
Using the benchmark script from https://github.com/Shopify/liquid/issues/678, on my machine this gives a ~10% performance improvement in that code path (rendering `for`loops with many iterations). I guess mostly due to avoiding the `Array#join`.

@pushrax @dylanahsmith @KnVerey 