### PR TITLE
handle join on fixnum

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -384,7 +384,7 @@ module Liquid
       end
 
       def join(glue)
-        to_a.join(glue)
+        to_a.join(glue.to_s)
       end
 
       def concat(args)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -170,6 +170,7 @@ class StandardFiltersTest < Minitest::Test
   def test_join
     assert_equal '1 2 3 4', @filters.join([1, 2, 3, 4])
     assert_equal '1 - 2 - 3 - 4', @filters.join([1, 2, 3, 4], ' - ')
+    assert_equal '1121314', @filters.join([1, 2, 3, 4], 1)
   end
 
   def test_sort


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify/issues/99422

There are reports of `no implicit conversion of Fixnum into String` in Shopify core when themes have been customized such that a Fixnum is used as the glue input to `join`. IIRC, liquid generally handles these cases by using type coercion to do a best effort output, this is a quick fix which handles this edge cases by always casting the glue, to ensure it is a string. The docs for this are already pretty clear https://help.shopify.com/themes/liquid/filters/array-filters#join but it would still be better, imho, if we didn't allow this to be a TypeError.

@dylanahsmith @fw42 cc @Thibaut 