### PR TITLE
Update iteration.md

### DIFF
--- a/tags/iteration.md
+++ b/tags/iteration.md
@@ -112,11 +112,11 @@ Defines a range of numbers to loop through. The range can be defined by both lit
 
 <p class="code-label">Input</p>
 ```liquid
+{% raw %}
 {% for i in (3..5) %}
   {{ i }}
 {% endfor %}
 
-{% raw %}
 {% assign num = 4 %}
 {% for i in (1..num) %}
   {{ i }}


### PR DESCRIPTION
Fix liquid syntax error

Liquid Warning: Liquid syntax error (line 111): Unexpected character   in "i in (3..5) " in tags/iteration.md