### PR TITLE
Standard filter truncate / truncatewords: force truncate_string to string

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -65,9 +65,10 @@ module Liquid
       return if input.nil?
       input_str = input.to_s
       length = Utils.to_integer(length)
-      l = length - truncate_string.length
+      truncate_string_str = truncate_string.to_s
+      l = length - truncate_string_str.length
       l = 0 if l < 0
-      input_str.length > length ? input_str[0...l] + truncate_string : input_str
+      input_str.length > length ? input_str[0...l] + truncate_string_str : input_str
     end
 
     def truncatewords(input, words = 15, truncate_string = "...".freeze)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -76,7 +76,7 @@ module Liquid
       words = Utils.to_integer(words)
       l = words - 1
       l = 0 if l < 0
-      wordlist.length > l ? wordlist[0..l].join(" ".freeze) + truncate_string : input
+      wordlist.length > l ? wordlist[0..l].join(" ".freeze) + truncate_string.to_s : input
     end
 
     # Split input string into an array of substrings separated by given pattern.

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -154,6 +154,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal 'one two three', @filters.truncatewords('one two three')
     assert_equal 'Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221;...', @filters.truncatewords('Two small (13&#8221; x 5.5&#8221; x 10&#8221; high) baskets fit inside one large basket (13&#8221; x 16&#8221; x 10.5&#8221; high) with cover.', 15)
     assert_equal "测试测试测试测试", @filters.truncatewords('测试测试测试测试', 5)
+    assert_equal 'one two1', @filters.truncatewords("one two three", 2, 1)
   end
 
   def test_strip_html

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -115,6 +115,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '...', @filters.truncate('1234567890', 0)
     assert_equal '1234567890', @filters.truncate('1234567890')
     assert_equal "测试...", @filters.truncate("测试测试测试测试", 5)
+    assert_equal '12341', @filters.truncate("1234567890", 5, 1)
   end
 
   def test_split


### PR DESCRIPTION
Currently, `truncatewords` raises a TypeError when the argument `truncate_string` is an integer. This PR forces string coercion for any value provided for this argument. Thus,

```ruby
assert_equal 'one two1', @filters.truncatewords("one two three", 2, 1)
```

holds true.

The standard filter `truncate` suffered from a similar problem, resulting in a `NoMethodError` when an integer was supplied as an argument to `truncate_string`. Thus, string coercion is forced in this instance, as well.

@Thibaut, please review.