### PR TITLE
Fixing #697 with better exception

### DIFF
--- a/lib/liquid/locales/en.yml
+++ b/lib/liquid/locales/en.yml
@@ -22,3 +22,5 @@
       tag_never_closed: "'%{block_name}' tag was never closed"
       meta_syntax_error: "Liquid syntax error: #{e.message}"
       table_row: "Syntax Error in 'table_row loop' - Valid syntax: table_row [item] in [collection] cols=3"
+    argument:
+      include: "Argument error in tag 'include' - Illegal template name"

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -42,8 +42,9 @@ module Liquid
 
     def render(context)
       template_name = context.evaluate(@template_name_expr)
-      partial = load_cached_partial(template_name, context)
+      raise ArgumentError.new(options[:locale].t("errors.argument.include")) unless template_name
 
+      partial = load_cached_partial(template_name, context)
       context_variable_name = template_name.split('/'.freeze).last
 
       variable = if @variable_name_expr

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -217,6 +217,17 @@ class IncludeTagTest < Minitest::Test
     end
   end
 
+  def test_render_raise_argument_error_when_template_is_undefined
+    assert_raises(Liquid::ArgumentError) do
+      template = Liquid::Template.parse('{% include undefined_variable %}')
+      template.render!
+    end
+    assert_raises(Liquid::ArgumentError) do
+      template = Liquid::Template.parse('{% include nil %}')
+      template.render!
+    end
+  end
+
   def test_including_via_variable_value
     assert_template_result "from TestFileSystem", "{% assign page = 'pick_a_source' %}{% include page %}"
 


### PR DESCRIPTION
Fix #697 

When including a template which is not defined, the exception raised is 
>undefined method `split` for nil:NilClass

This occurs for a scenario like the following:
`{% include nil %}`
or
`{% include undefined-var %}`

Making the code raise a syntax error to allow better understanding of the include error