### PR TITLE
Replace `assert_equal nil,` with a `assert_nil`

### DIFF
--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -128,7 +128,7 @@ class StandardFiltersTest < Minitest::Test
 
   def test_escape
     assert_equal '&lt;strong&gt;', @filters.escape('<strong>')
-    assert_equal nil, @filters.escape(nil)
+    assert_nil @filters.escape(nil)
     assert_equal '&lt;strong&gt;', @filters.h('<strong>')
   end
 
@@ -138,14 +138,14 @@ class StandardFiltersTest < Minitest::Test
 
   def test_url_encode
     assert_equal 'foo%2B1%40example.com', @filters.url_encode('foo+1@example.com')
-    assert_equal nil, @filters.url_encode(nil)
+    assert_nil @filters.url_encode(nil)
   end
 
   def test_url_decode
     assert_equal 'foo bar', @filters.url_decode('foo+bar')
     assert_equal 'foo bar', @filters.url_decode('foo%20bar')
     assert_equal 'foo+1@example.com', @filters.url_decode('foo%2B1%40example.com')
-    assert_equal nil, @filters.url_decode(nil)
+    assert_nil @filters.url_decode(nil)
   end
 
   def test_truncatewords
@@ -330,7 +330,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "#{Date.today.year}", @filters.date('today', '%Y')
     assert_equal "#{Date.today.year}", @filters.date('Today', '%Y')
 
-    assert_equal nil, @filters.date(nil, "%B")
+    assert_nil @filters.date(nil, "%B")
 
     assert_equal '', @filters.date('', "%B")
 
@@ -343,8 +343,8 @@ class StandardFiltersTest < Minitest::Test
   def test_first_last
     assert_equal 1, @filters.first([1, 2, 3])
     assert_equal 3, @filters.last([1, 2, 3])
-    assert_equal nil, @filters.first([])
-    assert_equal nil, @filters.last([])
+    assert_nil @filters.first([])
+    assert_nil @filters.last([])
   end
 
   def test_replace

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -65,8 +65,8 @@ class ConditionUnitTest < Minitest::Test
   end
 
   def test_hash_compare_backwards_compatibility
-    assert_equal nil, Condition.new({}, '>', 2).evaluate
-    assert_equal nil, Condition.new(2, '>', {}).evaluate
+    assert_nil Condition.new({}, '>', 2).evaluate
+    assert_nil Condition.new(2, '>', {}).evaluate
     assert_equal false, Condition.new({}, '==', 2).evaluate
     assert_equal true, Condition.new({ 'a' => 1 }, '==', { 'a' => 1 }).evaluate
     assert_equal true, Condition.new({ 'a' => 2 }, 'contains', 'a').evaluate

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -98,12 +98,12 @@ class ContextUnitTest < Minitest::Test
     assert_equal false, @context['bool']
 
     @context['nil'] = nil
-    assert_equal nil, @context['nil']
-    assert_equal nil, @context['nil']
+    assert_nil @context['nil']
+    assert_nil @context['nil']
   end
 
   def test_variables_not_existing
-    assert_equal nil, @context['does_not_exist']
+    assert_nil @context['does_not_exist']
   end
 
   def test_scoping
@@ -185,7 +185,7 @@ class ContextUnitTest < Minitest::Test
     @context['test'] = 'test'
     assert_equal 'test', @context['test']
     @context.pop
-    assert_equal nil, @context['test']
+    assert_nil @context['test']
   end
 
   def test_hierachical_data
@@ -300,7 +300,7 @@ class ContextUnitTest < Minitest::Test
     @context['hash'] = { 'first' => 'Hello' }
 
     assert_equal 1, @context['array.first']
-    assert_equal nil, @context['array["first"]']
+    assert_nil @context['array["first"]']
     assert_equal 'Hello', @context['hash["first"]']
   end
 


### PR DESCRIPTION
`assert_equal nil` is deprecated, so this removes a bunch of deprecation warnings that are output while running the tests