### PR TITLE
have travis test against ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3.3
+  - 2.3
+  - 2.4
   - ruby-head
   - jruby-head
 #  - rbx-2


### PR DESCRIPTION
This adds ruby 2.4 to the travis build matrix.