### PR TITLE
rename raw to raw liquid

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -93,10 +93,10 @@ module Liquid
         rescue MemoryError => e
           raise e
         rescue UndefinedVariable, UndefinedDropMethod, UndefinedFilter => e
-          context.handle_error(e, token.line_number, token.raw)
+          context.handle_error(e, token.line_number, token.raw_liquid)
           output << nil
         rescue ::StandardError => e
-          output << context.handle_error(e, token.line_number, token.raw)
+          output << context.handle_error(e, token.line_number, token.raw_liquid)
         end
       end
 

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -47,7 +47,7 @@ module Liquid
       attr_reader :code, :partial, :line_number, :children
 
       def initialize(node, partial)
-        @code        = node.respond_to?(:raw) ? node.raw : node
+        @code        = node.respond_to?(:raw_liquid) ? node.raw_liquid : node
         @partial     = partial
         @line_number = node.respond_to?(:line_number) ? node.line_number : nil
         @children    = []

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -24,7 +24,7 @@ module Liquid
     def parse(_tokens)
     end
 
-    def raw
+    def raw_liquid
       "#{@tag_name} #{@markup}"
     end
 

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -25,7 +25,7 @@ module Liquid
       parse_with_selected_parser(markup)
     end
 
-    def raw
+    def raw_liquid
       @markup
     end
 

--- a/test/unit/tag_unit_test.rb
+++ b/test/unit/tag_unit_test.rb
@@ -11,7 +11,7 @@ class TagUnitTest < Minitest::Test
 
   def test_return_raw_text_of_tag
     tag = Tag.parse("long_tag", "param1, param2, param3", Tokenizer.new(""), ParseContext.new)
-    assert_equal("long_tag param1, param2, param3", tag.raw)
+    assert_equal("long_tag param1, param2, param3", tag.raw_liquid)
   end
 
   def test_tag_name_should_return_name_of_the_tag

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -145,7 +145,7 @@ class VariableUnitTest < Minitest::Test
 
   def test_output_raw_source_of_variable
     var = create_variable(%( name_of_variable | upcase ))
-    assert_equal " name_of_variable | upcase ", var.raw
+    assert_equal " name_of_variable | upcase ", var.raw_liquid
   end
 
   def test_variable_lookup_interface


### PR DESCRIPTION
Straight rename of `raw` to `raw_liquid`.

Q: Why?
A: In Shopify core our definition of `Form < Liquid::Block` also includes `include ActionView::Helpers::TagHelper`, which in turn pulls in `require 'active_support/core_ext/string/output_safety'` https://github.com/rails/rails/blob/8f544bc447612924a50c37ead085a0ea4c217439/actionview/lib/action_view/helpers/tag_helper.rb#L1 Unfortunately, `OutputSafetyHelper` also defines `raw` which overwrites the definition https://github.com/rails/rails/blob/8f544bc447612924a50c37ead085a0ea4c217439/actionview/lib/action_view/helpers/output_safety_helper.rb#L16

```
(byebug) Form.ancestors
[Form, ActionView::Helpers::TagHelper, ActionView::Helpers::OutputSafetyHelper, ActionView::Helpers::CaptureHelper, Liquid::Block, Liquid::Tag, Liquid::ParserSwitching, NakayoshiFork, Object, Minitest::Expectations, Metaclass::ObjectMethods, Mocha::ObjectMethods, PP::ObjectMixin, Nori::CoreExt::Object, ERB::Util, ActiveSupport::Dependencies::Loadable, JSON::Ext::Generator::GeneratorMethods::Object, Kernel, BasicObject]
```

Defined first (correctly) in `Liquid::Tag` and the overwritten with the wrong code in `ActionView::Helpers::OutputSafetyHelper`

In order to be able to start using https://github.com/Shopify/liquid/pull/809 in Shopify production, we need to rename this method, so the conflict doesn't trigger some of the test suite to fail. 

@rafaelfranca @pushrax @dylanahsmith cc @Thibaut 