### PR TITLE
Replace unnecessary Array#each_with_index with Array#each

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -156,7 +156,7 @@ module Liquid
         begin
           context['forloop'.freeze] = loop_vars
 
-          segment.each_with_index do |item, index|
+          segment.each do |item|
             context[@variable_name] = item
             result << @for_block.render(context)
             loop_vars.send(:increment!)

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -33,7 +33,7 @@ module Liquid
         tablerowloop = Liquid::TablerowloopDrop.new(length, cols)
         context['tablerowloop'.freeze] = tablerowloop
 
-        collection.each_with_index do |item, index|
+        collection.each do |item|
           context[@variable_name] = item
 
           result << "<td class=\"col#{tablerowloop.col}\">" << super << '</td>'


### PR DESCRIPTION
The `index` parameter is not required in these function blocks as `Liquid::ForloopDrop` and `Liquid::TablerowloopDrop` have taken over the responsibility to handle associated array indices.