### PR TITLE
Allow variables to start with contains in strict parser

### DIFF
--- a/History.md
+++ b/History.md
@@ -22,6 +22,7 @@
 * Liquid::Template.register_filter raises when the module overrides registered public methods as private or protected (#705) [Gaurav Chande]
 
 ### Fixed
+* Fix variable names being detected as an operator when starting with contains (#788) [Michael Angell]
 * Fix map filter when value is a Proc (#672) [Guillaume Malette]
 * Fix truncate filter when value is not a string (#672) [Guillaume Malette]
 * Fix behaviour of escape filter when input is nil (#665) [Tanel Jakobsoo]

--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -18,10 +18,10 @@ module Liquid
     DOUBLE_STRING_LITERAL = /"[^\"]*"/
     NUMBER_LITERAL = /-?\d+(\.\d+)?/
     DOTDOT = /\.\./
-    COMPARISON_OPERATOR = /==|!=|<>|<=?|>=?|contains/
+    COMPARISON_OPERATOR = /==|!=|<>|<=?|>=?|contains(?=\s)/
 
     def initialize(input)
-      @ss = StringScanner.new(input.rstrip)
+      @ss = StringScanner.new(input)
     end
 
     def tokenize
@@ -29,6 +29,7 @@ module Liquid
 
       until @ss.eos?
         @ss.skip(/\s*/)
+        break if @ss.eos?
         tok = case
         when t = @ss.scan(COMPARISON_OPERATOR) then [:comparison, t]
         when t = @ss.scan(SINGLE_STRING_LITERAL) then [:string, t]

--- a/test/integration/parsing_quirks_test.rb
+++ b/test/integration/parsing_quirks_test.rb
@@ -115,4 +115,8 @@ class ParsingQuirksTest < Minitest::Test
       assert_template_result('12345', "{% for i in (1...5) %}{{ i }}{% endfor %}")
     end
   end
+
+  def test_contains_in_id
+    assert_template_result(' YES ', '{% if containsallshipments == true %} YES {% endif %}', 'containsallshipments' => true)
+  end
 end # ParsingQuirksTest

--- a/test/unit/lexer_unit_test.rb
+++ b/test/unit/lexer_unit_test.rb
@@ -19,7 +19,7 @@ class LexerUnitTest < Minitest::Test
   end
 
   def test_comparison
-    tokens = Lexer.new('== <> contains').tokenize
+    tokens = Lexer.new('== <> contains ').tokenize
     assert_equal [[:comparison, '=='], [:comparison, '<>'], [:comparison, 'contains'], [:end_of_string]], tokens
   end
 


### PR DESCRIPTION
Links with Issue #788 
