### PR TITLE
Fix stack level too deep error

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -7,6 +7,7 @@ module Liquid
   #   c.evaluate #=> true
   #
   class Condition #:nodoc:
+    @@depth = 0
     @@operators = {
       '=='.freeze => ->(cond, left, right) {  cond.send(:equal_variables, left, right) },
       '!='.freeze => ->(cond, left, right) { !cond.send(:equal_variables, left, right) },
@@ -47,6 +48,11 @@ module Liquid
       when :or
         result || @child_condition.evaluate(context)
       when :and
+        @@depth += 1
+        if @@depth >= 500
+          @@depth = 0
+          raise StackLevelError, "Nesting too deep".freeze
+        end
         result && @child_condition.evaluate(context)
       else
         result

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -130,6 +130,17 @@ class ConditionUnitTest < Minitest::Test
     assert_equal false, condition.evaluate
   end
 
+  def test_maximum_recursion_depth
+    condition = Condition.new(1, '==', 1)
+
+    assert_raises(Liquid::StackLevelError) do
+      (1..510).each do
+        condition.evaluate
+        condition.and Condition.new(2, '==', 2)
+      end
+    end
+  end
+
   def test_should_allow_custom_proc_operator
     Condition.operators['starts_with'] = proc { |cond, left, right| left =~ %r{^#{right}} }
 


### PR DESCRIPTION
Right now liquid doesn't have any limits for the recursion depth of conditions. Using a large amount of `and` operators will cause an uncatchable exception that depending on the configuration could stop the execution of the application using liquid. This could be an issue if users are allowed to provide or edit liquid templates.

To fix the issue I have added a maximum depth that will raise an exception if reached.

This issue only is reproducible with `and` operators.

@EiNSTeiN- @tjoyal 