### PR TITLE
Restore the down arrow in vertical scroll bar

### DIFF
--- a/_sass/modules/_layout.scss
+++ b/_sass/modules/_layout.scss
@@ -90,7 +90,7 @@ body {
 .sidebar__nav {
   padding: $spacing-unit $spacing-unit ($spacing-unit + $logo-height); // Add a bit more padding at the bottom for consistency.
   font-weight: bold;
-  max-height: 100%;
+  max-height: calc(100% - #{$logo-height});
   overflow-y: scroll;
 
   li {


### PR DESCRIPTION
Assigning `100%` to max-height property of sidebar navigation element prevents the browser from displaying the scroll down arrow in this widget… The height of the logo must be subtracted from this value.
