### PR TITLE
Refactored and optimized rendering

### DIFF
--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -1,13 +1,13 @@
 module Liquid
   class BlockBody
-    def render_node_with_profiling(node, context)
+    def render_node_with_profiling(node, output, context, skip_output = false)
       Profiler.profile_node_render(node) do
-        render_node_without_profiling(node, context)
+        render_node_without_profiling(node, output, context, skip_output)
       end
     end
 
-    alias_method :render_node_without_profiling, :render_node
-    alias_method :render_node, :render_node_with_profiling
+    alias_method :render_node_without_profiling, :render_node_to_output
+    alias_method :render_node_to_output, :render_node_with_profiling
   end
 
   class Include < Tag


### PR DESCRIPTION
Measures:
1) A while loop is faster than iterating with #each.
2) Check string tokens first. String tokens are far more frequent
   than interrupt tokens. If a token is a string token, checking
   for an interrupt token can be avoided.
3) String tokens just map to themselves and don't need the special
   treatment of `BlockBody#render_node` (except the resource limit
   check).

Benchmark
=========

$ bundle exec rake benchmark:run

Before
------
```
Run 1)
              parse:     41.630  (± 0.0%) i/s -    420.000  in  10.089309s
             render:     75.962  (± 3.9%) i/s -    763.000  in  10.066823s
     parse & render:     25.497  (± 0.0%) i/s -    256.000  in  10.040862s

Run 2)
              parse:     42.130  (± 0.0%) i/s -    424.000  in  10.064738s
             render:     77.003  (± 1.3%) i/s -    777.000  in  10.093524s
     parse & render:     25.739  (± 0.0%) i/s -    258.000  in  10.024581s

Run 3)
              parse:     41.976  (± 2.4%) i/s -    420.000  in  10.021406s
             render:     76.184  (± 1.3%) i/s -    763.000  in  10.018104s
     parse & render:     25.641  (± 0.0%) i/s -    258.000  in  10.062549s
```

After
-----
```
Run 1)
              parse:     42.198  (± 0.0%) i/s -    424.000  in  10.048737s
             render:     79.495  (± 2.5%) i/s -    798.000  in  10.042610s
     parse & render:     25.874  (± 3.9%) i/s -    260.000  in  10.053336s

Run 2)
              parse:     41.961  (± 0.0%) i/s -    420.000  in  10.009858s
             render:     78.623  (± 1.3%) i/s -    791.000  in  10.064043s
     parse & render:     25.927  (± 0.0%) i/s -    260.000  in  10.028472s

Run 3)
              parse:     42.321  (± 2.4%) i/s -    424.000  in  10.021159s
             render:     79.468  (± 2.5%) i/s -    798.000  in  10.048127s
     parse & render:     26.065  (± 0.0%) i/s -    262.000  in  10.053814s
```