### PR TITLE
Fix internal liquid error when comparing hash with incompatible type

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -110,7 +110,7 @@ module Liquid
 
       if operation.respond_to?(:call)
         operation.call(self, left, right)
-      elsif left.respond_to?(operation) && right.respond_to?(operation)
+      elsif left.respond_to?(operation) && right.respond_to?(operation) && !left.is_a?(Hash) && !right.is_a?(Hash)
         begin
           left.send(operation, right)
         rescue ::ArgumentError => e

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -67,6 +67,8 @@ class ConditionUnitTest < Minitest::Test
   def test_hash_compare_backwards_compatibility
     assert_equal nil, Condition.new({}, '>', 2).evaluate
     assert_equal nil, Condition.new(2, '>', {}).evaluate
+    assert_equal false, Condition.new({}, '==', 2).evaluate
+    assert_equal true, Condition.new({ 'a' => 2 }, 'contains', 'a').evaluate
   end
 
   def test_contains_works_on_arrays

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -64,6 +64,11 @@ class ConditionUnitTest < Minitest::Test
     assert_evaluates_argument_error '1', '<=', 0
   end
 
+  def test_hash_compare_backwards_compatibility
+    assert_equal nil, Condition.new({}, '>', 2).evaluate
+    assert_equal nil, Condition.new(2, '>', {}).evaluate
+  end
+
   def test_contains_works_on_arrays
     @context = Liquid::Context.new
     @context['array'] = [1, 2, 3, 4, 5]


### PR DESCRIPTION
Fixes #842

ruby 2.3 implements comparison operators on hashes, but these result in a TypeError when the types don't match.  Previously we did a respond_to? check for the operators which would cause `nil` to be returned, so along with the respond_to? check I checked for hash objects to keep compatibility with the previous behaviour.