### PR TITLE
Avoid hash with default values due to inconsistent marshaling

### DIFF
--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -30,7 +30,7 @@ module Liquid
     end
 
     def render(context)
-      context.registers[:cycle] ||= Hash.new
+      context.registers[:cycle] ||= {}
 
       context.stack do
         key = context.evaluate(@name)

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -30,11 +30,11 @@ module Liquid
     end
 
     def render(context)
-      context.registers[:cycle] ||= Hash.new(0)
+      context.registers[:cycle] ||= Hash.new
 
       context.stack do
         key = context.evaluate(@name)
-        iteration = context.registers[:cycle][key]
+        iteration = context.registers[:cycle][key].to_i
         result = context.evaluate(@variables[iteration])
         iteration += 1
         iteration  = 0 if iteration >= @variables.size

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -120,7 +120,7 @@ module Liquid
     private
 
     def collection_segment(context)
-      offsets = context.registers[:for] ||= Hash.new
+      offsets = context.registers[:for] ||= {}
 
       from = if @from == :continue
         offsets[@name].to_i

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -120,7 +120,7 @@ module Liquid
     private
 
     def collection_segment(context)
-      offsets = context.registers[:for] ||= Hash.new(0)
+      offsets = context.registers[:for] ||= Hash.new
 
       from = if @from == :continue
         offsets[@name].to_i


### PR DESCRIPTION
Encoding/Decoding the liquid context using different encoders doesn't always encode hashes and remember that they can have a default value.

```rb
# Poor example, but `snappy` would behave the same way.
irb(main):009:0> JSON.load(JSON.dump(Hash.new(0)))[0]
=> nil # => 0 would have been expected
```

Instead, it's easier to just avoid using default values here and simply cast them to Fixnum where needed. 