### PR TITLE
use bytesize, not length

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -115,7 +115,7 @@ module Liquid
     end
 
     def check_resources(context, node_output)
-      context.resource_limits.render_length += node_output.length
+      context.resource_limits.render_length += node_output.bytesize
       return unless context.resource_limits.reached?
       raise MemoryError.new("Memory limits exceeded".freeze)
     end

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -37,7 +37,7 @@ module Liquid
 
     def assign_score_of(val)
       if val.instance_of?(String)
-        val.length
+        val.bytesize
       elsif val.instance_of?(Array) || val.instance_of?(Hash)
         sum = 1
         # Uses #each to avoid extra allocations.

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -25,7 +25,7 @@ module Liquid
     def render(context)
       output = super
       context.scopes.last[@to] = output
-      context.resource_limits.assign_score += output.length
+      context.resource_limits.assign_score += output.bytesize
       ''.freeze
     end
 

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -139,6 +139,16 @@ class TemplateTest < Minitest::Test
     refute_nil t.resource_limits.assign_score
   end
 
+  def test_resource_limits_assign_score_counts_bytes_not_characters
+    t = Template.parse("{% assign foo = 'すごい' %}")
+    t.render
+    assert_equal 9, t.resource_limits.assign_score
+
+    t = Template.parse("{% capture foo %}すごい{% endcapture %}")
+    t.render
+    assert_equal 9, t.resource_limits.assign_score
+  end
+
   def test_resource_limits_assign_score_nested
     t = Template.parse("{% assign foo = 'aaaa' | reverse %}")
 
@@ -185,6 +195,14 @@ class TemplateTest < Minitest::Test
     assert_equal "Liquid error: Memory limits exceeded", t.render
     t.resource_limits.render_length_limit = 12
     assert_equal "ababab", t.render
+  end
+
+  def test_render_length_uses_number_of_bytes_not_characters
+    t = Template.parse("{% if true %}すごい{% endif %}")
+    t.resource_limits.render_length_limit = 10
+    assert_equal "Liquid error: Memory limits exceeded", t.render
+    t.resource_limits.render_length_limit = 18
+    assert_equal "すごい", t.render
   end
 
   def test_default_resource_limits_unaffected_by_render_with_context


### PR DESCRIPTION
While working on https://github.com/Shopify/liquid/pull/1091, I found this to be a significant performance improvement on that branch (I'm guessing because a `String` in Ruby always knows it's own size in bytes, but to calculate it's length, Ruby has to count characters).

I don't expect it to have a huge impact without https://github.com/Shopify/liquid/pull/1091 (where the string in question is much longer), but probably can't hurt to fix this regardless.