### PR TITLE
Replace String#=~(regex) w/ faster methods

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -2,7 +2,6 @@ module Liquid
   class BlockBody
     FullToken = /\A#{TagStart}#{WhitespaceControl}?\s*(\w+)\s*(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
-    WhitespaceOrNothing = /\A\s*\z/
     TAGSTART = "{%".freeze
     VARSTART = "{{".freeze
 
@@ -44,7 +43,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= !!(token =~ WhitespaceOrNothing)
+          @blank &&= token.strip.empty?
         end
         parse_context.line_number = tokenizer.line_number
       end


### PR DESCRIPTION
This is a micro-optimization that may not make a difference in the grand scheme of things.. :grin: 

Here's a crude benchmark script in case you're curious
```ruby
require 'benchmark/ips'

WhitespaceOrNothing = /\A\s*\z/

def match_regex(input)
  !!(input =~ WhitespaceOrNothing)
end

def strip_empty(input)
  input.strip.empty?
end

[
  "",
  "  ",
  "\n\n",
  "\n \n \n"
].each do |input|
  if match_regex(input) == strip_empty(input)
    Benchmark.ips do |x|
      x.report("'#{input}'-regex") { match_regex(input) }
      x.report("'#{input}'-native") { strip_empty(input) }
      x.compare!
    end
  end
end
```