### PR TITLE
Make 'include with' different from 'include for'

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -14,7 +14,7 @@ module Liquid
   #   {% include 'product' for products %}
   #
   class Include < Tag
-    Syntax = /(#{QuotedFragment}+)(\s+(?:with|for)\s+(#{QuotedFragment}+))?/o
+    Syntax = /(#{QuotedFragment}+)(\s+(with|for)\s+(#{QuotedFragment}+))?/o
 
     def initialize(tag_name, markup, options)
       super
@@ -22,10 +22,12 @@ module Liquid
       if markup =~ Syntax
 
         template_name = $1
-        variable_name = $3
+        local_inclusion_type = $3
+        variable_name = $4
 
         @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
         @template_name_expr = Expression.parse(template_name)
+        @local_inclusion_type = local_inclusion_type
         @attributes = {}
 
         markup.scan(TagAttributes) do |key, value|
@@ -63,7 +65,7 @@ module Liquid
             context[key] = context.evaluate(value)
           end
 
-          if variable.is_a?(Array)
+          if variable.is_a?(Array) && @local_inclusion_type != 'with'
             variable.collect do |var|
               context[context_variable_name] = var
               partial.render(context)

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 class TestFileSystem
   def read_template_file(template_path)
     case template_path
+    when "products"
+      "Products: {% for product in products %}Product: {{ product.title }} {% endfor %}"
+
     when "product"
       "Product: {{ product.title }} "
 
@@ -88,6 +91,11 @@ class IncludeTagTest < Minitest::Test
   def test_include_tag_with_default_name
     assert_template_result "Product: Draft 151cm ",
       "{% include 'product' %}", "product" => { 'title' => 'Draft 151cm' }
+  end
+
+  def test_include_tag_with_array
+    assert_template_result "Products: Product: Draft 151cm Product: Element 155cm ",
+      "{% include 'products' with products %}", "products" => [ { 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' } ]
   end
 
   def test_include_tag_for


### PR DESCRIPTION
The include tag currently accepts the 'with' and 'for' qualifiers when a
local variable is passed in. The documentation at
http://www.rubydoc.info/github/Shopify/liquid/Liquid/Include
implies that these different terms cause different behavior, but this
has never been the case. Consequently, when a variable exists in the
parent template with the same name as the partial it is not possible to
pass an array to that liquid partial without the partial being rendered
once for each element in the same-named array.

This change allows the caller to pass an array in using the 'with'
keyword and force the partial to be rendered once. The default behavior
for same-named variables, and the behavior with the for keyword, remain
unchanged.