### PR TITLE
While loop

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -427,6 +427,11 @@ module Liquid
       end
     end
 
+    #Convert a string to ascii (in hex)
+    def string_to_ascii(input)
+      input.split('').map(&:ord).map{ |n| n.to_s(16) }
+    end
+
     private
 
     def raise_property_error(property)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -427,9 +427,14 @@ module Liquid
       end
     end
 
-    #Convert a string to ascii (in hex)
-    def string_to_ascii(input)
-      input.split('').map(&:ord).map{ |n| n.to_s(16) }
+    #Convert a string to ascii
+    def to_ascii(input)
+      input.chars.map{ |c| c.ord }
+    end
+
+    #Convert to hexadecimal
+    def to_hex(input)
+      input.map{ |c| c.to_s(16) }
     end
 
     private

--- a/lib/liquid/tags/while.rb
+++ b/lib/liquid/tags/while.rb
@@ -2,9 +2,11 @@ module Liquid
   # "While" loops a block until some condition no longer holds true.
   #
   class While < Block
-    Syntax = /\A(#{VariableSegment}+)/o
+    Syntax = /(#{QuotedFragment})\s*([=!<>a-z_]+)?\s*(#{QuotedFragment})?/o
+    ExpressionsAndOperators = /(?:\b(?:\s?and\s?|\s?or\s?)\b|(?:\s*(?!\b(?:\s?and\s?|\s?or\s?)\b)(?:#{QuotedFragment}|\S+)\s*)+)/o
+    BOOLEAN_OPERATORS = %w(and or).freeze
 
-    attr_reader :variable_name
+    attr_reader :condition
 
     def initialize(tag_name, markup, options)
       super
@@ -13,7 +15,7 @@ module Liquid
     end
 
     def parse(tokens)
-      return unless parse_body(@while_block, tokens)
+      parse_body(@while_block, tokens)
     end
 
     def nodelist
@@ -24,7 +26,7 @@ module Liquid
       result = ''
 
       context.stack do
-        while context[@variable_name] do
+        while @condition.evaluate(context) do
           result << @while_block.render(context)
 
           # Handle any interrupts if they exist.
@@ -42,28 +44,56 @@ module Liquid
     protected
 
     def lax_parse(markup)
-      if markup =~ Syntax
-        @variable_name = $1
-      else
-        raise SyntaxError.new(options[:locale].t("errors.syntax.while".freeze))
+      expressions = markup.scan(ExpressionsAndOperators)
+      raise(SyntaxError.new(options[:locale].t("errors.syntax.while".freeze))) unless expressions.pop =~ Syntax
+
+      condition = Condition.new(Expression.parse($1), $2, Expression.parse($3))
+
+      until expressions.empty?
+        operator = expressions.pop.to_s.strip
+
+        raise(SyntaxError.new(options[:locale].t("errors.syntax.while".freeze))) unless expressions.pop.to_s =~ Syntax
+
+        new_condition = Condition.new(Expression.parse($1), $2, Expression.parse($3))
+        raise(SyntaxError.new(options[:locale].t("errors.syntax.while".freeze))) unless BOOLEAN_OPERATORS.include?(operator)
+        new_condition.send(operator, condition)
+        condition = new_condition
       end
+
+      @condition = condition
     end
 
     def strict_parse(markup)
       p = Parser.new(markup)
-      @variable_name = p.consume(:id)
-
+      condition = parse_binary_comparisons(p)
       p.consume(:end_of_string)
+      @condition = condition
     end
 
-    private
+  private
 
-    class ParseTreeVisitor < Liquid::ParseTreeVisitor
-      def children
-        (super).compact
+    def parse_binary_comparisons(p)
+      condition = parse_comparison(p)
+      first_condition = condition
+      while op = (p.id?('and'.freeze) || p.id?('or'.freeze))
+        child_condition = parse_comparison(p)
+        condition.send(op, child_condition)
+        condition = child_condition
+      end
+      first_condition
+    end
+
+    def parse_comparison(p)
+      a = Expression.parse(p.expression)
+      if op = p.consume?(:comparison)
+        b = Expression.parse(p.expression)
+        Condition.new(a, op, b)
+      else
+        Condition.new(a)
       end
     end
-  end
 
   Template.register_tag('while'.freeze, While)
+
+  end
 end

--- a/lib/liquid/tags/while.rb
+++ b/lib/liquid/tags/while.rb
@@ -1,0 +1,69 @@
+module Liquid
+  # "While" loops a block until some condition no longer holds true.
+  #
+  class While < Block
+    Syntax = /\A(#{VariableSegment}+)/o
+
+    attr_reader :variable_name
+
+    def initialize(tag_name, markup, options)
+      super
+      parse_with_selected_parser(markup)
+      @while_block = BlockBody.new
+    end
+
+    def parse(tokens)
+      return unless parse_body(@while_block, tokens)
+    end
+
+    def nodelist
+      @while_block.nodelist
+    end
+
+    def render(context)
+      result = ''
+
+      context.stack do
+        while context[@variable_name] do
+          result << @while_block.render(context)
+
+          # Handle any interrupts if they exist.
+          if context.interrupt?
+            interrupt = context.pop_interrupt
+            break if interrupt.is_a? BreakInterrupt
+            next if interrupt.is_a? ContinueInterrupt
+          end
+        end
+      end
+
+      result
+    end
+
+    protected
+
+    def lax_parse(markup)
+      if markup =~ Syntax
+        @variable_name = $1
+      else
+        raise SyntaxError.new(options[:locale].t("errors.syntax.while".freeze))
+      end
+    end
+
+    def strict_parse(markup)
+      p = Parser.new(markup)
+      @variable_name = p.consume(:id)
+
+      p.consume(:end_of_string)
+    end
+
+    private
+
+    class ParseTreeVisitor < Liquid::ParseTreeVisitor
+      def children
+        (super).compact
+      end
+    end
+  end
+
+  Template.register_tag('while'.freeze, While)
+end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -683,8 +683,12 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "bar", @filters.default({}, "bar")
   end
 
-  def test_string_to_ascii
-    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.string_to_ascii("Testing")
+  def test_to_ascii
+    assert_equal [84, 101, 115, 116, 105, 110, 103], @filters.to_ascii("Testing")
+  end
+
+  def test_to_hex
+    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.to_hex([84, 101, 115, 116, 105, 110, 103])
   end
 
   def test_cannot_access_private_methods

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -683,6 +683,10 @@ class StandardFiltersTest < Minitest::Test
     assert_equal "bar", @filters.default({}, "bar")
   end
 
+  def test_string_to_ascii
+    assert_equal ["54", "65", "73", "74", "69", "6e", "67"], @filters.string_to_ascii("Testing")
+  end
+
   def test_cannot_access_private_methods
     assert_template_result('a', "{{ 'a' | to_number }}")
   end

--- a/test/integration/tags/while_tag_test.rb
+++ b/test/integration/tags/while_tag_test.rb
@@ -13,6 +13,10 @@ class WhileTagTest < Minitest::Test
 
     assert_template_result('0123', '{%while myval %}{%increment counter %}{% if counter > 3 %}{% assign myval = false %}{%endif%}{%endwhile%}', 'myval' => true)
 
+    # test and/or
+    assert_template_result(' yo ', '{%while myval1 or myval2 %} yo {%assign myval1 = false%}{%endwhile%}', 'myval1' => true, 'myval2' => false)
+    assert_template_result('', '{%while myval1 and myval2 %} yo {%endwhile%}', 'myval1' => true, 'myval2' => false)
+
     # test binary comparators ==, !=, <, <=, >, >= with constants and with two variables
     # test ==
     assert_template_result('0', '{%while myval == 0 %}{{myval}}{%assign myval = myval | plus: 1 %}{%endwhile%}', 'myval' => 0)
@@ -37,6 +41,10 @@ class WhileTagTest < Minitest::Test
     # test >=
     assert_template_result('87654', '{%while myval >= 4 %}{{myval}}{%assign myval = myval | minus: 1 %}{%endwhile%}', 'myval' => 8)
     assert_template_result('87654', '{%while myval1 >= myval2 %}{{myval1}}{%assign myval1 = myval1 | minus: 1 %}{%endwhile%}', {'myval1' => 8, 'myval2' => 4})
+
+    # test compound expressions
+    assert_template_result('', '{%while true and 3 > 4 %} yo {%endwhile%}')
+    assert_template_result(' yo ', '{%while true and true or 3 > 4%} yo {%break%}{%endwhile%}')
   end
 
   def test_while_with_break

--- a/test/integration/tags/while_tag_test.rb
+++ b/test/integration/tags/while_tag_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class WhileTagTest < Minitest::Test
+  include Liquid
+
+  def test_while
+    assert_template_result(' yo ', '{%while myval %} yo {%assign myval = false%}{%endwhile%}', 'myval' => true)
+    assert_template_result('0123', '{%while myval %}{%increment myval %}{% if myval > 3 %}{% assign myval = false %}{%endif%}{%endwhile%}', 'myval' => 0)
+  end
+
+  def test_while_with_break
+    assert_template_result('', '{%while true %}{% break %}{%endwhile%}')
+    assert_template_result('0123', '{%while true %}{% increment counter %}{% if counter > 3 %}{% break %}{%endif%}{%endwhile%}')
+
+    # tests to ensure it only breaks out of local while loop and not all of them
+    assigns = {'counter1' => 0, 'counter2' => 0}
+    markup = '{% while true %}' \
+             ' outer{{counter1}} '\
+               '{% assign counter1 = counter1 | plus: 1 %}'\
+               '{% if counter1 > 3 %}'\
+                 '{% break %}'\
+               '{% endif %}'\
+               '{% assign counter2 = 0 %}'\
+               '{% while true %}'\
+                 '{{ counter2 }}'\
+                 '{% assign counter2 = counter2 | plus: 1 %}'\
+                 '{% if counter2 > 3 %}'\
+                   '{%break%}'\
+                 '{%endif%}'\
+               '{%endwhile%}'\
+             '{%endwhile%}'
+    expected = ' outer0 0123 outer1 0123 outer2 0123 outer3 '
+    assert_template_result(expected,markup,assigns)
+  end
+
+  def test_while_with_continue
+    assigns = {'counter' => 0}
+    markup = '{% while true %}'\
+               '{% assign counter = counter | plus: 1 %}'\
+               '{% if counter < 3 %}'\
+                 '{% continue %}'\
+               '{% endif %}'\
+               '{{ counter }}'\
+               '{% if counter > 5 %}'\
+                 '{% break %}'\
+               '{% endif %}'\
+             '{% endwhile %}'
+    expected = '3456'
+    assert_template_result(expected,markup,assigns)
+  end
+
+end

--- a/test/integration/tags/while_tag_test.rb
+++ b/test/integration/tags/while_tag_test.rb
@@ -4,8 +4,39 @@ class WhileTagTest < Minitest::Test
   include Liquid
 
   def test_while
+    # test value to be truthy/falsy
     assert_template_result(' yo ', '{%while myval %} yo {%assign myval = false%}{%endwhile%}', 'myval' => true)
-    assert_template_result('0123', '{%while myval %}{%increment myval %}{% if myval > 3 %}{% assign myval = false %}{%endif%}{%endwhile%}', 'myval' => 0)
+    assert_template_result(' yo ', '{%while myval %} yo {%assign myval = false%}{%endwhile%}', 'myval' => 0)
+    assert_template_result(' yo ', '{%while myval %} yo {%assign myval = false%}{%endwhile%}', 'myval' => 'test')
+    assert_template_result('', '{%while myval %} yo {%assign myval = true%}{%endwhile%}', 'myval' => false)
+    assert_template_result('', '{%while myval %} yo {%assign myval = true%}{%endwhile%}', 'myval' => nil)
+
+    assert_template_result('0123', '{%while myval %}{%increment counter %}{% if counter > 3 %}{% assign myval = false %}{%endif%}{%endwhile%}', 'myval' => true)
+
+    # test binary comparators ==, !=, <, <=, >, >= with constants and with two variables
+    # test ==
+    assert_template_result('0', '{%while myval == 0 %}{{myval}}{%assign myval = myval | plus: 1 %}{%endwhile%}', 'myval' => 0)
+    assert_template_result('0', '{%while myval1 == myval2 %}{{myval1}}{%assign myval1 = myval1 | plus: 1 %}{%endwhile%}', {'myval1' => 0, 'myval2' => 0})
+
+    # test !=
+    assert_template_result('0123', '{%while myval != 4 %}{{myval}}{%assign myval = myval | plus: 1 %}{%endwhile%}', 'myval' => 0)
+    assert_template_result('0123', '{%while myval1 != myval2 %}{{myval1}}{%assign myval1 = myval1 | plus: 1 %}{%endwhile%}', {'myval1' => 0, 'myval2' => 4})
+
+    # test <
+    assert_template_result('0123', '{%while myval < 4 %}{{myval}}{%assign myval = myval | plus: 1 %}{%endwhile%}', 'myval' => 0)
+    assert_template_result('0123', '{%while myval1 < myval2 %}{{myval1}}{%assign myval1 = myval1 | plus: 1 %}{%endwhile%}', {'myval1' => 0, 'myval2' => 4})
+
+    # test <=
+    assert_template_result('01234', '{%while myval <= 4 %}{{myval}}{%assign myval = myval | plus: 1 %}{%endwhile%}', 'myval' => 0)
+    assert_template_result('01234', '{%while myval1 <= myval2 %}{{myval1}}{%assign myval1 = myval1 | plus: 1 %}{%endwhile%}', {'myval1' => 0, 'myval2' => 4})
+
+    # test >
+    assert_template_result('8765', '{%while myval > 4 %}{{myval}}{%assign myval = myval | minus: 1 %}{%endwhile%}', 'myval' => 8)
+    assert_template_result('8765', '{%while myval1 > myval2 %}{{myval1}}{%assign myval1 = myval1 | minus: 1 %}{%endwhile%}', {'myval1' => 8, 'myval2' => 4})
+
+    # test >=
+    assert_template_result('87654', '{%while myval >= 4 %}{{myval}}{%assign myval = myval | minus: 1 %}{%endwhile%}', 'myval' => 8)
+    assert_template_result('87654', '{%while myval1 >= myval2 %}{{myval1}}{%assign myval1 = myval1 | minus: 1 %}{%endwhile%}', {'myval1' => 8, 'myval2' => 4})
   end
 
   def test_while_with_break


### PR DESCRIPTION
Created a new tag `while` to add while loops to liquid.  

The `while` tag functions as you would expect it to - it takes an expression and loops over a block of statements until the expression provided evaluates to be falsy.  

Example:  
```liquid
{% assign counter = 0 %}
{% while counter < 5 %}
  {{counter}}
  {% assign counter = counter | plus: 1 %}
{% endwhile %}

{% comment %}
Result: "01234"
{% endcomment %}
```  

