### PR TITLE
 add fact that to_str doesn't do anything anymore for drops to the history.md

### DIFF
--- a/History.md
+++ b/History.md
@@ -22,6 +22,7 @@
 * Liquid::Template.file_system's read_template_file method is no longer passed the context. (#441) [James Reid-Smith]
 * Remove `liquid_methods` (See https://github.com/Shopify/liquid/pull/568 for replacement)
 * Liquid::Template.register_filter raises when the module overrides registered public methods as private or protected (#705) [Gaurav Chande]
+* overriding to_str on a drop doesn't do anything anymore, override to_s instead.
 
 ### Fixed
 

--- a/History.md
+++ b/History.md
@@ -12,7 +12,7 @@
 * Add url_decode filter to invert url_encode (#645) [Larry Archer]
 * Add global_filter to apply a filter to all output (#610) [Loren Hale]
 * Add compact filter (#600) [Carson Reinke]
-* Rename deprecated "has_key?" and "has_interrupt?" methods (#593) [Florian Weingarten]
+* Rename deprecated "has_key?" and "has_interrupt?" methods to "key?" and "interrupt?" (#593) [Florian Weingarten]
 * Include template name with line numbers in render errors (574) [Dylan Thacker-Smith]
 * Add sort_natural filter (#554) [Martin Hanzel]
 * Add forloop.parentloop as a reference to the parent loop (#520) [Justin Li]


### PR DESCRIPTION
When I wrote my first drop, to_s didn't change the way a drop class rendered itself, but to_str did. 
In the new version it's the other way around, but I can't find anything on this in issues or commits.