### PR TITLE
Add whitespace control character and associated tests

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -24,6 +24,7 @@ module Liquid
   ArgumentSeparator           = ','.freeze
   FilterArgumentSeparator     = ':'.freeze
   VariableAttributeSeparator  = '.'.freeze
+  WhitespaceControl           = '-'.freeze
   TagStart                    = /\{\%/
   TagEnd                      = /\%\}/
   VariableSignature           = /\(?[\w\-\.\[\]]\)?/
@@ -34,7 +35,7 @@ module Liquid
   QuotedString                = /"[^"]*"|'[^']*'/
   QuotedFragment              = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
   TagAttributes               = /(\w+)\s*\:\s*(#{QuotedFragment})/o
-  AnyStartingTag              = /\{\{|\{\%/
+  AnyStartingTag              = /#{TagStart}|#{VariableStart}/o
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -56,10 +56,9 @@ module Liquid
 
     def whitespace_handler(token, parse_context)
       if token[2] == WhitespaceControl
-        previous_token = @nodelist.pop
+        previous_token = @nodelist.last
         if previous_token.is_a? String
           previous_token.rstrip!
-          @nodelist << previous_token
         end
       end
       parse_context.trim_whitespace = (token[-3] == WhitespaceControl)

--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -1,6 +1,6 @@
 module Liquid
   class ParseContext
-    attr_accessor :locale, :line_number
+    attr_accessor :locale, :line_number, :trim_whitespace
     attr_reader :partial, :warnings, :error_mode
 
     def initialize(options = {})

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -97,6 +97,22 @@ class ErrorHandlingTest < Minitest::Test
     assert_match(/Liquid syntax error \(line 4\)/, err.message)
   end
 
+  def test_with_line_numbers_adds_numbers_to_parser_errors_with_whitespace_trim
+    err = assert_raises(SyntaxError) do
+      Liquid::Template.parse(%q(
+          foobar
+
+          {%- "cat" | foobar -%}
+
+          bla
+        ),
+        line_numbers: true
+      )
+    end
+
+    assert_match(/Liquid syntax error \(line 4\)/, err.message)
+  end
+
   def test_parsing_warn_with_line_numbers_adds_numbers_to_lexer_errors
     template = Liquid::Template.parse('
         foobar

--- a/test/integration/trim_mode_test.rb
+++ b/test/integration/trim_mode_test.rb
@@ -1,0 +1,525 @@
+require 'test_helper'
+
+class TrimModeTest < Minitest::Test
+  include Liquid
+
+  # Make sure the trim isn't applied to standard output
+  def test_standard_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{ 'John' }}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          John
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_variable_output_with_multiple_blank_lines
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+
+
+          {{- 'John' -}}
+
+
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>John</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_tag_output_with_multiple_blank_lines
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+
+
+          {%- if true -%}
+          yes
+          {%- endif -%}
+
+
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>yes</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  # Make sure the trim isn't applied to standard tags
+  def test_standard_tags
+    whitespace = '          '
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if true %}
+          yes
+          {% endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+#{whitespace}
+          yes
+#{whitespace}
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if false %}
+          no
+          {% endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+#{whitespace}
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  # Make sure the trim isn't too agressive
+  def test_no_trim_output
+    text = '<p>{{- \'John\' -}}</p>'
+    expected = '<p>John</p>'
+    assert_template_result(expected, text)
+  end
+
+  # Make sure the trim isn't too agressive
+  def test_no_trim_tags
+    text = '<p>{%- if true -%}yes{%- endif -%}</p>'
+    expected = '<p>yes</p>'
+    assert_template_result(expected, text)
+
+    text = '<p>{%- if false -%}no{%- endif -%}</p>'
+    expected = '<p></p>'
+    assert_template_result(expected, text)
+  end
+
+  def test_single_line_outer_tag
+    text = '<p> {%- if true %} yes {% endif -%} </p>'
+    expected = '<p> yes </p>'
+    assert_template_result(expected, text)
+
+    text = '<p> {%- if false %} no {% endif -%} </p>'
+    expected = '<p></p>'
+    assert_template_result(expected, text)
+  end
+
+  def test_single_line_inner_tag
+    text = '<p> {% if true -%} yes {%- endif %} </p>'
+    expected = '<p> yes </p>'
+    assert_template_result(expected, text)
+
+    text = '<p> {% if false -%} no {%- endif %} </p>'
+    expected = '<p>  </p>'
+    assert_template_result(expected, text)
+  end
+
+  def test_single_line_post_tag
+    text = '<p> {% if true -%} yes {% endif -%} </p>'
+    expected = '<p> yes </p>'
+    assert_template_result(expected, text)
+
+    text = '<p> {% if false -%} no {% endif -%} </p>'
+    expected = '<p> </p>'
+    assert_template_result(expected, text)
+  end
+
+  def test_single_line_pre_tag
+    text = '<p> {%- if true %} yes {%- endif %} </p>'
+    expected = '<p> yes </p>'
+    assert_template_result(expected, text)
+
+    text = '<p> {%- if false %} no {%- endif %} </p>'
+    expected = '<p> </p>'
+    assert_template_result(expected, text)
+  end
+
+  def test_pre_trim_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{- 'John' }}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>John
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_pre_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if true %}
+          yes
+          {%- endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          yes
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if false %}
+          no
+          {%- endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_post_trim_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{ 'John' -}}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          John</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_post_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if true -%}
+          yes
+          {% endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          yes
+          </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if false -%}
+          no
+          {% endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_pre_and_post_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if true %}
+          yes
+          {% endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          yes
+          </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if false %}
+          no
+          {% endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p></p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_post_and_pre_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if true -%}
+          yes
+          {%- endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+          yes
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    whitespace = '          '
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {% if false -%}
+          no
+          {%- endif %}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>
+#{whitespace}
+        </p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_trim_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{- 'John' -}}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>John</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if true -%}
+          yes
+          {%- endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>yes</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if false -%}
+          no
+          {%- endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p></p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_whitespace_trim_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{- 'John' -}},
+          {{- '30' -}}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>John,30</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_whitespace_trim_tags
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if true -%}
+          yes
+          {%- endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>yes</p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {%- if false -%}
+          no
+          {%- endif -%}
+        </p>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p></p>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_complex_trim_output
+    text = <<-END_TEMPLATE
+      <div>
+        <p>
+          {{- 'John' -}}
+          {{- '30' -}}
+        </p>
+        <b>
+          {{ 'John' -}}
+          {{- '30' }}
+        </b>
+        <i>
+          {{- 'John' }}
+          {{ '30' -}}
+        </i>
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+        <p>John30</p>
+        <b>
+          John30
+        </b>
+        <i>John
+          30</i>
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_complex_trim
+    text = <<-END_TEMPLATE
+      <div>
+        {%- if true -%}
+          {%- if true -%}
+            <p>
+              {{- 'John' -}}
+            </p>
+          {%- endif -%}
+        {%- endif -%}
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div><p>John</p></div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+
+  def test_raw_output
+    whitespace = '        '
+    text = <<-END_TEMPLATE
+      <div>
+        {% raw %}
+          {%- if true -%}
+            <p>
+              {{- 'John' -}}
+            </p>
+          {%- endif -%}
+        {% endraw %}
+      </div>
+    END_TEMPLATE
+    expected = <<-END_EXPECTED
+      <div>
+#{whitespace}
+          {%- if true -%}
+            <p>
+              {{- 'John' -}}
+            </p>
+          {%- endif -%}
+#{whitespace}
+      </div>
+    END_EXPECTED
+    assert_template_result(expected, text)
+  end
+end # TrimModeTest


### PR DESCRIPTION
This adds support for {{- and {%- syntax which will lstrip! and -}} and -%} which will rstrip!

Depends on Shopify/liquid-c#30 to pass all tests.

Resolve issues Shopify/liquid#216, Shopify/liquid#215, Shopify/liquid#214, Shopify/liquid#194, Shopify/liquid#171, Shopify/liquid#162

Previously Pull Request #746