### PR TITLE
Drop support for ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3.3
   - ruby-head
   - jruby-head
 #  - rbx-2

--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 4.0.0 / not yet released / branch "master"
 
 ### Changed
+* Ruby 2.0 support dropped (#832) [Dylan Thacker-Smith]
 * Add to_number Drop method to allow custom drops to work with number filters (#731)
 * Add strict_variables and strict_filters options to detect undefined references (#691)
 * Improve loop performance (#681) [Florian Weingarten]

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   # s.description = "A secure, non-evaling end user template engine with aesthetic markup."
 
+  s.required_ruby_version     = ">= 2.1.0"
   s.required_rubygems_version = ">= 1.3.7"
 
   s.test_files  = Dir.glob("{test}/**/*")


### PR DESCRIPTION
@fw42 & @pushrax please review

https://www.ruby-lang.org/en/downloads/ says ruby 2.0 is no longer maintained, so I don't think we should support it for liquid v4.

## Motivation

ruby 2.1 added Exception#cause which I would like to assume it available for a PR I'm going to open up to add a Liquid::InternalError that will wrap non-Liquid::Error exceptions.  This way we can attach the template_name and line_number to the error and still have the original exception available through the cause method for error reporting and logging.