### PR TITLE
Implicit variable scoping

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -12,20 +12,18 @@ module Liquid
   #
   #   context['bob']  #=> nil  class Context
   class Context
-    attr_reader :scopes, :errors, :registers, :environments, :resource_limits
+    attr_reader :scope, :errors, :registers, :environments, :resource_limits
     attr_accessor :exception_renderer, :template_name, :partial, :global_filter, :strict_variables, :strict_filters
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil)
       @environments     = [environments].flatten
-      @scopes           = [(outer_scope || {})]
+      @scope            = outer_scope || {}
       @registers        = registers
       @errors           = []
       @partial          = false
       @strict_variables = false
       @resource_limits  = resource_limits || ResourceLimits.new(Template.default_resource_limits)
       squash_instance_assigns_with_environments
-
-      @this_stack_used = false
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
@@ -35,6 +33,8 @@ module Liquid
       @interrupts = []
       @filters = []
       @global_filter = nil
+
+      @stack_level = 0
     end
 
     def warnings
@@ -86,21 +86,9 @@ module Liquid
       strainer.invoke(method, *args).to_liquid
     end
 
-    # Push new local scope on the stack. use <tt>Context#stack</tt> instead
-    def push(new_scope = {})
-      @scopes.unshift(new_scope)
-      raise StackLevelError, "Nesting too deep".freeze if @scopes.length > Block::MAX_DEPTH
-    end
-
     # Merge a hash of variables in the current local scope
     def merge(new_scopes)
-      @scopes[0].merge!(new_scopes)
-    end
-
-    # Pop from the stack. use <tt>Context#stack</tt> instead
-    def pop
-      raise ContextError if @scopes.size == 1
-      @scopes.shift
+      @scope.merge!(new_scopes)
     end
 
     # Pushes a new local scope on the stack, pops it at the end of the block
@@ -111,32 +99,26 @@ module Liquid
     #   end
     #
     #   context['var]  #=> nil
-    def stack(new_scope = nil)
-      old_stack_used = @this_stack_used
-      if new_scope
-        push(new_scope)
-        @this_stack_used = true
-      else
-        @this_stack_used = false
+    def stack(*variable_names)
+      previous_values = {}
+      variable_names.each do |variable_name|
+        previous_values[variable_name] = @scope[variable_name]
       end
 
-      yield
-    ensure
-      pop if @this_stack_used
-      @this_stack_used = old_stack_used
-    end
+      @stack_level += 1
+      raise StackLevelError, "Nesting too deep".freeze if @stack_level > Block::MAX_DEPTH
 
-    def clear_instance_assigns
-      @scopes[0] = {}
+      begin
+        yield
+      ensure
+        @scope.merge!(previous_values)
+        @stack_level -= 1
+      end
     end
 
     # Only allow String, Numeric, Hash, Array, Proc, Boolean or <tt>Liquid::Drop</tt>
     def []=(key, value)
-      unless @this_stack_used
-        @this_stack_used = true
-        push({})
-      end
-      @scopes[0][key] = value
+      @scope[key] = value
     end
 
     # Look up variable, either resolve directly after considering the name. We can directly handle
@@ -161,26 +143,19 @@ module Liquid
 
     # Fetches an object starting at the local scope and then moving up the hierachy
     def find_variable(key, raise_on_not_found: true)
-      # This was changed from find() to find_index() because this is a very hot
-      # path and find_index() is optimized in MRI to reduce object allocation
-      index = @scopes.find_index { |s| s.key?(key) }
-      scope = @scopes[index] if index
-
-      variable = nil
+      scope = @scope if @scope.key?(key)
 
       if scope.nil?
-        @environments.each do |e|
+        index = @environments.find_index do |e|
           variable = lookup_and_evaluate(e, key, raise_on_not_found: raise_on_not_found)
           # When lookup returned a value OR there is no value but the lookup also did not raise
           # then it is the value we are looking for.
-          if !variable.nil? || @strict_variables && raise_on_not_found
-            scope = e
-            break
-          end
+          !variable.nil? || @strict_variables && raise_on_not_found
         end
+
+        scope = @environments[index || -1]
       end
 
-      scope ||= @environments.last || @scopes.last
       variable ||= lookup_and_evaluate(scope, key, raise_on_not_found: raise_on_not_found)
 
       variable = variable.to_liquid
@@ -213,10 +188,10 @@ module Liquid
     end
 
     def squash_instance_assigns_with_environments
-      @scopes.last.each_key do |k|
+      @scope.each_key do |k|
         @environments.each do |env|
           if env.key?(k)
-            scopes.last[k] = lookup_and_evaluate(env, k)
+            @scope[k] = lookup_and_evaluate(env, k)
             break
           end
         end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -143,7 +143,8 @@ module Liquid
 
     # Fetches an object starting at the local scope and then moving up the hierachy
     def find_variable(key, raise_on_not_found: true)
-      scope = @scope if @scope.key?(key)
+      value = @scope[key]
+      scope = @scope if value != nil
 
       if scope.nil?
         index = @environments.find_index do |e|

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -140,6 +140,16 @@ module Liquid
       @scope[key][0] = val
     end
 
+    def set_level(key, val, int)
+      @scope[key] ||= []
+      @scope[key][int] = val
+    end
+
+    def create_level(key)
+      (@scope[key] ||= [nil]) << nil
+      @scope[key].size - 1
+    end
+
     def key?(key)
       self[key] != nil
     end

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -24,7 +24,7 @@ module Liquid
 
     def render(context)
       val = @from.render(context)
-      context.scopes.last[@to] = val
+      context[@to] = val
       context.resource_limits.assign_score += assign_score_of(val)
       ''.freeze
     end

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -24,7 +24,7 @@ module Liquid
 
     def render(context)
       val = @from.render(context)
-      context[@to] = val
+      context.set_root(@to, val)
       context.resource_limits.assign_score += assign_score_of(val)
       ''.freeze
     end

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -24,7 +24,7 @@ module Liquid
 
     def render(context)
       output = super
-      context[@to] = output
+      context.set_root(@to, output)
       context.resource_limits.assign_score += output.bytesize
       ''.freeze
     end

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -24,7 +24,7 @@ module Liquid
 
     def render(context)
       output = super
-      context.scopes.last[@to] = output
+      context[@to] = output
       context.resource_limits.assign_score += output.bytesize
       ''.freeze
     end

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -39,20 +39,19 @@ module Liquid
     end
 
     def render(context)
-      context.stack do
-        execute_else_block = true
+      execute_else_block = true
 
-        output = ''
-        @blocks.each do |block|
-          if block.else?
-            return block.attachment.render(context) if execute_else_block
-          elsif block.evaluate(context)
-            execute_else_block = false
-            output << block.attachment.render(context)
-          end
+      output = ''
+      @blocks.each do |block|
+        if block.else?
+          return block.attachment.render(context) if execute_else_block
+        elsif block.evaluate(context)
+          execute_else_block = false
+          output << block.attachment.render(context)
         end
-        output
       end
+
+      output
     end
 
     private

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -34,15 +34,13 @@ module Liquid
     def render(context)
       context.registers[:cycle] ||= {}
 
-      context.stack do
-        key = context.evaluate(@name)
-        iteration = context.registers[:cycle][key].to_i
-        result = context.evaluate(@variables[iteration])
-        iteration += 1
-        iteration  = 0 if iteration >= @variables.size
-        context.registers[:cycle][key] = iteration
-        result
-      end
+      key = context.evaluate(@name)
+      iteration = context.registers[:cycle][key].to_i
+      result = context.evaluate(@variables[iteration])
+      iteration += 1
+      iteration  = 0 if iteration >= @variables.size
+      context.registers[:cycle][key] = iteration
+      result
     end
 
     private

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -168,6 +168,7 @@ module Liquid
             context[@variable_name] = item
             result << @for_block.render(context)
             loop_vars.send(:increment!)
+            context.unset(@variable_name)
 
             # Handle any interrupts if they exist.
             if context.interrupt?
@@ -176,6 +177,8 @@ module Liquid
               next if interrupt.is_a? ContinueInterrupt
             end
           end
+
+          context.unset('forloop'.freeze)
         ensure
           for_stack.pop
         end

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -163,13 +163,12 @@ module Liquid
 
         begin
           context['forloop'.freeze] = loop_vars
+          level = context.create_level(@variable_name)
 
           segment.each do |item|
-            context[@variable_name] = item
+            context.set_level(@variable_name, item, level)
             result << @for_block.render(context)
             loop_vars.send(:increment!)
-            context.unset(@variable_name)
-
             # Handle any interrupts if they exist.
             if context.interrupt?
               interrupt = context.pop_interrupt
@@ -177,9 +176,10 @@ module Liquid
               next if interrupt.is_a? ContinueInterrupt
             end
           end
-
+          context.unset(@variable_name)
           context.unset('forloop'.freeze)
         ensure
+
           for_stack.pop
         end
       end

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -156,7 +156,7 @@ module Liquid
 
       result = ''
 
-      context.stack do
+      context.stack('forloop', @variable_name) do
         loop_vars = Liquid::ForloopDrop.new(@name, length, for_stack[-1])
 
         for_stack.push(loop_vars)

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -40,14 +40,12 @@ module Liquid
     end
 
     def render(context)
-      context.stack do
-        @blocks.each do |block|
-          if block.evaluate(context)
-            return block.attachment.render(context)
-          end
+      @blocks.each do |block|
+        if block.evaluate(context)
+          return block.attachment.render(context)
         end
-        ''.freeze
       end
+      ''.freeze
     end
 
     private

--- a/lib/liquid/tags/ifchanged.rb
+++ b/lib/liquid/tags/ifchanged.rb
@@ -1,15 +1,13 @@
 module Liquid
   class Ifchanged < Block
     def render(context)
-      context.stack do
-        output = super
+      output = super
 
-        if output != context.registers[:ifchanged]
-          context.registers[:ifchanged] = output
-          output
-        else
-          ''.freeze
-        end
+      if output != context.registers[:ifchanged]
+        context.registers[:ifchanged] = output
+        output
+      else
+        ''.freeze
       end
     end
   end

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -60,7 +60,7 @@ module Liquid
       begin
         context.template_name = template_name
         context.partial = true
-        context.stack do
+        context.stack(context_variable_name, *@attributes.keys) do
           @attributes.each do |key, value|
             context[key] = context.evaluate(value)
           end

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -31,7 +31,7 @@ module Liquid
       cols = context.evaluate(@attributes['cols'.freeze]).to_i
 
       result = "<tr class=\"row1\">\n"
-      context.stack do
+      context.stack('tablerowloop', @variable_name) do
         tablerowloop = Liquid::TablerowloopDrop.new(length, cols)
         context['tablerowloop'.freeze] = tablerowloop
 

--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -7,22 +7,20 @@ module Liquid
   #
   class Unless < If
     def render(context)
-      context.stack do
-        # First condition is interpreted backwards ( if not )
-        first_block = @blocks.first
-        unless first_block.evaluate(context)
-          return first_block.attachment.render(context)
-        end
-
-        # After the first condition unless works just like if
-        @blocks[1..-1].each do |block|
-          if block.evaluate(context)
-            return block.attachment.render(context)
-          end
-        end
-
-        ''.freeze
+      # First condition is interpreted backwards ( if not )
+      first_block = @blocks.first
+      unless first_block.evaluate(context)
+        return first_block.attachment.render(context)
       end
+
+      # After the first condition unless works just like if
+      @blocks[1..-1].each do |block|
+        if block.evaluate(context)
+          return block.attachment.render(context)
+        end
+      end
+
+      ''.freeze
     end
   end
 

--- a/performance/shopify/comment_form.rb
+++ b/performance/shopify/comment_form.rb
@@ -15,7 +15,7 @@ class CommentForm < Liquid::Block
   def render(context)
     article = context[@variable_name]
 
-    context.stack do
+    context.stack('form') do
       context['form'] = {
         'posted_successfully?' => context.registers[:posted_successfully],
         'errors' => context['comment.errors'],

--- a/performance/shopify/paginate.rb
+++ b/performance/shopify/paginate.rb
@@ -24,7 +24,7 @@ class Paginate < Liquid::Block
   def render(context)
     @context = context
 
-    context.stack do
+    context.stack('paginate') do
       current_page  = context['current_page'].to_i
 
       pagination = {

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -1,14 +1,6 @@
 require 'test_helper'
 
 class ContextDrop < Liquid::Drop
-  def scopes
-    @context.scopes.size
-  end
-
-  def scopes_as_array
-    (1..@context.scopes.size).to_a
-  end
-
   def loop_pos
     @context['forloop.index']
   end
@@ -192,31 +184,6 @@ class DropsTest < Minitest::Test
       output = Liquid::Template.parse(" {{ product.#{method} }} ").render!('product' => ProductDrop.new)
       assert_equal '  ', output
     end
-  end
-
-  def test_scope
-    assert_equal '1', Liquid::Template.parse('{{ context.scopes }}').render!('context' => ContextDrop.new)
-    assert_equal '2', Liquid::Template.parse('{%for i in dummy%}{{ context.scopes }}{%endfor%}').render!('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '3', Liquid::Template.parse('{%for i in dummy%}{%for i in dummy%}{{ context.scopes }}{%endfor%}{%endfor%}').render!('context' => ContextDrop.new, 'dummy' => [1])
-  end
-
-  def test_scope_though_proc
-    assert_equal '1', Liquid::Template.parse('{{ s }}').render!('context' => ContextDrop.new, 's' => proc{ |c| c['context.scopes'] })
-    assert_equal '2', Liquid::Template.parse('{%for i in dummy%}{{ s }}{%endfor%}').render!('context' => ContextDrop.new, 's' => proc{ |c| c['context.scopes'] }, 'dummy' => [1])
-    assert_equal '3', Liquid::Template.parse('{%for i in dummy%}{%for i in dummy%}{{ s }}{%endfor%}{%endfor%}').render!('context' => ContextDrop.new, 's' => proc{ |c| c['context.scopes'] }, 'dummy' => [1])
-  end
-
-  def test_scope_with_assigns
-    assert_equal 'variable', Liquid::Template.parse('{% assign a = "variable"%}{{a}}').render!('context' => ContextDrop.new)
-    assert_equal 'variable', Liquid::Template.parse('{% assign a = "variable"%}{%for i in dummy%}{{a}}{%endfor%}').render!('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal 'test', Liquid::Template.parse('{% assign header_gif = "test"%}{{header_gif}}').render!('context' => ContextDrop.new)
-    assert_equal 'test', Liquid::Template.parse("{% assign header_gif = 'test'%}{{header_gif}}").render!('context' => ContextDrop.new)
-  end
-
-  def test_scope_from_tags
-    assert_equal '1', Liquid::Template.parse('{% for i in context.scopes_as_array %}{{i}}{% endfor %}').render!('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '12', Liquid::Template.parse('{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}').render!('context' => ContextDrop.new, 'dummy' => [1])
-    assert_equal '123', Liquid::Template.parse('{%for a in dummy%}{%for a in dummy%}{% for i in context.scopes_as_array %}{{i}}{% endfor %}{% endfor %}{% endfor %}').render!('context' => ContextDrop.new, 'dummy' => [1])
   end
 
   def test_access_context_from_drop

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -405,11 +405,11 @@ class StandardFiltersTest < Minitest::Test
   def test_map_over_drops_returning_procs
     drops = [
       {
-        "proc" => ->{ "foo" },
+        "proc" => ->{ "foo" }
       },
       {
-        "proc" => ->{ "bar" },
-      },
+        "proc" => ->{ "bar" }
+      }
     ]
     templ = '{{ drops | map: "proc" }}'
     assert_template_result "foobar", templ, "drops" => drops

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -369,7 +369,7 @@ HERE
   end
 
   def test_overwriting_internal_variable
-    template = <<-END_TEMPLATE
+    template = <<-HEREDOC
     {% assign forloop = 'first' %}
 
     {% for item in items %}
@@ -379,7 +379,7 @@ HERE
     {% endfor %}
 
     {{ forloop }}
-    END_TEMPLATE
+    HEREDOC
 
     result = Liquid::Template.parse(template).render('items' => '1')
     assert_equal 'Liquid::ForloopDrop Liquid::ForloopDrop second', result.split.map(&:strip).join(' ')

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -368,6 +368,23 @@ HERE
     assert_template_result(expected, template, assigns)
   end
 
+  def test_overwriting_internal_variable
+    template = <<-END_TEMPLATE
+    {% assign forloop = 'first' %}
+
+    {% for item in items %}
+      {{ forloop }}
+      {% assign forloop = 'second' %}
+      {{ forloop }}
+    {% endfor %}
+
+    {{ forloop }}
+    END_TEMPLATE
+
+    result = Liquid::Template.parse(template).render('items' => '1')
+    assert_equal 'Liquid::ForloopDrop Liquid::ForloopDrop second', result.split.map(&:strip).join(' ')
+  end
+
   class LoaderDrop < Liquid::Drop
     attr_accessor :each_called, :load_slice_called
 

--- a/test/integration/tags/if_else_tag_test.rb
+++ b/test/integration/tags/if_else_tag_test.rb
@@ -176,7 +176,7 @@ class IfElseTagTest < Minitest::Test
       [false, true, true] => true,
       [false, true, false] => false,
       [false, false, true] => false,
-      [false, false, false] => false,
+      [false, false, false] => false
     }
 
     tests.each do |vals, expected|

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -163,35 +163,6 @@ class ContextUnitTest < Minitest::Test
     assert_equal 'test', @context['test']
   end
 
-  def test_add_item_in_inner_scope
-    @context.stack('test') do
-      @context['test'] = 'test'
-      assert_equal 'test', @context['test']
-    end
-
-    assert_nil @context['test']
-  end
-
-  def test_nested_scopes
-    @context['test'] = 1
-
-    @context.stack('test') do
-      assert_equal 1, @context['test']
-      @context['test'] = 2
-      assert_equal 2, @context['test']
-
-      @context.stack('test') do
-        assert_equal 2, @context['test']
-        @context['test'] = 3
-        assert_equal 3, @context['test']
-      end
-
-      assert_equal 2, @context['test']
-    end
-
-    assert_equal 1, @context['test']
-  end
-
   def test_hierachical_data
     @context['hash'] = { "name" => 'tobi' }
     assert_equal 'tobi', @context['hash.name']


### PR DESCRIPTION
Just an experiment, not sure if this is a good idea.

Based on @evulse's comment in https://github.com/Shopify/liquid/pull/1086#issuecomment-482026596.

Not sure I got this right, might have misunderstood Mike.

Idea here is that we only explicitly keep track of one scope (the "current" one). All changes to this scope are tracked implicitly via the call stack. As an additional optimization, we tell `Context#stack` which variables we intend to change, so we don't have to save the entire previous stack but only the fields that will change.

This has the big advantage that `find_variable` (one of the hottest code paths in Liquid's rendering step) only has to look at **one** scope (the "current", i.e. innermost one, which has all outer ones "merged into it") rather than having to look at **all** of the previous scopes.

I'm kind of surprised that this just works and doesn't break any tests. What am I missing?

Some numbers (although I don't really trust them and not sure how to properly profile this):

<details>
<summary>fnova index page before (6.1% of samples in find_variable)</summary>

```
==================================
  Mode: cpu(1000)
  Samples: 14843 (0.58% miss rate)
  GC: 2276 (15.33%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2276  (15.3%)        2276  (15.3%)     (garbage collection)
...
      1508  (10.2%)         900   (6.1%)     Liquid::Context#find_variable
     11684  (78.7%)         830   (5.6%)     Liquid::BlockBody#render
      5379  (36.2%)         782   (5.3%)     Liquid::Context#evaluate
      3285  (22.1%)         584   (3.9%)     Liquid::Context#lookup_and_evaluate
       367   (2.5%)         367   (2.5%)     Set#include?
...

...

==================================
  Mode: cpu(1000)
  Samples: 16244 (0.67% miss rate)
  GC: 2492 (15.34%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2492  (15.3%)        2492  (15.3%)     (garbage collection)
...
      1711  (10.5%)        1002   (6.2%)     Liquid::Context#find_variable
     12819  (78.9%)         980   (6.0%)     Liquid::BlockBody#render
      5717  (35.2%)         886   (5.5%)     Liquid::Context#evaluate
      3316  (20.4%)         709   (4.4%)     Liquid::Context#lookup_and_evaluate
       391   (2.4%)         391   (2.4%)     Set#include?
...
```
</details>

<details>
<summary>fnova index page after (3.6% samples in find_variable)</summary>

```
==================================
  Mode: cpu(1000)
  Samples: 15797 (0.64% miss rate)
  GC: 2556 (16.18%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2556  (16.2%)        2556  (16.2%)     (garbage collection)
...
     12293  (77.8%)         953   (6.0%)     Liquid::BlockBody#render
      5302  (33.6%)         949   (6.0%)     Liquid::Context#evaluate
      3315  (21.0%)         749   (4.7%)     Liquid::Context#lookup_and_evaluate
      1312   (8.3%)         584   (3.7%)     Liquid::Context#find_variable
      3589  (22.7%)         393   (2.5%)     Liquid::Condition#interpret_condition
...

...

==================================
  Mode: cpu(1000)
  Samples: 15723 (0.68% miss rate)
  GC: 2479 (15.77%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2479  (15.8%)        2479  (15.8%)     (garbage collection)
...
      5339  (34.0%)        1024   (6.5%)     Liquid::Context#evaluate
     12271  (78.0%)        1002   (6.4%)     Liquid::BlockBody#render
      3287  (20.9%)         726   (4.6%)     Liquid::Context#lookup_and_evaluate
      1274   (8.1%)         547   (3.5%)     Liquid::Context#find_variable
...
```
</details>

<details>
<summary>rake profile:run before (1.9% cpu samples in find_variable)</summary>

```
Profiling in cpu mode...
==================================
  Mode: cpu(1000)
  Samples: 8593 (0.00% miss rate)
  GC: 926 (10.78%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3217  (37.4%)        1097  (12.8%)     Liquid::Variable#lax_parse
      1029  (12.0%)         865  (10.1%)     Liquid::VariableLookup#initialize
      1623  (18.9%)         743   (8.6%)     Liquid::Expression.parse
     11062 (128.7%)         405   (4.7%)     Liquid::BlockBody#parse
      1118  (13.0%)         327   (3.8%)     Liquid::Context#evaluate
       771   (9.0%)         293   (3.4%)     Liquid::Variable#parse_filter_expressions
      5828  (67.8%)         275   (3.2%)     Liquid::BlockBody#render
       253   (2.9%)         253   (2.9%)     Liquid::Tokenizer#tokenize
       215   (2.5%)         200   (2.3%)     Liquid::Context#lookup_and_evaluate
       531   (6.2%)         194   (2.3%)     Liquid::If#lax_parse
       515   (6.0%)         167   (1.9%)     Liquid::Context#find_variable
       145   (1.7%)         145   (1.7%)     Liquid::ResourceLimits#reached?
       140   (1.6%)         140   (1.6%)     Liquid::Tokenizer#shift
       139   (1.6%)         139   (1.6%)     Liquid::BlockBody#whitespace_handler
      5129  (59.7%)         110   (1.3%)     Liquid::BlockBody#create_variable
      1064  (12.4%)         109   (1.3%)     Liquid::VariableLookup#evaluate
       304   (3.5%)         105   (1.2%)     Liquid::For#lax_parse
       102   (1.2%)         102   (1.2%)     Liquid::Tag#initialize
        92   (1.1%)          92   (1.1%)     Set#include?
        85   (1.0%)          85   (1.0%)     Liquid::Template.tags
Profiling in object mode...
==================================
  Mode: object(1)
  Samples: 15768261 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   8648800  (54.8%)     3538000  (22.4%)     Liquid::Variable#lax_parse
   2034200  (12.9%)     2034200  (12.9%)     Liquid::VariableLookup#initialize
  14969600  (94.9%)     1671600  (10.6%)     Liquid::BlockBody#create_variable
    877201   (5.6%)      877201   (5.6%)     Liquid::Tokenizer#tokenize
   3176600  (20.1%)      847600   (5.4%)     Liquid::Expression.parse
    828800   (5.3%)      828800   (5.3%)     Liquid::BlockBody#whitespace_handler
   3815903  (24.2%)      798200   (5.1%)     Liquid::Variable#render
  27691600 (175.6%)      749000   (4.8%)     Liquid::BlockBody#parse
   1458000   (9.2%)      627600   (4.0%)     Liquid::Variable#parse_filter_expressions
   1075000   (6.8%)      495400   (3.1%)     Liquid::If#lax_parse
    409600   (2.6%)      409600   (2.6%)     Liquid::StandardFilters#truncatewords
   2329000  (14.8%)      294800   (1.9%)     Liquid::VariableLookup.parse
    524000   (3.3%)      198200   (1.3%)     Liquid::For#lax_parse
    211400   (1.3%)      197000   (1.2%)     Liquid::Variable#evaluate_filter_expressions
   1166251   (7.4%)      197000   (1.2%)     Liquid::Context#invoke
   6132883  (38.9%)      133200   (0.8%)     Liquid::BlockBody#render
    108000   (0.7%)      108000   (0.7%)     Liquid::Context#initialize
    104400   (0.7%)      104400   (0.7%)     Liquid::BlockBody#initialize
    188000   (1.2%)       94000   (0.6%)     Liquid::Context#find_variable
   5999683  (38.0%)       84200   (0.5%)     Liquid::BlockBody#render_node_to_output
```
</details>

<details>
<summary>rake profile:run after (1.2% cpu samples in find_variable)</summary>

```
==================================
  Mode: cpu(1000)
  Samples: 8446 (0.00% miss rate)
  GC: 877 (10.38%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      3252  (38.5%)        1137  (13.5%)     Liquid::Variable#lax_parse
      1023  (12.1%)         849  (10.1%)     Liquid::VariableLookup#initialize
      1559  (18.5%)         684   (8.1%)     Liquid::Expression.parse
     11034 (130.6%)         405   (4.8%)     Liquid::BlockBody#parse
       778   (9.2%)         317   (3.8%)     Liquid::Variable#parse_filter_expressions
       974  (11.5%)         278   (3.3%)     Liquid::Context#evaluate
      5273  (62.4%)         246   (2.9%)     Liquid::BlockBody#render
       232   (2.7%)         232   (2.7%)     Liquid::Tokenizer#tokenize
       226   (2.7%)         213   (2.5%)     Liquid::Context#lookup_and_evaluate
       494   (5.8%)         192   (2.3%)     Liquid::If#lax_parse
       173   (2.0%)         173   (2.0%)     Liquid::BlockBody#whitespace_handler
       151   (1.8%)         151   (1.8%)     Liquid::ResourceLimits#reached?
      5190  (61.4%)         124   (1.5%)     Liquid::BlockBody#create_variable
       124   (1.5%)         124   (1.5%)     Liquid::Tokenizer#shift
       313   (3.7%)         104   (1.2%)     Liquid::For#lax_parse
       104   (1.2%)         104   (1.2%)     Liquid::Tag#initialize
       384   (4.5%)         102   (1.2%)     Liquid::Context#find_variable
       937  (11.1%)         101   (1.2%)     Liquid::VariableLookup#evaluate
        87   (1.0%)          87   (1.0%)     Liquid::Template.tags
        83   (1.0%)          83   (1.0%)     Set#include?

Profiling in object mode...
==================================
  Mode: object(1)
  Samples: 15696858 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
   8648800  (55.1%)     3538000  (22.5%)     Liquid::Variable#lax_parse
   2034200  (13.0%)     2034200  (13.0%)     Liquid::VariableLookup#initialize
  14969600  (95.4%)     1671600  (10.6%)     Liquid::BlockBody#create_variable
    877201   (5.6%)      877201   (5.6%)     Liquid::Tokenizer#tokenize
   3176600  (20.2%)      847600   (5.4%)     Liquid::Expression.parse
    828800   (5.3%)      828800   (5.3%)     Liquid::BlockBody#whitespace_handler
   3746497  (23.9%)      798200   (5.1%)     Liquid::Variable#render
  27691600 (176.4%)      749000   (4.8%)     Liquid::BlockBody#parse
   1458000   (9.3%)      627600   (4.0%)     Liquid::Variable#parse_filter_expressions
   1075000   (6.8%)      495400   (3.2%)     Liquid::If#lax_parse
    409600   (2.6%)      409600   (2.6%)     Liquid::StandardFilters#truncatewords
   2329000  (14.8%)      294800   (1.9%)     Liquid::VariableLookup.parse
    524000   (3.3%)      198200   (1.3%)     Liquid::For#lax_parse
   1166248   (7.4%)      197000   (1.3%)     Liquid::Context#invoke
    197000   (1.3%)      197000   (1.3%)     Liquid::Variable#evaluate_filter_expressions
   6029502  (38.4%)      133200   (0.8%)     Liquid::BlockBody#render
    104400   (0.7%)      104400   (0.7%)     Liquid::BlockBody#initialize
     96000   (0.6%)       96000   (0.6%)     Liquid::Context#initialize
   5896302  (37.6%)       84200   (0.5%)     Liquid::BlockBody#render_node_to_output
  17815400 (113.5%)       83200   (0.5%)     Liquid::Tag.parse
```
</details>

@pushrax @dylanahsmith @sirupsen
FYI @tobi 