### PR TITLE
Do not raise when variable is defined

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,9 +73,6 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/TrailingComma:
-  Enabled: false
-
 Style/IndentHash:
   EnforcedStyle: consistent
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,9 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/TrailingComma:
+  Enabled: false
+
 Style/IndentHash:
   EnforcedStyle: consistent
 

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -171,7 +171,9 @@ module Liquid
       if scope.nil?
         @environments.each do |e|
           variable = lookup_and_evaluate(e, key, raise_on_not_found: raise_on_not_found)
-          unless variable.nil?
+          # When lookup returned a value OR there is no value but the lookup also did not raise
+          # then it is the value we are looking for.
+          if variable != nil || @strict_variables && raise_on_not_found
             scope = e
             break
           end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -173,7 +173,7 @@ module Liquid
           variable = lookup_and_evaluate(e, key, raise_on_not_found: raise_on_not_found)
           # When lookup returned a value OR there is no value but the lookup also did not raise
           # then it is the value we are looking for.
-          if variable != nil || @strict_variables && raise_on_not_found
+          if !variable.nil? || @strict_variables && raise_on_not_found
             scope = e
             break
           end

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -264,7 +264,7 @@ class TemplateTest < Minitest::Test
   def test_nil_value_does_not_raise
     Liquid::Template.error_mode = :strict
     t = Template.parse("some{{x}}thing")
-    result = t.render!({'x' => nil}, strict_variables: true)
+    result = t.render!({ 'x' => nil }, strict_variables: true)
 
     assert_equal 0, t.errors.count
     assert_equal 'something', result

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -261,6 +261,15 @@ class TemplateTest < Minitest::Test
     assert_equal 'Liquid error: undefined variable d', t.errors[2].message
   end
 
+  def test_nil_value_does_not_raise
+    Liquid::Template.error_mode = :strict
+    t = Template.parse("some{{x}}thing")
+    result = t.render!({'x' => nil}, strict_variables: true)
+
+    assert_equal 0, t.errors.count
+    assert_equal 'something', result
+  end
+
   def test_undefined_variables_raise
     t = Template.parse("{{x}} {{y}} {{z.a}} {{z.b}} {{z.c.d}}")
 


### PR DESCRIPTION
Variables which are defined but have a nil value should not raise.

See #749