### PR TITLE
fix  #861: duplicate inclusion condition logic error of Liquid::Strainer.add_filter method

### DIFF
--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -27,7 +27,7 @@ module Liquid
 
     def self.add_filter(filter)
       raise ArgumentError, "Expected module but got: #{filter.class}" unless filter.is_a?(Module)
-      unless self.class.include?(filter)
+      unless self.include?(filter)
         invokable_non_public_methods = (filter.private_instance_methods + filter.protected_instance_methods).select { |m| invokable?(m) }
         if invokable_non_public_methods.any?
           raise MethodOverrideError, "Filter overrides registered public methods as non public: #{invokable_non_public_methods.join(', ')}"

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -145,4 +145,13 @@ class StrainerUnitTest < Minitest::Test
     Strainer.global_filter(LateAddedFilter)
     assert_equal 'filtered', Strainer.create(nil).invoke('late_added_filter', 'input')
   end
+
+  def test_add_filter_returns_nil_when_a_filter_module_was_added
+    a = Module.new
+    strainer = Context.new.strainer
+    result1 = strainer.class.add_filter(a)
+    result2 = strainer.class.add_filter(a)
+    assert_kind_of Set, result1
+    assert_kind_of NilClass, result2
+  end
 end # StrainerTest

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -146,12 +146,19 @@ class StrainerUnitTest < Minitest::Test
     assert_equal 'filtered', Strainer.create(nil).invoke('late_added_filter', 'input')
   end
 
-  def test_add_filter_returns_nil_when_a_filter_module_was_added
-    a = Module.new
+  def test_add_filter_does_not_include_already_included_module
+    mod = Module.new do
+      class << self
+        attr_accessor :include_count
+        def included(mod)
+          self.include_count += 1
+        end
+      end
+      self.include_count = 0
+    end
     strainer = Context.new.strainer
-    result1 = strainer.class.add_filter(a)
-    result2 = strainer.class.add_filter(a)
-    assert_kind_of Set, result1
-    assert_kind_of NilClass, result2
+    strainer.class.add_filter(mod)
+    strainer.class.add_filter(mod)
+    assert_equal 1, mod.include_count
   end
 end # StrainerTest


### PR DESCRIPTION
fix  #861: duplicate inclusion condition logic error of Liquid::Strainer.add_filter method