### PR TITLE
Assign regexps to constants

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -2,6 +2,7 @@ module Liquid
   class BlockBody
     FullToken = /\A#{TagStart}#{WhitespaceControl}?\s*(\w+)\s*(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
+    WhitespaceOrNothing = /\A\s*\z/
     TAGSTART = "{%".freeze
     VARSTART = "{{".freeze
 
@@ -43,7 +44,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= !!(token =~ /\A\s*\z/)
+          @blank &&= !!(token =~ WhitespaceOrNothing)
         end
         parse_context.line_number = tokenizer.line_number
       end

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -21,20 +21,24 @@ module Liquid
       'empty'.freeze => MethodLiteral.new(:empty?, '').freeze
     }
 
+    SINGLE_QUOTED_STRING = /\A'(.*)'\z/m
+    DOUBLE_QUOTED_STRING = /\A"(.*)"\z/m
+    INTEGERS_REGEX       = /\A(-?\d+)\z/
+    FLOATS_REGEX         = /\A(-?\d+\.\d+)\z/
+    RANGES_REGEX         = /\A\((\S+)\.\.(\S+)\)\z/
+
     def self.parse(markup)
       if LITERALS.key?(markup)
         LITERALS[markup]
       else
         case markup
-        when /\A'(.*)'\z/m # Single quoted strings
+        when SINGLE_QUOTED_STRING, DOUBLE_QUOTED_STRING
           $1
-        when /\A"(.*)"\z/m # Double quoted strings
-          $1
-        when /\A(-?\d+)\z/ # Integer and floats
+        when INTEGERS_REGEX
           $1.to_i
-        when /\A\((\S+)\.\.(\S+)\)\z/ # Ranges
+        when RANGES_REGEX
           RangeLookup.parse($1, $2)
-        when /\A(-?\d[\d\.]+)\z/ # Floats
+        when FLOATS_REGEX
           $1.to_f
         else
           VariableLookup.parse(markup)

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -24,7 +24,7 @@ module Liquid
     SINGLE_QUOTED_STRING = /\A'(.*)'\z/m
     DOUBLE_QUOTED_STRING = /\A"(.*)"\z/m
     INTEGERS_REGEX       = /\A(-?\d+)\z/
-    FLOATS_REGEX         = /\A(-?\d+\.\d+)\z/
+    FLOATS_REGEX         = /\A(-?\d[\d\.]+)\z/
     RANGES_REGEX         = /\A\((\S+)\.\.(\S+)\)\z/
 
     def self.parse(markup)

--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -19,6 +19,7 @@ module Liquid
     NUMBER_LITERAL = /-?\d+(\.\d+)?/
     DOTDOT = /\.\./
     COMPARISON_OPERATOR = /==|!=|<>|<=?|>=?|contains(?=\s)/
+    WHITESPACE_OR_NOTHING = /\s*/
 
     def initialize(input)
       @ss = StringScanner.new(input)
@@ -28,7 +29,7 @@ module Liquid
       @output = []
 
       until @ss.eos?
-        @ss.skip(/\s*/)
+        @ss.skip(WHITESPACE_OR_NOTHING)
         break if @ss.eos?
         tok = case
         when t = @ss.scan(COMPARISON_OPERATOR) then [:comparison, t]


### PR DESCRIPTION
This is to avoid creating multiple instances of those regexps each time they're encountered within a given Class instance