### PR TITLE
standardfilters: add regex replace/remove filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -204,9 +204,19 @@ module Liquid
       input.to_s.gsub(string.to_s, replacement.to_s)
     end
 
+    # Replace occurrences of a string which matches the regular expression with another
+    def regex_replace(input, regex, replacement = ''.freeze)
+      input.to_s.gsub(Regexp.new(regex.to_s), replacement.to_s)
+    end
+
     # Replace the first occurrences of a string with another
     def replace_first(input, string, replacement = ''.freeze)
       input.to_s.sub(string.to_s, replacement.to_s)
+    end
+
+    # Replace the first occurrences of a string which matches the regular expression with another
+    def regex_replace_first(input, regex, replacement = ''.freeze)
+      input.to_s.sub(Regexp.new(regex.to_s), replacement.to_s)
     end
 
     # remove a substring
@@ -214,9 +224,19 @@ module Liquid
       input.to_s.gsub(string.to_s, ''.freeze)
     end
 
+    # remove a substring which matches the regular expression
+    def regex_remove(input, regex)
+      input.to_s.gsub(Regexp.new(regex.to_s), ''.freeze)
+    end
+
     # remove the first occurrences of a substring
     def remove_first(input, string)
       input.to_s.sub(string.to_s, ''.freeze)
+    end
+
+    # remove the first occurrences of a substring which matches the regular expression
+    def regex_remove_first(input, regex)
+      input.to_s.sub(Regexp.new(regex.to_s), ''.freeze)
     end
 
     # add one string to another

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -367,12 +367,24 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result '2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}"
   end
 
+  def test_regex_replace
+    assert_equal 'foo bar baz baz', @filters.regex_replace('foo bar 123 456', '\d+', 'baz')
+    assert_equal 'foo bar baz 456', @filters.regex_replace_first('foo bar 123 456', '\d+', 'baz')
+    assert_template_result 'foo bar baz 456', "{{ 'foo bar 123 456' | regex_replace_first: '\\d+', 'baz' }}"
+  end
+
   def test_remove
     assert_equal '   ', @filters.remove("a a a a", 'a')
     assert_equal '   ', @filters.remove("1 1 1 1", 1)
     assert_equal 'a a a', @filters.remove_first("a a a a", 'a ')
     assert_equal ' 1 1 1', @filters.remove_first("1 1 1 1", 1)
     assert_template_result 'a a a', "{{ 'a a a a' | remove_first: 'a ' }}"
+  end
+
+  def test_regex_remove
+    assert_equal 'foo bar  ', @filters.regex_remove('foo bar 123 456', '\d+')
+    assert_equal 'foo bar  456', @filters.regex_remove_first('foo bar 123 456', '\d+')
+    assert_template_result 'foo bar ', "{{ 'foo bar 123' | regex_remove_first: '\\d+' }}"
   end
 
   def test_pipes_in_string_arguments


### PR DESCRIPTION
This commit adds the following new filters:
 * regex_replace
 * regex_replace_first
 * regex_remove
 * regex_remove_first

They are similar to the existing replace/replace_first/remove/remove_first filters.
Except, they treat the search string parameter as regular expression.