### PR TITLE
Add globals for strict_variables & strict_filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For standard use you can just pass it the content of a file and call render with
 
 Setting the error mode of Liquid lets you specify how strictly you want your templates to be interpreted.
 Normally the parser is very lax and will accept almost anything without error. Unfortunately this can make
-it very hard to debug and can lead to unexpected behaviour. 
+it very hard to debug and can lead to unexpected behaviour.
 
 Liquid also comes with a stricter parser that can be used when editing templates to give better error messages
 when templates are invalid. You can enable this new parser like this:
@@ -103,4 +103,15 @@ If you want to raise on a first exception instead of pushing all of them in `err
 template = Liquid::Template.parse("{{x}} {{y}}")
 template.render!({ 'x' => 1}, { strict_variables: true })
 #=> Liquid::UndefinedVariable: Liquid error: undefined variable y
+```
+
+It is also possible to register theses settings globally:
+
+```ruby
+Liquid::Template.strict_variables = true
+Liquid::Template.strict_filters = true
+
+template = Liquid::Template.parse("{{ x | filter1 }}")
+template.render! # => Liquid::UndefinedVariable: Liquid error: undefined variable x
+template.render!({ 'x' => 'foo' }) # => Liquid::UndefinedFilter: Liquid error: undefined filter filter1
 ```

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -63,6 +63,8 @@ module Liquid
       # :strict will enforce correct syntax.
       attr_writer :error_mode
 
+      attr_accessor :strict_filters, :strict_variables
+
       # Sets how strict the taint checker should be.
       # :lax is the default, and ignores the taint flag completely
       # :warn adds a warning, but does not interrupt the rendering
@@ -186,6 +188,9 @@ module Liquid
       else
         raise ArgumentError, "Expected Hash or Liquid::Context as parameter"
       end
+
+      context.strict_variables = self.class.strict_variables if self.class.strict_variables
+      context.strict_filters = self.class.strict_filters if self.class.strict_filters
 
       case args.last
       when Hash

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -288,6 +288,20 @@ class TemplateTest < Minitest::Test
     end
   end
 
+  def test_undefined_drop_methods_raise_with_global_setting
+    old_strict_variables = Template.strict_variables
+    Template.strict_variables = true
+
+    d = DropWithUndefinedMethod.new
+    t = Template.new.parse('{{ foo }} {{ woot }}')
+
+    assert_raises UndefinedDropMethod do
+      t.render!(d)
+    end
+  ensure
+    Template.strict_variables = old_strict_variables
+  end
+
   def test_undefined_filters
     t = Template.parse("{{a}} {{x | upcase | somefilter1 | somefilter2 | somefilter3}}")
     filters = Module.new do
@@ -309,6 +323,19 @@ class TemplateTest < Minitest::Test
     assert_raises UndefinedFilter do
       t.render!({ 'x' => 'foo' }, { strict_filters: true })
     end
+  end
+
+  def test_undefined_filters_raise_with_global_setting
+    old_strict_filters = Template.strict_filters
+    Template.strict_filters = true
+
+    t = Template.parse("{{x | somefilter1 | upcase | somefilter2}}")
+
+    assert_raises UndefinedFilter do
+      t.render!({ 'x' => 'foo' })
+    end
+  ensure
+    Template.strict_filters = old_strict_filters
   end
 
   def test_using_range_literal_works_as_expected


### PR DESCRIPTION
Add the possibility to configure strict_variables and strict_filters globally. This makes it easy to switch the behaviour in tests, yet preserve the lax validation in production. (useful when you want to ensure default templates uses appropriate variables or filters).

Thoughts?

@tjoyal @fw42 