### PR TITLE
Examples for second parameter of truncate

### DIFF
--- a/filters/truncate.md
+++ b/filters/truncate.md
@@ -15,3 +15,37 @@ title: truncate
 ```text
 {{ "Ground control to Major Tom." | truncate: 20 }}
 ```
+
+### Custom ellipsis
+
+`truncate` takes an optional second parameter that specifies the sequence of characters to be appended to the truncated string. By default this is an ellipsis (...), but you can specify a different sequence.
+
+The length of the second parameter counts against the number of characters specified by the first parameter. For example, if you want to truncate a string to exactly 10 characters, and use a 3-character ellipsis, use **13** for the first parameter of `truncate`, since the ellipsis counts as 3 characters.
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ "Ground control to Major Tom." | truncate: 25, ", and so on" }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ "Ground control to Major Tom." | truncate: 25, ", and so on" }}
+```
+
+### No ellipsis
+
+You can truncate to the exact number of characters specified by the first parameter and show no trailing characters by passing a blank string as the second parameter:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ "Ground control to Major Tom." | truncate: 20, "" }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ "Ground control to Major Tom." | truncate: 20, "" }}
+```

--- a/filters/truncatewords.md
+++ b/filters/truncatewords.md
@@ -15,3 +15,35 @@ Shortens a string down to the number of words passed as the argument. If the spe
 ```text
 {{ "Ground control to Major Tom." | truncatewords: 3 }}
 ```
+
+### Custom ellipsis
+
+`truncatewords` takes an optional second parameter that specifies the sequence of characters to be appended to the truncated string. By default this is an ellipsis (...), but you can specify a different sequence.
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ "Ground control to Major Tom." | truncatewords: 3, "--" }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ "Ground control to Major Tom." | truncatewords: 3, "--" }}
+```
+
+### No ellipsis
+
+You can avoid showing trailing characters by passing a blank string as the second parameter:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ "Ground control to Major Tom." | truncatewords: 3, "" }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ "Ground control to Major Tom." | truncatewords: 3, "" }}
+```


### PR DESCRIPTION
This adds usage examples for the second parameter of `truncate` and `truncatewords`.

cc @fw42 @Tetsuro 