### PR TITLE
Add a filter to compute percentages

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -332,6 +332,12 @@ module Liquid
       raise Liquid::ZeroDivisionError, e.message
     end
 
+    # percentage
+    def percentage_of(input, operand)
+      floating_product = apply_operation(input, 100.0, :*)
+      apply_operation(floating_product, operand, :/)
+    end
+
     def round(input, n = 0)
       result = Utils.to_number(input).round(Utils.to_number(n))
       result = result.to_f if result.is_a?(BigDecimal)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -442,6 +442,21 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "5", "{{ price | divided_by:2 }}", 'price' => NumberLikeThing.new(10)
   end
 
+  def test_percentage_of
+    assert_template_result "300.0", "{{ 120 | percentage_of: 40 }}"
+    assert_template_result "300.0", "{{ 120.0 | percentage_of: 40 }}"
+    assert_template_result "33.333333333333336", "{{ 40 | percentage_of: 120 }}"
+
+    # dividing a float by 0 yields "Infinity"
+    assert_template_result "Infinity", "{{ 40 | percentage_of: 0 }}"
+
+    assert_template_result "33", "{{ 40 | percentage_of: 120 | round }}"
+    assert_template_result "33.33", "{{ 40 | percentage_of: 120 | round: 2 }}"
+
+    assert_template_result "30.0", "{{ price | percentage_of: 150 }}", 'price' => NumberLikeThing.new(45)
+    assert_template_result "30.0", "{{ current | percentage_of: original | round: 2 }}", 'current' => 45, 'original' => 150
+  end
+
   def test_modulo
     assert_template_result "1", "{{ 3 | modulo:2 }}"
     assert_raises(Liquid::ZeroDivisionError) do


### PR DESCRIPTION
a filter to compute what percentage `num A` is of `num B`
  - returns a float
  - returns "Infinity" when supplied with `0`
  - can be rounded off to required decimal places by the *round* filter
  - returns a float with `.0` even when the modulo of `input` and `operand` is `0` && even if `round: 2` is used