### PR TITLE
Add support for iterating ranges with float boundaries.

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -129,7 +129,7 @@ module Liquid
       end
 
       collection = context.evaluate(@collection_name)
-      collection = collection.to_a if collection.is_a?(Range)
+      collection = collection.step(1).to_a if collection.is_a?(Range)
 
       limit = context.evaluate(@limit)
       to = limit ? limit.to_i + from : nil

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -48,6 +48,10 @@ HERE
 
   def test_for_with_variable_range
     assert_template_result(' 1  2  3 ', '{%for item in (1..foobar) %} {{item}} {%endfor%}', "foobar" => 3)
+    assert_template_result(' 1.0  2.0  3.0 ', '{%for item in foobar %} {{item}} {%endfor%}', "foobar" => (1..3.0))
+    assert_template_result(' 1.0  2.0  3.0 ', '{%for item in foobar %} {{item}} {%endfor%}', "foobar" => (1.0..3))
+    assert_template_result(' 1.0  2.0  3.0 ', '{%for item in foobar %} {{item}} {%endfor%}', "foobar" => (1.0..3.0))
+    assert_template_result(' 1.5  2.5 ', '{%for item in foobar %} {{item}} {%endfor%}', "foobar" => (1.5..3))
   end
 
   def test_for_with_hash_value_range


### PR DESCRIPTION
The meaning I gave is to start at the lower bound and step by one. This has the
advantage of having (n..m) and ((n.to_f)..(m.to_f)) behave the same. Another
thing we could do that have this same property is to cast bounds to integer.
This would do the right thing if there is a floating point rounding error, but I
feel it is more surprising for cases such as (1.5..8).

Note that it is not possible to create ranges with floating point boundaries
directly in Liquid at the moment. However, since there is no distinction between
Ruby and Liquid ranges, a drop can introduce such a value by returning it.