### PR TITLE
[Docs] Adds a11y landmarks

### DIFF
--- a/_includes/home-banner.html
+++ b/_includes/home-banner.html
@@ -1,8 +1,8 @@
-<header class="home-banner">
+<div class="home-banner">
   <h1>Liquid</h1>
   <p>Safe, customer facing template language for flexible web apps.</p>
   <p class="btn-row">
     <a href="https://github.com/Shopify/liquid/archive/master.zip" target="_blank" class="btn"><i class="icon fa fa-2x fa-arrow-circle-down" aria-hidden="true"></i>Download</a>
-    <a href="https://github.com/Shopify/liquid" target="_blank" class="btn" aria-hidden="true"><i class="icon fa fa-2x fa-github"></i>View on GitHub</a>
+    <a href="https://github.com/Shopify/liquid" target="_blank" class="btn"><i class="icon fa fa-2x fa-github" aria-hidden="true"></i>View on GitHub</a>
   </p>
-</header>
+</div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,5 @@
 <div class="sidebar">
-  <header class="sidebar__logo">
+  <header class="sidebar__logo" role="banner">
     <a href="{{ "/" | prepend: site.baseurl }}">Liquid</a>
   </header>
   <nav class="sidebar__nav"> {% assign sections = "basics, tags, filters" | split: ", " %}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <div class="sidebar">
-  <div class="sidebar__logo">
+  <header class="sidebar__logo">
     <a href="{{ "/" | prepend: site.baseurl }}">Liquid</a>
-  </div>
+  </header>
   <nav class="sidebar__nav"> {% assign sections = "basics, tags, filters" | split: ", " %}
 
     {% for section in sections %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
     {% include sidebar.html %}
 
     <div class="content__overlay"></div>
-    <div class="content__area">
+    <main class="content__area" role="main">
       <div class="content">
         <button class="menu-button">
           <i class="icon fa fa-2x fa-bars" aria-hidden="true"></i>
@@ -29,7 +29,7 @@
         <h1>{{ page.title }}</h1>
         {{ content }}
       </div>
-    </div>
+    </main>
   </body>
   <script src="{{ '/js/script.js' | prepend: site.baseurl }}"></script>
 </html>


### PR DESCRIPTION
Addresses part of https://github.com/Shopify/liquid/issues/720. 

Adds ARIA landmarks to sidebar, banner, and main content area for easier screen reader navigation. 

@fw42 @admhlt @parkr 