### PR TITLE
introduce unhandled liquid exception

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -93,10 +93,10 @@ module Liquid
         rescue MemoryError => e
           raise e
         rescue UndefinedVariable, UndefinedDropMethod, UndefinedFilter => e
-          context.handle_error(e, token.line_number)
+          context.handle_error(e, token.line_number, token.raw)
           output << nil
         rescue ::StandardError => e
-          output << context.handle_error(e, token.line_number)
+          output << context.handle_error(e, token.line_number, token.raw)
         end
       end
 

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -73,7 +73,7 @@ module Liquid
       @interrupts.pop
     end
 
-    def handle_error(e, line_number = nil)
+    def handle_error(e, line_number = nil, raw_token = nil)
       if e.is_a?(Liquid::Error)
         e.template_name ||= template_name
         e.line_number ||= line_number
@@ -82,7 +82,9 @@ module Liquid
       output = nil
 
       if exception_handler
-        result = exception_handler.call(e)
+        args = [e]
+        args << { line_number: line_number, raw_token: raw_token } if exception_handler.arity == 2
+        result = exception_handler.call(*args)
         case result
         when Exception
           e = result


### PR DESCRIPTION
The goal of this change is to make it easier to debug exceptions which are generated in the process of rendering liquid.

As it stands, when a liquid error such as `UndefinedDropMethod` is raised, it is augmented with the template name and line number, which aids in debugging the error.

However, for so called "unhandled" errors we do not add this information, which makes debugging errors such as TypeError more challenging.

This PR improves the situation in a couple ways:

Firstly, we add the actual line in question, as an example this might contain "paginate collection.products by test".

Secondly, we wrap StandardErrors in an UnhandledError class, which can carry this additional information (which can use then used in Shopify core, for example, when we report these exceptions.)

@dylanahsmith @pushmatrix @fw42 cc @Thibaut 
