### PR TITLE
Fix scroll bug on firefox

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,17 +6,26 @@
       <a href="{{ "/" | relative_url }}">Liquid</a>
     {% endif %}
   </header>
-  <nav class="sidebar__nav"> {% assign sections = "basics, tags, filters" | split: ", " %}
 
-    {% for section in sections %}
-    <h3 class="section__header">{{ section | capitalize }}</h3>
+  {%- assign sections = "basics, tags, filters" | split: ", " -%}
 
-    <ul class="section__links">
-    {% for item in site.pages %}{% if item.url contains section/ %}{% unless item.path contains "index" %}
-      <li><a href="{{ item.url | relative_url }}" class="section__link{% if item.url contains page.url and page.url != '/' and page.type != 'index' %} section__link--is-active{% endif %}">{{ item.title }}</a></li>
-    {% endunless %}{% endif %}{% endfor %}
-    </ul>
-    {% endfor %}
+  <nav class="sidebar__nav">
+    <div class="sidebar__nav-interior">
+      {%- for section in sections -%}
+        <h3 class="section__header">{{ section | capitalize }}</h3>
 
+        <ul class="section__links">
+        {%- for item in site.pages -%}
+          {%- if item.url contains section/ -%}
+            {%- unless item.path contains "index" -%}
+              <li class="section__item">
+                <a href="{{ item.url | relative_url }}" class="section__link {% if item.url contains page.url and page.url != '/' and page.type != 'index' %} section__link--is-active{% endif %}">{{ item.title }}</a>
+              </li>
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endfor -%}
+        </ul>
+      {%- endfor -%}
+    </div>
   </nav>
 </div>

--- a/_sass/modules/_layout.scss
+++ b/_sass/modules/_layout.scss
@@ -1,4 +1,3 @@
-
 $sidebar-width: 250px;
 $logo-height: 130px;
 $wrapper-width: 800px;
@@ -95,34 +94,16 @@ body {
 }
 
 .sidebar__nav {
-  padding: $spacing-unit $spacing-unit ($spacing-unit + $logo-height); // Add a bit more padding at the bottom for consistency.
+
   font-weight: bold;
   max-height: 100%;
-  overflow-y: scroll;
-
-  li {
-    list-style: none;
-
-    a {
-      color: $color-white;
-
-      &:hover {
-        text-decoration: none;
-      }
-    }
-  }
+  overflow-y: auto;
 }
 
-.section {
-  margin: 0px;
-
-  > li {
-    margin-bottom: $spacing-unit / 2;
-
-    &:last-child {
-      margin-bottom: $spacing-unit;
-    }
-  }
+.sidebar__nav-interior {
+  height: 100%;
+  // Add a bit more padding at the bottom for consistency.
+  padding: $spacing-unit $spacing-unit ($spacing-unit + $logo-height);
 }
 
 .section__header {
@@ -131,13 +112,22 @@ body {
   color: $color-white;
   margin-top: 0;
   margin-bottom: $spacing-unit / 4;
+
+  .section__links + & {
+    margin-top: $spacing-unit;
+  }
 }
 
 .section__links {
-  margin-left: $spacing-unit / 2;
-  margin-bottom: $spacing-unit;
-  font-weight: normal;
   font-size: 0.9em;
+  font-weight: normal;
+
+  list-style: none;
+  margin-left: $spacing-unit / 2;
+}
+
+.section__item {
+  list-style: none;
 }
 
 .section__link {
@@ -145,13 +135,26 @@ body {
   margin-top: $spacing-unit/4;
   opacity: 0.75;
   text-decoration: none;
+  color: $color-white;
 
   &:hover {
     opacity: 1;
+    text-decoration: none;
+  }
+
+  &:empty {
+    // there is an error in the liquid logic that spits out a
+    // empty last-child
+    display: none;
+  }
+
+  &:visited {
+    color: $color-white;
   }
 }
 
 .section__link--is-active {
   font-weight: bold;
   opacity: 1;
+  color: $color-white;
 }


### PR DESCRIPTION
### Before
<img width="224" alt="screen shot 2018-10-15 at 1 59 02 pm" src="https://user-images.githubusercontent.com/3770220/46969106-03551180-d083-11e8-8d56-139ff5c198d8.png">


### After
<img width="208" alt="screen shot 2018-10-15 at 2 02 12 pm" src="https://user-images.githubusercontent.com/3770220/46969112-06e89880-d083-11e8-9f85-7ae5313239c8.png">

Previously the bottom options on the sidebar would not be visible due to them overflowing past the bottom. This PR fixes this issue by introducing a wrapping element to simplify the height calculation and make it consistent between firefox and chrome.

cc: @beefchimi 