### PR TITLE
add installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Liquid is a template engine which was written with very specific requirements:
 
 ## How to use Liquid
 
+Install Liquid by adding `gem 'liquid'` to your gemfile.
+
 Liquid supports a very simple API based around the Liquid::Template class.
 For standard use you can just pass it the content of a file and call render with a parameters hash.
 


### PR DESCRIPTION
I was personally confused when installing this because googling for `liquid gem rails` leads to this other [gem](https://github.com/chamnap/liquid-rails) which doesn't work on rails 4 anymore. 

A simple installation instruction line would be very helpful to let people know what the gem name is.