### PR TITLE
Add to_power as standard filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -319,6 +319,10 @@ module Liquid
       apply_operation(input, operand, :*)
     end
 
+    def to_power(input, operand)
+      apply_operation(input, operand, :**)
+    end
+
     # division
     def divided_by(input, operand)
       apply_operation(input, operand, :/)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -440,6 +440,18 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "4", "{{ price | times:2 }}", 'price' => NumberLikeThing.new(2)
   end
 
+  def test_to_power
+    assert_template_result "9", "{{ 3 | to_power:2 }}"
+    assert_template_result "4", "{{ 4 | to_power:1 }}"
+    assert_template_result "3.0", '{{ 9 | to_power:"0.5" }}'
+    assert_template_result "1", "{{ 1 | to_power:3 }}"
+    assert_template_result "0", "{{ 0 | to_power:4 }}"
+    assert_template_result "0", "{{ 'foo' | to_power:2 }}"
+    assert_template_result "4", '{{ "-2" | to_power:2 }}'
+    assert_template_result "-27", '{{ "-3" | to_power:3 }}'
+    assert_template_result "32", "{{ price | to_power:5 }}", 'price' => NumberLikeThing.new(2)
+  end
+
   def test_divided_by
     assert_template_result "4", "{{ 12 | divided_by:3 }}"
     assert_template_result "4", "{{ 14 | divided_by:3 }}"


### PR DESCRIPTION
A simple filter to computer the input to a certain power, it
- will compute any number to any power.
- will correctly handle a negative base.
- will return 0 if the input is not a number.
- will return a float when the power is less then 1 (i.e. a root), **would like some feedback on this**.

Although this is a filter that can be implemented with ease when needed, the filter is so basic and small that I think it doesn't hurt to add it to the core. Additionally, [in some scenarios](https://github.com/simple-icons/simple-icons/issues/480#issuecomment-319086273) it will not be possible to add custom filters, in which case something as basic as this would be nice to have available 🙂 