### PR TITLE
Make builds green

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,10 +71,7 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
+Style/TrailingCommaInLiteral:
   Enabled: false
 
 Layout/IndentHash:
@@ -125,6 +122,6 @@ Style/TrivialAccessors:
 Style/WordArray:
   Enabled: false
 
-Naming/MethodName:
+Style/MethodName:
   Exclude:
     - 'example/server/liquid_servlet.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake/testtask'
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "liquid/version"
 
-task default: [:rubocop, :test]
+task default: [:test, :rubocop]
 
 desc 'run test suite with default parser'
 Rake::TestTask.new(:base_test) do |t|

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -120,25 +120,16 @@ module Liquid
     # provide optional property with which to sort an array of hashes or drops
     def sort(input, property = nil)
       ary = InputIterator.new(input)
+
+      return [] if ary.empty?
+
       if property.nil?
         ary.sort do |a, b|
-          if !a.nil? && !b.nil?
-            a <=> b
-          else
-            a.nil? ? 1 : -1
-          end
+          nil_safe_compare(a, b)
         end
-      elsif ary.empty? # The next two cases assume a non-empty array.
-        []
       elsif ary.all? { |el| el.respond_to?(:[]) }
         ary.sort do |a, b|
-          a = a[property]
-          b = b[property]
-          if !a.nil? && !b.nil?
-            a <=> b
-          else
-            a.nil? ? 1 : -1
-          end
+          nil_safe_compare(a[property], b[property])
         end
       end
     end
@@ -148,25 +139,15 @@ module Liquid
     def sort_natural(input, property = nil)
       ary = InputIterator.new(input)
 
+      return [] if ary.empty?
+
       if property.nil?
         ary.sort do |a, b|
-          if !a.nil? && !b.nil?
-            a.to_s.casecmp(b.to_s)
-          else
-            a.nil? ? 1 : -1
-          end
+          nil_safe_casecmp(a, b)
         end
-      elsif ary.empty? # The next two cases assume a non-empty array.
-        []
       elsif ary.all? { |el| el.respond_to?(:[]) }
         ary.sort do |a, b|
-          a = a[property]
-          b = b[property]
-          if !a.nil? && !b.nil?
-            a.to_s.casecmp(b.to_s)
-          else
-            a.nil? ? 1 : -1
-          end
+          nil_safe_casecmp(a[property], b[property])
         end
       end
     end
@@ -416,6 +397,22 @@ module Liquid
     def apply_operation(input, operand, operation)
       result = Utils.to_number(input).send(operation, Utils.to_number(operand))
       result.is_a?(BigDecimal) ? result.to_f : result
+    end
+
+    def nil_safe_compare(a, b)
+      if !a.nil? && !b.nil?
+        a <=> b
+      else
+        a.nil? ? 1 : -1
+      end
+    end
+
+    def nil_safe_casecmp(a, b)
+      if !a.nil? && !b.nil?
+        a.to_s.casecmp(b.to_s)
+      else
+        a.nil? ? 1 : -1
+      end
     end
 
     class InputIterator


### PR DESCRIPTION
Just realized master builds are failing (example: https://travis-ci.org/Shopify/liquid/jobs/443702626) because of RuboCop violations. This also means we're not actually running tests in master as the default Rake task runs `:rubocop` first. 

https://github.com/Shopify/liquid/blob/ca9e75db5329b864982218f70b9f3bab9a8ddc05/Rakefile#L6

## Changes

- Our `.rubocop.yml` ignores a couple of different rules for trailing commas but these introduced in a later version so RuboCop still complains about them
- With the trailing commas ignored, RuboCop was still complaining about the perceived complexity of a couple of methods in `StandardFilters`

    ```
    lib/liquid/standardfilters.rb:121:5: C: Perceived complexity for sort is too high. [13/11]
        def sort(input, property = nil)
        ^^^
    lib/liquid/standardfilters.rb:148:5: C: Perceived complexity for sort_natural is too high. [13/11]
        def sort_natural(input, property = nil)
        ^^^
    ```

    Rather than whitelist these or change the rule I removed some duplication and added an early return for empty inputs which solved the problem and cleans things up nicely.