### PR TITLE
Use a loop to evaluate binary comparisions to avoid recursion

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -41,16 +41,22 @@ module Liquid
     end
 
     def evaluate(context = Context.new)
-      result = interpret_condition(left, right, operator, context)
+      condition = self
+      result = nil
+      loop do
+        result = interpret_condition(condition.left, condition.right, condition.operator, context)
 
-      case @child_relation
-      when :or
-        result || @child_condition.evaluate(context)
-      when :and
-        result && @child_condition.evaluate(context)
-      else
-        result
+        case condition.child_relation
+        when :or
+          break if result
+        when :and
+          break unless result
+        else
+          break
+        end
+        condition = condition.child_condition
       end
+      result
     end
 
     def or(condition)
@@ -74,6 +80,10 @@ module Liquid
     def inspect
       "#<Condition #{[@left, @operator, @right].compact.join(' '.freeze)}>"
     end
+
+    protected
+
+    attr_reader :child_relation, :child_condition
 
     private
 


### PR DESCRIPTION
Fixes #890

## Problem

Running the following script results in a SystemStackError due to the recursive method calls used to evaluate conditions

```ruby
require 'liquid'

code = "{% if true "
code << "and true " * 50_000
code << "%}rendered{% endif %}"
puts Liquid::Template.parse(code).render
```

## Solution

Use a loop to evaluate the conditions, where local variables keep track of the current state, including a `condition` variable that is used instead of `self` to evaluate child conditions.