### PR TITLE
Prefer faster `while true` over `loop do`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,13 @@ Lint/UnusedBlockArgument:
 Lint/EndAlignment:
   AlignWith: variable
 
+Lint/LiteralInCondition:
+  Enabled: false
+
 Lint/UnusedMethodArgument:
+  Enabled: false
+
+Style/InfiniteLoop:
   Enabled: false
 
 Style/SingleLineBlockParams:

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -42,7 +42,6 @@ module Liquid
 
     def evaluate(context = Context.new)
       condition = self
-      result = nil
       while true
         result = interpret_condition(condition.left, condition.right, condition.operator, context)
 

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -43,7 +43,7 @@ module Liquid
     def evaluate(context = Context.new)
       condition = self
       result = nil
-      loop do
+      while true
         result = interpret_condition(condition.left, condition.right, condition.operator, context)
 
         case condition.child_relation


### PR DESCRIPTION
`Kernel#loop` is about more than **`2x slower`** than `while true`
Even slower with Ruby 2.4
 
Benchmark: https://github.com/JuanitoFatas/fast-ruby#loop-vs-while-true-code