### PR TITLE
Use replacement string for replace filters literally

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -201,12 +201,14 @@ module Liquid
 
     # Replace occurrences of a string with another
     def replace(input, string, replacement = ''.freeze)
-      input.to_s.gsub(string.to_s, replacement.to_s)
+      replacement = replacement.to_s
+      input.to_s.gsub(string.to_s) { replacement }
     end
 
     # Replace the first occurrences of a string with another
     def replace_first(input, string, replacement = ''.freeze)
-      input.to_s.sub(string.to_s, replacement.to_s)
+      replacement = replacement.to_s
+      input.to_s.sub(string.to_s) { replacement }
     end
 
     # remove a substring

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -362,8 +362,10 @@ class StandardFiltersTest < Minitest::Test
   def test_replace
     assert_equal '2 2 2 2', @filters.replace('1 1 1 1', '1', 2)
     assert_equal '2 2 2 2', @filters.replace('1 1 1 1', 1, 2)
+    assert_equal "\\& \\& \\& \\&", @filters.replace('1 1 1 1', '1', "\\&")
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2)
     assert_equal '2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2)
+    assert_equal '\\& 1 1 1', @filters.replace_first("1 1 1 1", '1', "\\&")
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
   end
 


### PR DESCRIPTION
Fixes #923

Use the block form of String#sub and String#gsub so the replacement string is treated literally.