### PR TITLE
Use stackprof to test the lack of object allocations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'stackprof', platforms: :mri_21
+
+gem 'stackprof', platforms: :mri
 
 group :benchmark, :test do
   gem 'benchmark-ips'
 end
 
 group :test do
-  gem 'spy', '0.4.1'
   gem 'rubocop', '0.34.2'
 
   platform :mri do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@
 
 ENV["MT_NO_EXPECTATIONS"] = "1"
 require 'minitest/autorun'
-require 'spy/integration'
 
 $LOAD_PATH.unshift(File.join(File.expand_path(__dir__), '..', 'lib'))
 require 'liquid.rb'

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -70,10 +70,6 @@ class ContextUnitTest < Minitest::Test
     @context = Liquid::Context.new
   end
 
-  def teardown
-    Spy.teardown
-  end
-
   def test_variables
     @context['string'] = 'string'
     assert_equal 'string', @context['string']
@@ -450,14 +446,10 @@ class ContextUnitTest < Minitest::Test
     assert_equal @context, @context['category'].context
   end
 
-  def test_use_empty_instead_of_any_in_interrupt_handling_to_avoid_lots_of_unnecessary_object_allocations
-    mock_any = Spy.on_instance_method(Array, :any?)
-    mock_empty = Spy.on_instance_method(Array, :empty?)
-
-    @context.interrupt?
-
-    refute mock_any.has_been_called?
-    assert mock_empty.has_been_called?
+  def test_interrupt_avoids_object_allocations
+    assert_no_object_allocations do
+      @context.interrupt?
+    end
   end
 
   def test_context_initialization_with_a_proc_in_environment
@@ -479,5 +471,19 @@ class ContextUnitTest < Minitest::Test
   def test_apply_global_filter_when_no_global_filter_exist
     context = Context.new
     assert_equal 'hi', context.apply_global_filter('hi')
+  end
+
+  private
+
+  def assert_no_object_allocations
+    unless RUBY_ENGINE == 'ruby'
+      skip "stackprof needed to count object allocations"
+    end
+    require 'stackprof'
+
+    profile = StackProf.run(mode: :object) do
+      yield
+    end
+    assert_equal 0, profile[:samples]
   end
 end # ContextTest


### PR DESCRIPTION
## Problem

I was getting a bunch of warnings when running the tests that were caused by the Spy gem

```
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:55: warning: method redefined; discarding old any?
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:55: warning: method redefined; discarding old empty?
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:204: warning: instance variable @plan not initialized
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:72: warning: method redefined; discarding old any?
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:228: warning: previous definition of any? was here
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:72: warning: method redefined; discarding old empty?
/Users/dylansmith/.gem/ruby/2.3.3/gems/spy-0.4.1/lib/spy/subroutine.rb:228: warning: previous definition of empty? was here
```

## Solution

We were just using the spy gem in a single test, where we were testing the implementation instead of what we actually cared about, avoiding object allocations.  I changed the test to use stackprof to count object allocations so we could assert that none were made.

This also fixes the Gemfile so that we can use stackprof to profile any any of the support MRI versions.  Previously it would only install stackprof for MRI ruby 2.1, which is now the minimum ruby version we support.