### PR TITLE
refactor: Reduce maximum block nesting in Liquid::BlockBody#parse

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,8 +7,6 @@ AllCops:
 
 Metrics/BlockNesting:
   Max: 3
-  Exclude:
-    - 'lib/liquid/block_body.rb'
 
 Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
## Problem

From https://github.com/Shopify/liquid/pull/937#issuecomment-337062937

> CI is angry at me because of linter errors (I re-used BlockBody#parse's structure which has more than 3 levels of block nesting), the the rest of the test suite runs successfully.

## Solution

Use early `return`s or `next` statements to reduce nesting.  That way we no longer have a rubocop exception for this method.