### PR TITLE
defer hash allocation until needed for unparsed_args

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -95,16 +95,17 @@ module Liquid
 
     def parse_filter_expressions(filter_name, unparsed_args)
       filter_args = []
-      keyword_args = {}
+      keyword_args = nil
       unparsed_args.each do |a|
         if matches = a.match(JustTagAttributes)
+          keyword_args ||= {}
           keyword_args[matches[1]] = Expression.parse(matches[2])
         else
           filter_args << Expression.parse(a)
         end
       end
       result = [filter_name, filter_args]
-      result << keyword_args unless keyword_args.empty?
+      result << keyword_args if keyword_args
       result
     end
 


### PR DESCRIPTION
### Summary

Depending on whether there are any `unparsed_args` args we may be performing unnecessary hash allocations in the `parse_filter_expressions` method. This may seem trivial, but given the frequency with which this method is called, this may actually be putting extra strain on the GC.

### Performance

I did not want to propose this potential optimization unless I had some numbers to back it up, so I did a simple CPU benchmark and checked on the GC stats to see if allocations were improved. (I removed the test I was using to run the performance check in the last commit of this branch, but you can check the second commit if you'd like to see my performance test setup.)

```bash
user     system      total        real
pre alloc w kwargs  0.880000   0.000000   0.880000 (  0.892699)
allocated_objects: 2600059
deferred alloc w kwargs  0.890000   0.010000   0.900000 (  0.889087)
allocated_objects: 2600050
pre alloc wo kwargs  0.030000   0.000000   0.030000 (  0.032060)
allocated_objects: 500050
deferred alloc wo kwargs  0.030000   0.000000   0.030000 (  0.027086)
allocated_objects: 400049
pre alloc w arg  0.230000   0.000000   0.230000 (  0.239780)
allocated_objects: 1100050
deferred alloc w arg  0.240000   0.000000   0.240000 (  0.233269)
allocated_objects: 1000050
```

Performance-wise, the change is mostly negligible, with the suggestion of some improvement in the case of no `unparsed_args`. 😐

However, on the GC/allocation side, again in the case of no `unparsed_args`, we clearly are making less allocations. 😄

### Conclusion

Given that this change should have zero user facing implications, I think it might be worth while.

