### PR TITLE
Add max and min filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -355,6 +355,22 @@ module Liquid
       raise Liquid::FloatDomainError, e.message
     end
 
+    def max(input, n)
+      max_value = Utils.to_number(n)
+
+      result = Utils.to_number(input)
+      result = max_value if result > max_value
+      result.is_a?(BigDecimal) ? result.to_f : result
+    end
+
+    def min(input, n)
+      min_value = Utils.to_number(n)
+
+      result = Utils.to_number(input)
+      result = min_value if result < min_value
+      result.is_a?(BigDecimal) ? result.to_f : result
+    end
+
     def default(input, default_value = ''.freeze)
       if !input || input.respond_to?(:empty?) && input.empty?
         default_value

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -498,6 +498,28 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "5", "{{ price | floor }}", 'price' => NumberLikeThing.new(5.4)
   end
 
+  def test_max
+    assert_template_result "4", "{{ 5 | max:4 }}"
+    assert_template_result "5", "{{ 5 | max:5 }}"
+    assert_template_result "5", "{{ 5 | max:6 }}"
+
+    assert_template_result "4.5", "{{ 4.5 | max:5 }}"
+    assert_template_result "5", "{{ width | max:5 }}", 'width' => NumberLikeThing.new(6)
+    assert_template_result "4", "{{ width | max:5 }}", 'width' => NumberLikeThing.new(4)
+    assert_template_result "4", "{{ 5 | max: width }}", 'width' => NumberLikeThing.new(4)
+  end
+
+  def test_min
+    assert_template_result "5", "{{ 5 | min:4 }}"
+    assert_template_result "5", "{{ 5 | min:5 }}"
+    assert_template_result "6", "{{ 5 | min:6 }}"
+
+    assert_template_result "5", "{{ 4.5 | min:5 }}"
+    assert_template_result "6", "{{ width | min:5 }}", 'width' => NumberLikeThing.new(6)
+    assert_template_result "5", "{{ width | min:5 }}", 'width' => NumberLikeThing.new(4)
+    assert_template_result "6", "{{ 5 | min: width }}", 'width' => NumberLikeThing.new(6)
+  end
+
   def test_append
     assigns = { 'a' => 'bc', 'b' => 'd' }
     assert_template_result('bcd', "{{ a | append: 'd'}}", assigns)


### PR DESCRIPTION
This will introduce `max` and `min` filters. An example use case:

```liquid
{%- assign width = 250 -%}

{%- if image.width < width -%}
  {%- assign width = image.width -%}
{%- endif -%}
```

The above can be replaced with:

```liquid
{%- assign width = image.width | max: 250 -%}
```

If invalid inputs are given (eg. `"foo"`), they would default to 0 (eg. `{{ "foo" | max: 5 }` returns `0`, and `{{ "foo" | min:5 }}` returns `5`), which is consistent with other filters that work on numbers (ceil, floor etc), but I haven't added test cases for those.

@Thibaut 