### PR TITLE
828 fix content variable error

### DIFF
--- a/History.md
+++ b/History.md
@@ -22,6 +22,7 @@
 * Liquid::Template.register_filter raises when the module overrides registered public methods as private or protected (#705) [Gaurav Chande]
 
 ### Fixed
+* Fix include tag used with strict_variables (#828) [QuickPay]
 * Fix map filter when value is a Proc (#672) [Guillaume Malette]
 * Fix truncate filter when value is not a string (#672) [Guillaume Malette]
 * Fix behaviour of escape filter when input is nil (#665) [Tanel Jakobsoo]

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -50,7 +50,7 @@ module Liquid
       variable = if @variable_name_expr
         context.evaluate(@variable_name_expr)
       else
-        context.find_variable(template_name)
+        context.find_variable(template_name, raise_on_not_found: false)
       end
 
       old_template_name = context.template_name

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -235,4 +235,11 @@ class IncludeTagTest < Minitest::Test
 
     assert_template_result "Product: Draft 151cm ", "{% assign page = 'product' %}{% include page for foo %}", "foo" => { 'title' => 'Draft 151cm' }
   end
+
+  def test_including_with_strict_variables
+    template = Liquid::Template.parse("{% include 'simple' %}", error_mode: :warn)
+    template.render(nil, strict_variables: true)
+
+    assert_equal [], template.errors
+  end
 end # IncludeTagTest


### PR DESCRIPTION
This fixes #828 

The test describes the wanted behaviour of not adding an error when including a template when using `strict_variables: true`