### PR TITLE
CGI powered standard filters to handle non string inputs

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -33,7 +33,7 @@ module Liquid
     end
 
     def escape(input)
-      CGI.escapeHTML(input).untaint unless input.nil?
+      CGI.escapeHTML(input.to_s).untaint unless input.nil?
     end
     alias_method :h, :escape
 
@@ -42,11 +42,11 @@ module Liquid
     end
 
     def url_encode(input)
-      CGI.escape(input) unless input.nil?
+      CGI.escape(input.to_s) unless input.nil?
     end
 
     def url_decode(input)
-      CGI.unescape(input) unless input.nil?
+      CGI.unescape(input.to_s) unless input.nil?
     end
 
     def slice(input, offset, length = nil)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -128,8 +128,16 @@ class StandardFiltersTest < Minitest::Test
 
   def test_escape
     assert_equal '&lt;strong&gt;', @filters.escape('<strong>')
+    assert_equal '1', @filters.escape(1)
+    assert_equal '2001-02-03', @filters.escape(Date.new(2001, 2, 3))
     assert_nil @filters.escape(nil)
+  end
+
+  def test_h
     assert_equal '&lt;strong&gt;', @filters.h('<strong>')
+    assert_equal '1', @filters.h(1)
+    assert_equal '2001-02-03', @filters.h(Date.new(2001, 2, 3))
+    assert_nil @filters.h(nil)
   end
 
   def test_escape_once
@@ -138,6 +146,8 @@ class StandardFiltersTest < Minitest::Test
 
   def test_url_encode
     assert_equal 'foo%2B1%40example.com', @filters.url_encode('foo+1@example.com')
+    assert_equal '1', @filters.url_encode(1)
+    assert_equal '2001-02-03', @filters.url_encode(Date.new(2001, 2, 3))
     assert_nil @filters.url_encode(nil)
   end
 
@@ -145,6 +155,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal 'foo bar', @filters.url_decode('foo+bar')
     assert_equal 'foo bar', @filters.url_decode('foo%20bar')
     assert_equal 'foo+1@example.com', @filters.url_decode('foo%2B1%40example.com')
+    assert_equal '1', @filters.url_decode(1)
+    assert_equal '2001-02-03', @filters.url_decode(Date.new(2001, 2, 3))
     assert_nil @filters.url_decode(nil)
   end
 


### PR DESCRIPTION
## Problem

Some standard filters to not properly handle unexpected argument.

```ruby
Liquid::Template.parse("{{ 1 | url_encode }}").render
```

```
NoMethodError: undefined method `encoding' for 1:Fixnum
    /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/cgi/util.rb:7:in `escape'
    /Users/tjoyal/projects/liquid/lib/liquid/standardfilters.rb:45:in `url_encode'
```

## Solution

I'm usually aim to raise exceptions when the received parameters is not of the proper type(eg.: `Liquid::StandardError`), but most of the standard filters do explicit `to_s` before processing the input (for the same reason we also do an explicit check for `nil`?).

I ended up adding explicit `to_s`. 

Thoughts?
Is this going in the right direction or should all non string parameters raise an exception?
Why is `nil` treated differently here compared to other filters? Seems to be a behaviour split introduced by https://github.com/Shopify/liquid/commit/704937bc00b4472200196158c7a7f4ef43c18714#diff-844406140a08cdeddd843cfbdf0222d6L45