### PR TITLE
Add a regression test for a liquid-c trim mode bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :test do
   gem 'rubocop', '~> 0.49.0'
 
   platform :mri do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'bd53db95de3d44d631e7c5a267c3d934e66107dd'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: '9168659de45d6d576fce30c735f857e597fa26f6'
   end
 end

--- a/test/integration/trim_mode_test.rb
+++ b/test/integration/trim_mode_test.rb
@@ -496,6 +496,10 @@ class TrimModeTest < Minitest::Test
     assert_template_result(expected, text)
   end
 
+  def test_right_trim_followed_by_tag
+    assert_template_result('ab c', '{{ "a" -}}{{ "b" }} c')
+  end
+
   def test_raw_output
     whitespace = '        '
     text = <<-END_TEMPLATE


### PR DESCRIPTION
This is a regression test to make sure https://github.com/Shopify/liquid-c/pull/39 fixes #971