### PR TITLE
feature: Allow a default exception renderer to be specified

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -27,6 +27,7 @@ module Liquid
 
       @this_stack_used = false
 
+      self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
         self.exception_renderer = ->(e) { raise }
       end
@@ -78,9 +79,7 @@ module Liquid
       e.template_name ||= template_name
       e.line_number ||= line_number
       errors.push(e)
-
-      e = exception_renderer.call(e) if exception_renderer
-      e.to_s
+      exception_renderer.call(e).to_s
     end
 
     def invoke(method, *args)

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -69,6 +69,11 @@ module Liquid
       # :error raises an error when tainted output is used
       attr_writer :taint_mode
 
+      attr_accessor :default_exception_renderer
+      Template.default_exception_renderer = lambda do |exception|
+        exception
+      end
+
       def file_system
         @@file_system
       end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -211,6 +211,20 @@ class ErrorHandlingTest < Minitest::Test
     assert_equal [Liquid::InternalError], template.errors.map(&:class)
   end
 
+  def test_setting_default_exception_renderer
+    old_exception_renderer = Liquid::Template.default_exception_renderer
+    exceptions = []
+    Liquid::Template.default_exception_renderer = ->(e) { exceptions << e; '' }
+    template = Liquid::Template.parse('This is a runtime error: {{ errors.argument_error }}')
+
+    output = template.render({ 'errors' => ErrorDrop.new })
+
+    assert_equal 'This is a runtime error: ', output
+    assert_equal [Liquid::ArgumentError], template.errors.map(&:class)
+  ensure
+    Liquid::Template.default_exception_renderer = old_exception_renderer if old_exception_renderer
+  end
+
   def test_exception_renderer_exposing_non_liquid_error
     template = Liquid::Template.parse('This is a runtime error: {{ errors.runtime_error }}', line_numbers: true)
     exceptions = []


### PR DESCRIPTION
@pushrax & @fw42 please review

## Problem

As mentioned in https://github.com/Shopify/liquid/pull/835 I would like to be able to specify the default liquid error renderer.  The motivation for this is that an app might be doing liquid rendering from multiple places so could easily forget to specify the error handler and miss important behaviour like error reporting.

## Solution

Add a `Liquid::Template.default_error_renderer` accessor which will be used as the default error renderer if one isn't specified on Liquid::Template#render, Liquid::Context#error_renderer= or implicitly through using Liquid::Template#render!

This change will also make it easier to upgrade to liquid v4 if the behaviour change from https://github.com/Shopify/liquid/pull/835 requires a lot of changes.  That could be done as follows:

```ruby
Liquid::Template.default_exception_renderer = lambda do |exception|
  exception.is_a?(Liquid::InternalError) ? "Liquid error: #{exception.cause.message}" : exception
end
```