### PR TITLE
Clarifies spelling of for’s reversed flag to address #843

### DIFF
--- a/tags/iteration.md
+++ b/tags/iteration.md
@@ -133,7 +133,7 @@ Defines a range of numbers to loop through. The range can be defined by both lit
 
 ### reversed
 
-Reverses the order of the loop.
+Reverses the order of the loop. Note that the flag’s spelling is different to the filter `reverse`.
 
 <p class="code-label">Input</p>
 ```liquid


### PR DESCRIPTION
It should now be harder to read the docs and miss the extra letter required for reversed compared to reverse, which causes a fairly generic syntax warning when trying to reverse sort a collection in a for loop.