### PR TITLE
Add GA tag for tracking

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,16 @@
     <meta name="twitter:url" content="{{ site.url | relative_url }}">
     <meta name="twitter:title" content="{{ page.title | default: site.title }}">
     <meta name="twitter:description" content="{{ page.description | default: site.description }}">
+    
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49178120-52"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-49178120-52');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
Adding UA tracking tag received from data team to monitor site traffic on Google Analytics. 

![UA tracking snippet](https://user-images.githubusercontent.com/16498248/55080066-5c46be00-5095-11e9-98f2-ec6216fbe380.jpg)


CC: @tiffanytse @nwtn 