### PR TITLE
Suppress warning: `BigDecimal.new` is deprecated

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -46,11 +46,11 @@ module Liquid
     def self.to_number(obj)
       case obj
       when Float
-        BigDecimal.new(obj.to_s)
+        BigDecimal(obj.to_s)
       when Numeric
         obj
       when String
-        (obj.strip =~ /\A-?\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
+        (obj.strip =~ /\A-?\d+\.\d+\z/) ? BigDecimal(obj) : obj.to_i
       else
         if obj.respond_to?(:to_number)
           obj.to_number


### PR DESCRIPTION
## Summary

`BigDecimal.new` is deprecated since BigDecimal 1.3.3 for Ruby 2.5.

This PR suppresses the following warnings.

```console
% ruby -v
ruby 2.6.0dev (2018-09-06 trunk 64648) [x86_64-darwin17]
% RUBYOPT=-w bundle exec rake
(snip)
/Users/koic/src/github.com/Shopify/liquid/lib/liquid/utils.rb:49:
warning: BigDecimal.new is deprecated; use Kernel.BigDecimal method
instead.
/Users/koic/src/github.com/Shopify/liquid/lib/liquid/utils.rb:53:
warning: BigDecimal.new is deprecated; use Kernel.BigDecimal method
instead.
```

## Other Information

The following is a change of BigDecimal 1.3.3 for Ruby 2.5 related to this PR.

- https://github.com/ruby/bigdecimal/commit/533737338db915b00dc7168c3602e4b462b23503
- https://github.com/ruby/bigdecimal/commit/16738ad0aca158d3c70123990d8caa5789818177