### PR TITLE
Fixes #852: Undocumented Things

### DIFF
--- a/basics/introduction.md
+++ b/basics/introduction.md
@@ -68,3 +68,17 @@ You can read more about each type of tag in their respective sections.
 ```text
 {{ "/my/fancy/url" | append: ".html" }}
 ```
+
+Multiple filters can be used on one output. They are applied from left to right.
+
+<p class="code-label">Input</p>
+```liquid
+{% raw %}
+{{ "adam!" | capitalize | prepend: "Hello " }}
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```text
+Hello Adam!
+```

--- a/tags/comment.md
+++ b/tags/comment.md
@@ -10,13 +10,13 @@ within will not be executed.
 <p class="code-label">Input</p>
 ```liquid
 {% raw %}
-Any contents that you put between {% comment %} and {% endcomment %} tags
+Anything you put between {% comment %} and {% endcomment %} tags
 is turned into a comment.
 {% endraw %}
 ```
 
 <p class="code-label">Output</p>
 ```liquid
-Any contents that you put between {% comment %} and {% endcomment %} tags
+Anything you put between {% comment %} and {% endcomment %} tags
 is turned into a comment.
 ```

--- a/tags/comment.md
+++ b/tags/comment.md
@@ -1,5 +1,5 @@
 ---
-title: Comments
+title: Comment
 description: An overview of comments tags in the Liquid template language.
 ---
 

--- a/tags/comments.md
+++ b/tags/comments.md
@@ -1,0 +1,22 @@
+---
+title: Comments
+description: An overview of comments tags in the Liquid template language.
+---
+
+Allows you to leave un-rendered code inside a Liquid template. Any text within
+the opening and closing `comment` blocks will not be output, and any Liquid code
+within will not be executed.
+
+<p class="code-label">Input</p>
+```liquid
+{% raw %}
+Any contents that you put between {% comment %} and {% endcomment %} tags
+is turned into a comment.
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```liquid
+Any contents that you put between {% comment %} and {% endcomment %} tags
+is turned into a comment.
+```

--- a/tags/raw.md
+++ b/tags/raw.md
@@ -7,16 +7,16 @@ Raw temporarily disables tag processing. This is useful for generating content
 (eg, Mustache, Handlebars) which uses conflicting syntax.
 
 <p class="code-label">Input</p>
-```text
-{% raw %}
-{% raw %}
-  In Handlebars, {{ this }} will be HTML-escaped, but {{{ that }}} will not.
-{% endraw % }
-{% endraw %}
-```
+<pre class="highlight">
+<code>{% raw %}
+&#123;&#37; raw &#37;&#125;
+  In Handlebars, {{ this }} will be HTML-escaped, but
+  {{{ that }}} will not.
+&#123;&#37; endraw &#37;&#125;
+{% endraw %}</code>
+</pre>
 
 <p class="code-label">Output</p>
-```liquid
-Any contents that you put between {% comment %} and {% endcomment %} tags
-is turned into a comment.
+```text
+{% raw %}In Handlebars, {{ this }} will be HTML-escaped, but {{{ that }}} will not.{% endraw %}
 ```

--- a/tags/raw.md
+++ b/tags/raw.md
@@ -1,0 +1,22 @@
+---
+title: Raw
+description: An overview of raw tags in the Liquid template language.
+---
+
+Raw temporarily disables tag processing. This is useful for generating content
+(eg, Mustache, Handlebars) which uses conflicting syntax.
+
+<p class="code-label">Input</p>
+```text
+{% raw %}
+{% raw %}
+  In Handlebars, {{ this }} will be HTML-escaped, but {{{ that }}} will not.
+{% endraw % }
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```liquid
+Any contents that you put between {% comment %} and {% endcomment %} tags
+is turned into a comment.
+```


### PR DESCRIPTION
I was studying the Liquid code and saw #852. Figured I would be a good open source citizen and submit a quick pull request.

A few things about this PR. I really wasn't sure where things should go. Like should `comments` go on their own page, or a section on another page, like Introduction. Also, I wasn't sure if there should be a section on forloop helper variables added, as there's a note about them on the iterations page. So give me your feedback and I'll fix it up.

Lastly, for the life of me I could not figure out how to get the {% raw %} {% endraw %} tags to show up in the Input preview of the raw.md page. I know there has to be a way to do it, as it's done on [this](https://help.shopify.com/themes/liquid/tags/theme-tags#raw) Shopify documentation. If someone can let me know how to fix that properly, I'll correct the preview.