### PR TITLE
Memoize Liquid::Tag#raw

### DIFF
--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -25,7 +25,7 @@ module Liquid
     end
 
     def raw
-      "#{@tag_name} #{@markup}"
+      @raw ||= "#{@tag_name} #{@markup}".strip
     end
 
     def name


### PR DESCRIPTION
This change is avoid unnecessary String allocations.

## Theory

- Since interpolated strings can't be frozen, they generate a new object for each call
- Not every tag is initialized with a `markup`. For example, `{% comment %}`. In such cases, the string resulting from `Tag#raw` has a trailing whitespace (`"comment "`) which has to be stripped away which may or may not result in a new string object based on the method used.

Memoizing the resulting object resolves the above two issues.