### PR TITLE
fix: Clear the strainer cache when a global filter is added

### DIFF
--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -39,6 +39,7 @@ module Liquid
     end
 
     def self.global_filter(filter)
+      @@strainer_class_cache.clear
       @@global_strainer.add_filter(filter)
     end
 

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -133,4 +133,16 @@ class StrainerUnitTest < Minitest::Test
     strainer.class.add_filter(PublicMethodOverrideFilter)
     assert strainer.class.filter_methods.include?('public_filter')
   end
+
+  module LateAddedFilter
+    def late_added_filter(input)
+      "filtered"
+    end
+  end
+
+  def test_global_filter_clears_cache
+    assert_equal 'input', Strainer.create(nil).invoke('late_added_filter', 'input')
+    Strainer.global_filter(LateAddedFilter)
+    assert_equal 'filtered', Strainer.create(nil).invoke('late_added_filter', 'input')
+  end
 end # StrainerTest


### PR DESCRIPTION
Fixes #825

@fw42 & @richardmonette please review

Filters are implemented by including modules into strainer classes.  We allow global filters and per-template filters, so we have a global strainer class and strainer classes derived from that created for each template.  Surprisingly we actually use a derived strainer class when the list of per-template filters is empty.

What causes the issue to occur is that we also have a filter method set that is stored in an instance variable for each strainer class, which won't get updated for the derived strainer class when filters are added to the global strainer.  So this PR fixes that by just clearing the strainer class cache when a global strainer is added.