### PR TITLE
Create a benchmark group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,12 @@ source 'https://rubygems.org'
 gemspec
 gem 'stackprof', platforms: :mri_21
 
+group :benchmark, :test do
+  gem 'benchmark-ips'
+end
+
 group :test do
   gem 'spy', '0.4.1'
-  gem 'benchmark-ips'
   gem 'rubocop', '0.34.2'
 
   platform :mri do


### PR DESCRIPTION
This is so that in rubybench, when we submodule liquid (to get its performance directory), we can run `bundle install --without test` to install benchmark-ips to do the benchmarking, rather than have an explicit dependency on benchmark-ips

see https://github.com/jerryliu55/ruby-bench-docker/pull/2/files#diff-c7cb1a7821c81d5dd84ff5d8fb81ec21R57