### PR TITLE
Add version constraint to rake to fix CI

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '~> 11.3'
   s.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
cc @fw42 & @pushrax 

I was just about to open a pull request when I noticed a CI failure, which I was able to reproduce on master by doing

```
rm Gemfile.lock
bundle install
bundle exec rake
```

which output the following failure

```
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007ff45637aa80>
/Users/dylansmith/.gem/ruby/2.3.1/gems/rubocop-0.34.2/lib/rubocop/rake_task.rb:23:in `initialize'
/Users/dylansmith/src/liquid/Rakefile:23:in `new'
/Users/dylansmith/src/liquid/Rakefile:23:in `block in <top (required)>'
/Users/dylansmith/.gem/ruby/2.3.1/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli/exec.rb:74:in `load'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli/exec.rb:27:in `run'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli.rb:332:in `exec'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli.rb:20:in `dispatch'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/cli.rb:11:in `start'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/exe/bundle:34:in `block in <top (required)>'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/Users/dylansmith/.gem/ruby/2.3.1/gems/bundler-1.13.3/exe/bundle:26:in `<top (required)>'
/Users/dylansmith/.gem/ruby/2.3.1/bin/bundle:23:in `load'
/Users/dylansmith/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'
Tasks: TOP => default => rubocop
(See full trace by running task with --trace)
```

The rake gem just released version 12.0.0 on December 6, 2016 and we didn't specify a version for rake, so that is why it started failing.  The tests pass when using the previous version of rake, so I specified I pinned the major version to 11 in in the gemspec.