### PR TITLE
allow split to accept numeric

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -86,7 +86,7 @@ module Liquid
     #   <div class="summary">{{ post | split '//' | first }}</div>
     #
     def split(input, pattern)
-      input.to_s.split(pattern)
+      input.to_s.split(pattern.to_s)
     end
 
     def strip(input)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -122,9 +122,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal ['12', '34'], @filters.split('12~34', '~')
     assert_equal ['A? ', ' ,Z'], @filters.split('A? ~ ~ ~ ,Z', '~ ~ ~')
     assert_equal ['A?Z'], @filters.split('A?Z', '~')
-    # Regexp works although Liquid does not support.
-    assert_equal ['A', 'Z'], @filters.split('AxZ', /x/)
     assert_equal [], @filters.split(nil, ' ')
+    assert_equal ['A', 'Z'], @filters.split('A1Z', 1)
   end
 
   def test_escape


### PR DESCRIPTION
Attempt to coerce numeric values to string such that `'Fall 2016 Collection' | split: 2016` doesn't result in `wrong argument type Fixnum (expected Regexp)` The type check on `Numeric` is so that we don't convert, for example, a regex input to its `to_s` representation.

@dylanahsmith @pushrax 