### PR TITLE
Fixes #784: Filters page shows raw code for examples after 'floor'

### DIFF
--- a/filters/index.md
+++ b/filters/index.md
@@ -8,7 +8,26 @@ type: index
 {% assign filter_pages = site.pages | where: 'type', 'filter' %}
 
 {% for item in filter_pages %}
+    {% capture path %}{{ item.name }}{% endcapture %}
+    {% capture content %}{% include_relative {{path}} %}{% endcapture %}
+    {% assign lines = content | newline_to_br | split: "<br />" %}
+
+    {% assign content = "" %}
+    {% assign counter = 0 %}
+
+    {% for line in lines %}
+        {% assign stripped = line | strip_newlines %}
+        {% if counter < 2 %}
+            {% if stripped == '---' %}
+                {% assign counter = counter | plus: 1 %}
+                {% continue %}
+            {% endif %}
+        {% else %}
+            {% assign content = content | append: line %}
+        {% endif %}
+    {% endfor %}
+
 ## [{{ item.title }}]({{ item.url | prepend: site.baseurl }})
 
-{{ item.content }}
+{{ content }}
 {% endfor %}


### PR DESCRIPTION
Apparently Jekyll refuses to parse Liquid tags in recursion. Once it hits `index.md`, parsing all the following files will fail.

The workaround is to strip away YAML front-matter and process the content separately.
