### PR TITLE
Fix large for-loop collection

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -1,5 +1,4 @@
 module Liquid
-
   # "For" iterates over an array or collection.
   # Several useful variables are available to you within the loop.
   #

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -1,4 +1,5 @@
 module Liquid
+
   # "For" iterates over an array or collection.
   # Several useful variables are available to you within the loop.
   #
@@ -128,7 +129,14 @@ module Liquid
       end
 
       collection = context.evaluate(@collection_name)
-      collection = collection.to_a if collection.is_a?(Range)
+      if collection.is_a?(Range)
+        score_limit = context.resource_limits.render_score_limit
+        if score_limit && score_limit < collection.size
+          context.resource_limits.render_score += collection.size
+          raise MemoryError.new("Memory limits exceeded".freeze)
+        end
+        collection = collection.to_a
+      end
 
       limit = context.evaluate(@limit)
       to = limit ? limit.to_i + from : nil

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -118,6 +118,11 @@ class TemplateTest < Minitest::Test
     assert_equal "Liquid error: Memory limits exceeded", t.render
     assert t.resource_limits.reached?
 
+    t = Template.parse("{% for a in (1..100000000000000) %} {% for a in (1..10) %} foo {% endfor %} {% endfor %}")
+    t.resource_limits.render_score_limit = 50
+    assert_equal "Liquid error: Memory limits exceeded", t.render
+    assert t.resource_limits.reached?
+
     t = Template.parse("{% for a in (1..100) %} foo {% endfor %}")
     t.resource_limits.render_score_limit = 50
     assert_equal "Liquid error: Memory limits exceeded", t.render


### PR DESCRIPTION
When a large Range is given in a for-loop (e.g. 1..100000000000000), it may crash the Ruby process or at least eats a lot of memory and takes a significant amount of time to render the template.

I added the following testcase to template_test.rb:

```
    t = Template.parse("{% for a in (1..100000000000000) %} {% for a in (1..10) %} foo {% endfor %} {% endfor %}")
    t.resource_limits.render_score_limit = 50
    assert_equal "Liquid error: Memory limits exceeded", t.render
    assert t.resource_limits.reached?
```

The render_score_limit does not help here because it's more of a Ruby performance problem in for.rb, where the `collection = collection.to_a if collection.is_a?(Range)` happens. 

A fix may be to check if the given Range is larger than the given render_score_limit. I'm actually not sure if there may be a better fix (e.g. checking the resource limits somewhere else) but at least it works for the given test case.
