### PR TITLE
Single regexp for strip_html

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -11,6 +11,12 @@ module Liquid
       "'".freeze => '&#39;'.freeze
     }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
+    STRIP_HTML = Regexp.union(
+      /<script.*?<\/script>/m,
+      /<!--.*?-->/m,
+      /<style.*?<\/style>/m,
+      /<.*?>/m,
+    )
 
     # Return the size of an array or of an string
     def size(input)
@@ -102,8 +108,7 @@ module Liquid
     end
 
     def strip_html(input)
-      empty = ''.freeze
-      input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
+      input.to_s.gsub(STRIP_HTML, ''.freeze)
     end
 
     # Remove all newlines from the string

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -11,12 +11,12 @@ module Liquid
       "'".freeze => '&#39;'.freeze
     }
     HTML_ESCAPE_ONCE_REGEXP = /["><']|&(?!([a-zA-Z]+|(#\d+));)/
-    STRIP_HTML = Regexp.union(
+    STRIP_HTML_BLOCKS = Regexp.union(
       /<script.*?<\/script>/m,
       /<!--.*?-->/m,
-      /<style.*?<\/style>/m,
-      /<.*?>/m
+      /<style.*?<\/style>/m
     )
+    STRIP_HTML_TAGS = /<.*?>/m
 
     # Return the size of an array or of an string
     def size(input)
@@ -108,7 +108,10 @@ module Liquid
     end
 
     def strip_html(input)
-      input.to_s.gsub(STRIP_HTML, ''.freeze)
+      empty = ''.freeze
+      result = input.to_s.gsub(STRIP_HTML_BLOCKS, empty)
+      result.gsub!(STRIP_HTML_TAGS, empty)
+      result
     end
 
     # Remove all newlines from the string

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -15,7 +15,7 @@ module Liquid
       /<script.*?<\/script>/m,
       /<!--.*?-->/m,
       /<style.*?<\/style>/m,
-      /<.*?>/m,
+      /<.*?>/m
     )
 
     # Return the size of an array or of an string

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -177,6 +177,9 @@ class StandardFiltersTest < Minitest::Test
     assert_equal 'test', @filters.strip_html("<div\nclass='multiline'>test</div>")
     assert_equal 'test', @filters.strip_html("<!-- foo bar \n test -->test")
     assert_equal '', @filters.strip_html(nil)
+
+    # Quirk of the existing implementation
+    assert_equal 'foo;', @filters.strip_html("<<<script </script>script>foo;</script>")
   end
 
   def test_join


### PR DESCRIPTION
Hi!

Benchmark shows almost 2x improvement.

<details>
<summary>Benchmark source</summary>

```ruby
STRIP_HTML = Regexp.union(
  /<script.*?<\/script>/m,
  /<!--.*?-->/m,
  /<style.*?<\/style>/m,
  /<.*?>/m,
)

def strip_html_old(input)
  empty = ''.freeze
  input.to_s.gsub(/<script.*?<\/script>/m, empty).gsub(/<!--.*?-->/m, empty).gsub(/<style.*?<\/style>/m, empty).gsub(/<.*?>/m, empty)
end

def strip_html_new(input)
  input.to_s.gsub(STRIP_HTML, ''.freeze)
end

require 'benchmark/ips'        

string = <<~HTML
  <div>test</div>
  <div id='test'>test</div>
  <script type='text/javascript'>document.write('some stuff');</script>
  <style type='text/css'>foo bar</style>
  <div\nclass='multiline'>test</div>
  <!-- foo bar \n test -->test
HTML

Benchmark.ips do |x|
  x.report('old') { strip_html_old(string) }
  x.report('new') { strip_html_new(string) }
  x.compare!
end
```
</details>