### PR TITLE
Clarifies spelling of for’s reversed flag to address #843

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -23,7 +23,7 @@ module Liquid
   #      {{ item.name }}
   #    {% end %}
   #
-  #  To reverse the for loop simply use {% for item in collection reversed %} (note that the flag’s spelling is different to the filter `reverse`)
+  #  To reverse the for loop simply use {% for item in collection reversed %} (note that the flag's spelling is different to the filter `reverse`)
   #
   # == Available variables:
   #

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -23,7 +23,7 @@ module Liquid
   #      {{ item.name }}
   #    {% end %}
   #
-  #  To reverse the for loop simply use {% for item in collection reversed %}
+  #  To reverse the for loop simply use {% for item in collection reversed %} (note that the flag’s spelling is different to the filter `reverse`)
   #
   # == Available variables:
   #


### PR DESCRIPTION
It should now be harder to read the docs and miss the extra letter required for reversed compared to reverse, which causes a fairly generic syntax warning when trying to reverse sort a collection in a for loop.

Not sure what your branching policy is—thought it would be worth updating the Ruby docs as well but feel free to reject this if it doesn’t fit.