### PR TITLE
Avoid calling line_number on String node when rescuing a render error.

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -107,7 +107,7 @@ module Liquid
     private
 
     def render_node(node, context)
-      node_output = (node.respond_to?(:render) ? node.render(context) : node)
+      node_output = node.is_a?(String) ? node : node.render(context)
       node_output = node_output.is_a?(Array) ? node_output.join : node_output.to_s
 
       context.resource_limits.render_length += node_output.length

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -93,10 +93,11 @@ module Liquid
         rescue MemoryError => e
           raise e
         rescue UndefinedVariable, UndefinedDropMethod, UndefinedFilter => e
-          context.handle_error(e, token.line_number, token.raw)
+          context.handle_error(e, token.line_number)
           output << nil
         rescue ::StandardError => e
-          output << context.handle_error(e, token.line_number, token.raw)
+          line_number = token.is_a?(String) ? nil : token.line_number
+          output << context.handle_error(e, line_number)
         end
       end
 

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -74,7 +74,7 @@ module Liquid
       @interrupts.pop
     end
 
-    def handle_error(e, line_number = nil, raw_token = nil)
+    def handle_error(e, line_number = nil)
       e = internal_error unless e.is_a?(Liquid::Error)
       e.template_name ||= template_name
       e.line_number ||= line_number


### PR DESCRIPTION
Fixes #853

## Problem

The backtrace in that issue shows ```NoMethodError: undefined method `line_number' for "hi ":String``` is happening on on line [lib/liquid/block_body.rb:99](https://github.com/Shopify/liquid/blob/v4.0.0/lib/liquid/block_body.rb#L99).  That means that something is causing a StandardError exception when rendering a String node, then the rescue block is calling `token.line_number` on the String token which causes a NoMethodError that hides the original exception.

## Solution

If the token is a `String`, then we don't know the line number, so I just passed `nil` as the line_number to Context#handle_error.

The third argument to Context#handle_error wasn't being used, so I removed it.

I'm not sure how to write a regression test for this.  I will need more information from @Apokly about what caused the original exception.  @Apokly could you try using this liquid branch and see what exception you end up getting, since that should be the exception that caused the rendering of the string node to fail.