### PR TITLE
add title case filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -32,6 +32,20 @@ module Liquid
       input.to_s.capitalize
     end
 
+    # Capitalize first character only
+    # or if input all or none caps use standard capitalization
+    def title_case(input)
+      result = []
+      input.split(' ').each do |e|
+        if e.to_s == e.to_s.downcase || e.to_s == e.to_s.upcase
+          result << e.to_s.capitalize
+        else
+          result << (e[0].to_s.capitalize + e[1..e.length])
+        end
+      end
+      result.join(' ')
+    end
+
     def escape(input)
       CGI.escapeHTML(input).untaint unless input.nil?
     end


### PR DESCRIPTION
A common problem with inputs is that they are entered oddly by users. While they are commonly backend filtered they are not always. 

The Title Case filter capitalizes the first character only unless the input is all upper or lower, in which case use standard capitalization.

```2.3.0 :002 > @template = Liquid::Template.parse("{{ name | title_case }}")
 => #<Liquid::Template: [...] > 
2.3.0 :003 > @template.render( 'name' => 'bob JONES mcAllister' )
 => "Bob Jones McAllister" ```

This is essentially a much quicker version of: 

```{% capture input %}
  {% assign inputs = input | split: ' ' %}
  {% for input in inputs %}
    {% assign x = 0 %}
    {% assign y = 0 %}
    {% assign input_arr = input | split: '' %}
      {% for char in input_arr %}
        {% assign char_cap = char | capitalize %}
        {% if char_cap == char %}
          {% assign x = x | plus: 1 %}
        {% endif %}
        {% assign y = y | plus: 1 %}
      {% endfor %}
      {% if x == 0 or x == y %}
        {{ input | capitalize }} (CASE1: {{x}},{{y}}) 
      {% else %}
        {% assign input_first_letter = input_arr[0] | capitalize %}
        {{ input_first_letter }}{{ input | replace_first: input_arr[0], '' }}
      {% endif %}
  {% endfor %}
{% endcapture %}
{{ input | rstrip }}```

I think this is a features that is likely to be useful to the majority of Liquid users.