### PR TITLE
Fix interrupts through includes

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -89,6 +89,7 @@ module Liquid
           break
         else # Other non-Block tags
           render_node_to_output(node, output, context)
+          break if context.interrupt? # might have happened through an include
         end
         idx += 1
       end

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -30,6 +30,9 @@ class TestFileSystem
     when 'assignments'
       "{% assign foo = 'bar' %}"
 
+    when 'break'
+      "{% break %}"
+
     else
       template_path
     end
@@ -241,5 +244,10 @@ class IncludeTagTest < Minitest::Test
     template.render(nil, strict_variables: true)
 
     assert_equal [], template.errors
+  end
+
+  def test_break_through_include
+    assert_template_result "1", "{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}"
+    assert_template_result "1", "{% for i in (1..3) %}{{ i }}{% include 'break' %}{{ i }}{% endfor %}"
   end
 end # IncludeTagTest


### PR DESCRIPTION
Changing the interrupt state inside non-block tags (e.g. in the include tag) would not correctly break the parent render loop.