### PR TITLE
Better explanation of divided_by filter

### DIFF
--- a/filters/divided_by.md
+++ b/filters/divided_by.md
@@ -4,40 +4,100 @@ title: divided_by
 
 Divides a number by the specified number.
 
-The result is rounded down to the nearest integer (that is, the [floor]({{ "/filters/floor" | prepend: site.baseurl }})).
+The result is rounded down to the nearest integer (that is, the [floor]({{ "/filters/floor" | prepend: site.baseurl }})) if the divisor is an integer.
 
 <p class="code-label">Input</p>
-```liquid
 {% raw %}
-{{ 4 | divided_by: 2 }}
-{% endraw %}
-```
-
-<p class="code-label">Output</p>
-```text
-{{ 4 | divided_by: 2 }}
-```
-
-<p class="code-label">Input</p>
-```liquid
-{% raw %}
+``` liquid
 {{ 16 | divided_by: 4 }}
-{% endraw %}
 ```
+{% endraw %}
 
 <p class="code-label">Output</p>
-```text
+``` text
 {{ 16 | divided_by: 4 }}
 ```
 
 <p class="code-label">Input</p>
-```liquid
 {% raw %}
+``` liquid
 {{ 5 | divided_by: 3 }}
-{% endraw %}
 ```
+{% endraw %}
 
 <p class="code-label">Output</p>
-```text
+``` text
 {{ 5 | divided_by: 3 }}
+```
+
+### Controlling rounding
+
+`divided_by` produces a result of the same type as the divisor — that is, if you divide by an integer, the result will be an integer. If you divide by a float (a number with a decimal in it), the result will be a float.
+
+For example, here the divisor is an integer:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ 20 | divided_by: 7 }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ 20 | divided_by: 7 }}
+```
+
+Here it is a float:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{{ 20 | divided_by: 7.0 }}
+```
+{% endraw %}
+
+<p class="code-label">Output</p>
+``` text
+{{ 20 | divided_by: 7.0 }}
+```
+
+### Changing variable types
+
+You might want to use a variable as a divisor, in which case you can't simply add `.0` to convert it to a float. In these cases, you can `assign` a version of your variable converted to a float using the `times` filter:
+
+In this example, we're dividing by a variable that contains an integer, so we get an integer:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{% assign my_integer = 7 %}
+{{ 20 | divided_by: my_integer }}
+```
+{% endraw %}
+
+
+<p class="code-label">Output</p>
+``` text
+{% assign my_integer = 7 %}
+{{ 20 | divided_by: my_integer }}
+```
+
+Here, we [multiply]({{ site.baseurl}}/filters/times) the variable by `1.0` to get a float, then divide by the float instead:
+
+<p class="code-label">Input</p>
+{% raw %}
+``` liquid
+{% assign my_integer = 7 %}
+{% assign my_float = my_integer | times: 1.0 %}
+{{ 20 | divided_by: my_float }}
+```
+{% endraw %}
+
+
+<p class="code-label">Output</p>
+``` text
+{% assign my_integer = 7 %}
+{% assign my_float = my_integer | times: 1.0 %}
+{{ 20 | divided_by: my_float }}
 ```

--- a/filters/divided_by.md
+++ b/filters/divided_by.md
@@ -4,7 +4,7 @@ title: divided_by
 
 Divides a number by the specified number.
 
-The result is rounded down to the nearest integer (that is, the [floor]({{ "/filters/floor" | prepend: site.baseurl }})) if the divisor is an integer.
+The result is rounded down to the nearest integer (that is, the [floor]({{ site.baseurl }}/filters/floor)) if the divisor is an integer.
 
 <p class="code-label">Input</p>
 {% raw %}
@@ -76,7 +76,6 @@ In this example, we're dividing by a variable that contains an integer, so we ge
 ```
 {% endraw %}
 
-
 <p class="code-label">Output</p>
 ``` text
 {% assign my_integer = 7 %}
@@ -93,7 +92,6 @@ Here, we [multiply]({{ site.baseurl}}/filters/times) the variable by `1.0` to ge
 {{ 20 | divided_by: my_float }}
 ```
 {% endraw %}
-
 
 <p class="code-label">Output</p>
 ``` text

--- a/filters/divided_by.md
+++ b/filters/divided_by.md
@@ -64,7 +64,7 @@ Here it is a float:
 
 ### Changing variable types
 
-You might want to use a variable as a divisor, in which case you can't simply add `.0` to convert it to a float. In these cases, you can `assign` a version of your variable converted to a float using the `times` filter:
+You might want to use a variable as a divisor, in which case you can't simply add `.0` to convert it to a float. In these cases, you can `assign` a version of your variable converted to a float using the `times` filter.
 
 In this example, we're dividing by a variable that contains an integer, so we get an integer:
 


### PR DESCRIPTION
This provides a bunch more examples of the `divided_by` filter, including (an attempt at) an explanation of the way the filter's result is converted to the type (integer or float) of the divisor. This has confused a bunch of Shopify merchants so I figured it would be a good thing to break down further.

There's a new section about number conversion and another one explaining how to control conversion when the divisor is a variable.

cc @Tetsuro 