### PR TITLE
Fix escape_once not working with hex entities or named entities ending with numbers

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -10,7 +10,7 @@ module Liquid
       '"'.freeze => '&quot;'.freeze,
       "'".freeze => '&#39;'.freeze
     }
-    HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
+    HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+\d*|(#\d+)|(#[xX][\da-fA-F]+));)/
 
     # Return the size of an array or of an string
     def size(input)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -134,6 +134,12 @@ class StandardFiltersTest < Minitest::Test
 
   def test_escape_once
     assert_equal '&lt;strong&gt;Hulk&lt;/strong&gt;', @filters.escape_once('&lt;strong&gt;Hulk</strong>')
+    assert_equal '&excl;1&#x00021;2&#33;', @filters.escape_once('&excl;1&#x00021;2&#33;')
+    assert_equal '&ncy;2&#x0043D;3&#1085;', @filters.escape_once('&ncy;2&#x0043D;3&#1085;')
+    assert_equal '&frac34;&#x000BE;&#190;', @filters.escape_once('&frac34;&#x000BE;&#190;')
+    assert_equal '&blk14;&#x02591;&#9617;', @filters.escape_once('&blk14;&#x02591;&#9617;')
+    assert_equal '&UpArrowBar;&DownArrowBar;', @filters.escape_once('&UpArrowBar;&DownArrowBar;')
+    assert_equal '&#x000BE;&#X000BE;', @filters.escape_once('&#x000BE;&#X000BE;')
   end
 
   def test_url_encode


### PR DESCRIPTION
Fixes #792
