### PR TITLE
Add JSON parse as standard filter

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -53,4 +53,5 @@ module Liquid
   UndefinedFilter = Class.new(Error)
   MethodOverrideError = Class.new(Error)
   InternalError = Class.new(Error)
+  JsonParserError = Class.new(Error)
 end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'bigdecimal'
+require 'json'
 
 module Liquid
   module StandardFilters
@@ -47,6 +48,12 @@ module Liquid
 
     def url_decode(input)
       CGI.unescape(input) unless input.nil?
+    end
+
+    def json_parse(input)
+      JSON.parse(input.to_s) unless input.nil?
+    rescue JSON::ParserError => e
+      raise Liquid::JsonParserError, e.message
     end
 
     def slice(input, offset, length = nil)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -151,14 +151,12 @@ class StandardFiltersTest < Minitest::Test
   def test_json_parse
     assert_equal({ "foo" => "bar" }, @filters.json_parse('{"foo":"bar"}'))
     assert_equal({ "foo" => 2 }, @filters.json_parse('{"foo":2}'))
-    assert_template_result "foo", '{{ \'"foo"\' | json_parse }}', {}
     assert_template_result "{\"foo\"=>{\"bar\"=>[1, 2, 3]}}", '{% assign json_result = json_data | json_parse %}{{ json_result }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_template_result "{\"bar\"=>[1, 2, 3]}", '{% assign json_result = json_data | json_parse %}{{ json_result.foo }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_template_result "123", '{% assign json_result = json_data | json_parse %}{{ json_result.foo.bar }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_template_result "123", '{% assign json_result = json_data | json_parse %}{{ json_result.foo["bar"] }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_template_result "1", '{% assign json_result = json_data | json_parse %}{{ json_result.foo.bar[0] }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_equal nil, @filters.json_parse(nil)
-    assert_equal 9, @filters.json_parse(9)
     assert_raises(Liquid::JsonParserError) do
       @filters.json_parse('invalid json {{')
     end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -151,7 +151,6 @@ class StandardFiltersTest < Minitest::Test
   def test_json_parse
     assert_equal({ "foo" => "bar" }, @filters.json_parse('{"foo":"bar"}'))
     assert_equal({ "foo" => 2 }, @filters.json_parse('{"foo":2}'))
-    assert_equal "Liquid error: 743: unexpected token at 'foo'", Template.parse("{{ 'foo' | json_parse }}").render
     assert_template_result "foo", '{{ \'"foo"\' | json_parse }}', {}
     assert_template_result "{\"foo\"=>{\"bar\"=>[1, 2, 3]}}", '{% assign json_result = json_data | json_parse %}{{ json_result }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'
     assert_template_result "{\"bar\"=>[1, 2, 3]}", '{% assign json_result = json_data | json_parse %}{{ json_result.foo }}', "json_data" => '{"foo":{"bar":[1,2,3]}}'


### PR DESCRIPTION
Why this pull request is important

1. Adds the ability for us to make objects in liquid by using JSON 
1. Adds the ability for us to sync supplement data to shopify via Metafields

Our use case below

1. The only way to sync supplemental product data to Shopify currently is Metafields
1. Metafields don't work when you have 20,000 products to sync as Metafield syncing is a P * D problem where P is the number of products and D is the number of data attributes. With a constant API limit of 2 per second once P*D is too great syncing becomes impossible
1. We solved this solution by building https://github.com/culturekings/shopify-json-parser which allows us to store all data in a single metafield. Bringing our P * D problem to just an P problem for us as 20,000 * 1 is always 20,000.
1. Although we fixed our problem for product pages with very minimum load times, we have now hit another problem with collection pages. So we now have a time issue of P * T where P is the number of items on a collection page and T is the amount of time the extremely slow Liquid JSON parser takes. Every product takes about 1 second so we are now seeing double digit loading times on our collection pages.

This implementation fixes our final problem as parsing natively in ruby is a millisecond process vs our liquid JSON parser which is very slow and very resource heavy.