### PR TITLE
change: Render an opaque internal error by default for non-Liquid::Error

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 4.0.0 / not yet released / branch "master"
 
 ### Changed
+* Render an opaque internal error by default for non-Liquid::Error (#835) [Dylan Thacker-Smith]
 * Ruby 2.0 support dropped (#832) [Dylan Thacker-Smith]
 * Add to_number Drop method to allow custom drops to work with number filters (#731)
 * Add strict_variables and strict_filters options to detect undefined references (#691)

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -17,14 +17,6 @@ module Liquid
       str
     end
 
-    def self.render(e)
-      if e.is_a?(Liquid::Error)
-        e.to_s
-      else
-        "Liquid error: #{e}"
-      end
-    end
-
     private
 
     def message_prefix
@@ -60,4 +52,5 @@ module Liquid
   UndefinedDropMethod = Class.new(Error)
   UndefinedFilter = Class.new(Error)
   MethodOverrideError = Class.new(Error)
+  InternalError = Class.new(Error)
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -167,7 +167,7 @@ module Liquid
         c = args.shift
 
         if @rethrow_errors
-          c.exception_handler = ->(e) { raise }
+          c.exception_renderer = ->(e) { raise }
         end
 
         c
@@ -241,7 +241,7 @@ module Liquid
     def apply_options_to_context(context, options)
       context.add_filters(options[:filters]) if options[:filters]
       context.global_filter = options[:global_filter] if options[:global_filter]
-      context.exception_handler = options[:exception_handler] if options[:exception_handler]
+      context.exception_renderer = options[:exception_renderer] if options[:exception_renderer]
       context.strict_variables = options[:strict_variables] if options[:strict_variables]
       context.strict_filters = options[:strict_filters] if options[:strict_filters]
     end

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -215,16 +215,20 @@ class TemplateTest < Minitest::Test
     assert_equal 'ruby error in drop', e.message
   end
 
-  def test_exception_handler_doesnt_reraise_if_it_returns_false
+  def test_exception_renderer_that_returns_string
     exception = nil
-    Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; false })
+    handler = ->(e) { exception = e; '<!-- error -->' }
+
+    output = Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_renderer: handler)
+
     assert exception.is_a?(Liquid::ZeroDivisionError)
+    assert_equal '<!-- error -->', output
   end
 
-  def test_exception_handler_does_reraise_if_it_returns_true
+  def test_exception_renderer_that_raises
     exception = nil
     assert_raises(Liquid::ZeroDivisionError) do
-      Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_handler: ->(e) { exception = e; true })
+      Template.parse("{{ 1 | divided_by: 0 }}").render({}, exception_renderer: ->(e) { exception = e; raise })
     end
     assert exception.is_a?(Liquid::ZeroDivisionError)
   end


### PR DESCRIPTION
@fw42 & @pushrax, @richardmonette please review

## Problem

When a non-Liquid::Error exception is caught and rendered by liquid, it can cause sensitive information to be rendered.  I opened https://github.com/Shopify/liquid/pull/576 to solve this problem at Shopify, but it would be safer to have the default behaviour be to not show the message from these non-Liquid::Errors.

## Solution

When a non-Liquid::Error occurs during liquid rendering, it is replaced with a Liquid::InternalError exception which has the original exception available through its [cause](http://ruby-doc.org/core-2.2.4/Exception.html#method-i-cause) method.  The Liquid::InternalError has a message 'internal' so will show up as `Liquid error: internal` in the rendered output.  This Liquid::InternalError exception is what is pushed to the Liquid::Context#errors array.

The Liquid::Context#exception_handler's API has changed quite a bit since the last release of liquid.  It used to return a truthy value to re-raise the exception and a falsey value to render the error, however, re-raising the exception is a clearer and more flexible way to handle that behaviour. On master it has become more complicated to attach metadata to the error, which isn't necessary now that a Liquid::InternalError can be passed to it.  Instead, I just kept the feature of allowing the handler to return a value to render for the error, since nothing else is needed.  I changed `exception_handler` to `exception_renderer` to remove support for the old behaviour while avoiding a subtle breaking change.  I think the new name is also clearer.

The old behaviour can be acheived with the following exception_handler:

```ruby
context.exception_renderer = lambda do |exc|
  exc.is_a?(Liquid::InternalError) ? "Liquid error: #{exc.cause.message}" : exc
end
```

## Future Work

I think it would also be useful to be able to change the default template error handler.  That way it would be easier to provide a consistent way of handling exceptions across an app, even when there are multiple places where liquid rendering is done.  For instance, to simplify upgrading from liquid v3, the default exception_renderer could be overridden with the liquid v3 compatible one mentioned above.  This would also be an ideal place to report internal errors to an error reporting system like errbit or bugsnag if they are not re-raised.