### PR TITLE
Support Range Type

### DIFF
--- a/lib/liquid/extensions.rb
+++ b/lib/liquid/extensions.rb
@@ -25,6 +25,12 @@ class Numeric # :nodoc:
   end
 end
 
+class Range # :nodoc:
+  def to_liquid
+    self
+  end
+end
+
 class Time # :nodoc:
   def to_liquid
     self

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -306,4 +306,14 @@ class TemplateTest < Minitest::Test
       t.render!({ 'x' => 'foo' }, { strict_filters: true })
     end
   end
+
+  def test_using_range_literal_works_as_expected
+    t = Template.parse("{% assign foo = (x..y) %}{{ foo }}")
+    result = t.render({ 'x' => 1, 'y' => 5 })
+    assert_equal '1..5', result
+
+    t = Template.parse("{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}")
+    result = t.render({ 'x' => 1, 'y' => 5 })
+    assert_equal '12345', result
+  end
 end


### PR DESCRIPTION
Fixes [such issues](https://github.com/Shopify/shopify/issues/67060) in Shopify which cause range literals in liquid templates to blow up.

@dylanahsmith @fw42 