### PR TITLE
Backport String#match? to reduce object allocations on ruby 2.4+

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -45,6 +45,7 @@ module Liquid
 end
 
 require "liquid/version"
+require "liquid/ruby_backports"
 require 'liquid/lexer'
 require 'liquid/parser'
 require 'liquid/i18n'

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -1,4 +1,6 @@
 module Liquid
+  using RubyBackports
+
   class BlockBody
     FullToken = /\A#{TagStart}#{WhitespaceControl}?\s*(\w+)\s*(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
@@ -44,7 +46,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= !!(token =~ WhitespaceOrNothing)
+          @blank &&= token.match?(WhitespaceOrNothing)
         end
         parse_context.line_number = tokenizer.line_number
       end

--- a/lib/liquid/ruby_backports.rb
+++ b/lib/liquid/ruby_backports.rb
@@ -1,0 +1,13 @@
+module Liquid
+  module RubyBackports
+    Liquid.private_constant :RubyBackports
+
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
+      refine String do
+        def match?(regexp)
+          !!(self =~ regexp)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #990
cc @ashmaroli

We can use refinements to backport ruby features without affecting the code using the library.

I haven't yet benchmarked the difference, so just threw this together in response to https://github.com/Shopify/liquid/pull/990#discussion_r174843621