### PR TITLE
Add code labels for abs filter

### DIFF
--- a/filters/abs.md
+++ b/filters/abs.md
@@ -4,34 +4,40 @@ title: abs
 
 Returns the absolute value of a number.
 
+<p class="code-label">Input</p>
 ```liquid
 {% raw %}
 {{ -17 | abs }}
 {% endraw %}
 ```
 
+<p class="code-label">Output</p>
 ```text
 17
 ```
 
+<p class="code-label">Input</p>
 ```liquid
 {% raw %}
 {{ 4 | abs }}
 {% endraw %}
 ```
 
+<p class="code-label">Output</p>
 ```text
 4
 ```
 
 `abs` will also work on a string if the string only contains a number.
 
+<p class="code-label">Input</p>
 ```liquid
 {% raw %}
 {{ "-19.86" | abs }}
 {% endraw %}
 ```
 
+<p class="code-label">Output</p>
 ```text
 19.86
 ```


### PR DESCRIPTION
This just adds the fancy code labels to the new code blocks for the `abs` filter.