### PR TITLE
Update release date for Liquid 4.0.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 # Liquid Change Log
 
-## 4.0.0 / not yet released / branch "master"
+## 4.0.0 / 2016-12-14 / branch "master"
 
 ### Changed
 * Render an opaque internal error by default for non-Liquid::Error (#835) [Dylan Thacker-Smith]


### PR DESCRIPTION
4.0.0 was released the other day, so we should update the history doc.