### PR TITLE
Validate the character encoding in url_decode.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -52,7 +52,12 @@ module Liquid
     end
 
     def url_decode(input)
-      CGI.unescape(input.to_s) unless input.nil?
+      return if input.nil?
+
+      result = CGI.unescape(input.to_s)
+      raise Liquid::ArgumentError, "invalid byte sequence in #{result.encoding}" unless result.valid_encoding?
+
+      result
     end
 
     def slice(input, offset, length = nil)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -158,6 +158,10 @@ class StandardFiltersTest < Minitest::Test
     assert_equal '1', @filters.url_decode(1)
     assert_equal '2001-02-03', @filters.url_decode(Date.new(2001, 2, 3))
     assert_nil @filters.url_decode(nil)
+    exception = assert_raises Liquid::ArgumentError do
+      @filters.url_decode('%ff')
+    end
+    assert_equal 'Liquid error: invalid byte sequence in UTF-8', exception.message
   end
 
   def test_truncatewords


### PR DESCRIPTION
The `url_decode` filter can produce arbitrary byte sequences, including ones that are not valid for the current character encoding. Applications using Liquid most likely expect its output to be validly encoded. Therefore, it seems useful to raise an error in cases where `url_decode` produces an invalid byte sequence.