### PR TITLE
Make Template.tags loop-able

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -19,6 +19,8 @@ module Liquid
     @@file_system = BlankFileSystem.new
 
     class TagRegistry
+      include Enumerable
+
       def initialize
         @tags = {}
         @cache = {}
@@ -39,6 +41,10 @@ module Liquid
       def delete(tag_name)
         @tags.delete(tag_name)
         @cache.delete(tag_name)
+      end
+
+      def each(&block)
+        @tags.each(&block)
       end
 
       private

--- a/test/unit/block_unit_test.rb
+++ b/test/unit/block_unit_test.rb
@@ -46,6 +46,8 @@ class BlockUnitTest < Minitest::Test
   def test_with_custom_tag
     Liquid::Template.register_tag("testtag", Block)
     assert Liquid::Template.parse("{% testtag %} {% endtesttag %}")
+  ensure
+    Liquid::Template.tags.delete('testtag')
   end
 
   private

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -72,5 +72,7 @@ class TemplateUnitTest < Minitest::Test
     Template.register_tag('fake', FakeTag)
     result = Template.tags.map { |name, klass| [name, klass] }
     assert result.include?(["fake", "TemplateUnitTest::FakeTag"])
+  ensure
+    Template.tags.delete('fake')
   end
 end

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -67,4 +67,10 @@ class TemplateUnitTest < Minitest::Test
     Template.tags.delete('fake')
     assert_nil Template.tags['fake']
   end
+
+  def test_tags_can_be_looped_over
+    Template.register_tag('fake', FakeTag)
+    result = Template.tags.map { |name, klass| [name, klass] }
+    assert result.include?(["fake", "TemplateUnitTest::FakeTag"])
+  end
 end


### PR DESCRIPTION
This makes it so that you can get all registered template tags by looping over them. This is a small followup to [an older PR](https://github.com/Shopify/liquid/pull/590) that made it possible to have custom tag registry for a custom liquid document. Reason for this change is that in our most recent implementation of section liquid template (Please see [this comment](https://github.com/Shopify/shopify/pull/68815#discussion_r59066058) for more.), we want the parsing step to recognize existing tags + few new tags specific to section template.

@dylanahsmith @pushrax cc @Thibaut 