### PR TITLE
Avoid creating unnecessary local variables in each blocks

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -82,10 +82,8 @@ module Liquid
             break
           end
 
-          node_output = render_node(token, context)
-
           unless token.is_a?(Block) && token.blank?
-            output << node_output
+            output << render_node(token, context)
           end
         rescue MemoryError => e
           raise e


### PR DESCRIPTION
especially when the local variable is not used elsewhere in the method