### PR TITLE
Fix double-adding tokens in raw tags

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -12,9 +12,9 @@ module Liquid
     def parse(tokens)
       @body = ''
       while token = tokens.shift
-        if token =~ FullTokenPossiblyInvalid
+        if token =~ FullTokenPossiblyInvalid and block_delimiter == $2
           @body << $1 if $1 != "".freeze
-          return if block_delimiter == $2
+          return
         end
         @body << token unless token.empty?
       end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -23,6 +23,10 @@ class RawTagTest < Minitest::Test
     assert_template_result ' Foobar {{ invalid 1', '{% raw %} Foobar {{ invalid {% endraw %}{{ 1 }}'
   end
 
+  def test_nested_tag_in_raw
+    assert_template_result '{{ {% test %} }}', '{% raw %}{{ {% test %} }}{% endraw %}'
+  end
+
   def test_invalid_raw
     assert_match_syntax_error(/tag was never closed/, '{% raw %} foo')
     assert_match_syntax_error(/Valid syntax/, '{% raw } foo {% endraw %}')


### PR DESCRIPTION
The current logic for adding tokens in the raw tag has the potential to
add to the body a substring of a token, and then the full token,
resulting in doubled data. This happens when the token matches the
FullTokenPossiblyInvalid regex, but does not contain the expected end
tag. For example, this occurs when a template contains a string like
"{% raw %}{{ {% test %} }}{% endraw %}", in which case the tokenizer
produces "{{ {% test %}" as one of the tokens, and the template output is "{{ {{ {% test %} }}"