### PR TITLE
Rename min/max filters for clarity

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -353,19 +353,19 @@ module Liquid
       raise Liquid::FloatDomainError, e.message
     end
 
-    def max(input, n)
-      max_value = Utils.to_number(n)
-
-      result = Utils.to_number(input)
-      result = max_value if max_value > result
-      result.is_a?(BigDecimal) ? result.to_f : result
-    end
-
-    def min(input, n)
+    def at_least(input, n)
       min_value = Utils.to_number(n)
 
       result = Utils.to_number(input)
-      result = min_value if min_value < result
+      result = min_value if min_value > result
+      result.is_a?(BigDecimal) ? result.to_f : result
+    end
+
+    def at_most(input, n)
+      max_value = Utils.to_number(n)
+
+      result = Utils.to_number(input)
+      result = max_value if max_value < result
       result.is_a?(BigDecimal) ? result.to_f : result
     end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -496,26 +496,26 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "5", "{{ price | floor }}", 'price' => NumberLikeThing.new(5.4)
   end
 
-  def test_min
-    assert_template_result "4", "{{ 5 | min:4 }}"
-    assert_template_result "5", "{{ 5 | min:5 }}"
-    assert_template_result "5", "{{ 5 | min:6 }}"
+  def test_at_most
+    assert_template_result "4", "{{ 5 | at_most:4 }}"
+    assert_template_result "5", "{{ 5 | at_most:5 }}"
+    assert_template_result "5", "{{ 5 | at_most:6 }}"
 
-    assert_template_result "4.5", "{{ 4.5 | min:5 }}"
-    assert_template_result "5", "{{ width | min:5 }}", 'width' => NumberLikeThing.new(6)
-    assert_template_result "4", "{{ width | min:5 }}", 'width' => NumberLikeThing.new(4)
-    assert_template_result "4", "{{ 5 | min: width }}", 'width' => NumberLikeThing.new(4)
+    assert_template_result "4.5", "{{ 4.5 | at_most:5 }}"
+    assert_template_result "5", "{{ width | at_most:5 }}", 'width' => NumberLikeThing.new(6)
+    assert_template_result "4", "{{ width | at_most:5 }}", 'width' => NumberLikeThing.new(4)
+    assert_template_result "4", "{{ 5 | at_most: width }}", 'width' => NumberLikeThing.new(4)
   end
 
-  def test_max
-    assert_template_result "5", "{{ 5 | max:4 }}"
-    assert_template_result "5", "{{ 5 | max:5 }}"
-    assert_template_result "6", "{{ 5 | max:6 }}"
+  def test_at_least
+    assert_template_result "5", "{{ 5 | at_least:4 }}"
+    assert_template_result "5", "{{ 5 | at_least:5 }}"
+    assert_template_result "6", "{{ 5 | at_least:6 }}"
 
-    assert_template_result "5", "{{ 4.5 | max:5 }}"
-    assert_template_result "6", "{{ width | max:5 }}", 'width' => NumberLikeThing.new(6)
-    assert_template_result "5", "{{ width | max:5 }}", 'width' => NumberLikeThing.new(4)
-    assert_template_result "6", "{{ 5 | max: width }}", 'width' => NumberLikeThing.new(6)
+    assert_template_result "5", "{{ 4.5 | at_least:5 }}"
+    assert_template_result "6", "{{ width | at_least:5 }}", 'width' => NumberLikeThing.new(6)
+    assert_template_result "5", "{{ width | at_least:5 }}", 'width' => NumberLikeThing.new(4)
+    assert_template_result "6", "{{ 5 | at_least: width }}", 'width' => NumberLikeThing.new(6)
   end
 
   def test_append


### PR DESCRIPTION
`min` and `max` were added in https://github.com/Shopify/liquid/pull/954. The original implementation behaved as "`min` = limit a number to a minimum value" and "`max` = limit a number to a maximum value".

This makes sense in the context of Liquid, since a filter is generally interpreted as a verb/action, but is confusing in the context of programming languages in general, which tend to have `min` / `max` functions that return the minimum/maximum value passed as argument.

After realizing this, I flipped the behavior in 282d42f98d03d8bdedc1f4964c46be13ba0d98f4, before realizing that it's not that simple 😛 

Given the confusion (I've asked multiple people and got different answers), I propose we rename the filters for clarity.

@nithinbekal @pushrax @davidcornu @fw42 @dylanahsmith thoughts?