### PR TITLE
Use a loop to strictly parse binary comparisons to avoid recursion

### DIFF
--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -83,17 +83,20 @@ module Liquid
 
     def strict_parse(markup)
       p = Parser.new(markup)
-      condition = parse_binary_comparison(p)
+      condition = parse_binary_comparisons(p)
       p.consume(:end_of_string)
       condition
     end
 
-    def parse_binary_comparison(p)
+    def parse_binary_comparisons(p)
       condition = parse_comparison(p)
-      if op = (p.id?('and'.freeze) || p.id?('or'.freeze))
-        condition.send(op, parse_binary_comparison(p))
+      first_condition = condition
+      while op = (p.id?('and'.freeze) || p.id?('or'.freeze))
+        child_condition = parse_comparison(p)
+        condition.send(op, child_condition)
+        condition = child_condition
       end
-      condition
+      first_condition
     end
 
     def parse_comparison(p)


### PR DESCRIPTION
## Problem

Similar to #891, we were also using recursive method calls to strictly parse binary comparisons, where a template could cause a SystemStackError as shown by the following script

```ruby
require 'liquid'

code = "{% if true "
code << "and true " * 50_000
code << "%}rendered{% endif %}"
puts Liquid::Template.parse(code, error_mode: :strict).render
```

## Solution

Use a loop to parse the conditions, where a local variable keep track of the current condition link child conditions to following conditions, and the first condition is kept track of in a separate variable to use as the return value.