### PR TITLE
Make sure the for tag's limit and offset are integers

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -124,14 +124,23 @@ module Liquid
       from = if @from == :continue
         offsets[@name].to_i
       else
-        context.evaluate(@from).to_i
+        from_value = context.evaluate(@from)
+        if from_value.nil?
+          0
+        else
+          Utils.to_integer(from_value)
+        end
       end
 
       collection = context.evaluate(@collection_name)
       collection = collection.to_a if collection.is_a?(Range)
 
-      limit = context.evaluate(@limit)
-      to = limit ? limit.to_i + from : nil
+      limit_value = context.evaluate(@limit)
+      to = if limit_value.nil?
+        nil
+      else
+        Utils.to_integer(limit_value) + from
+      end
 
       segment = Utils.slice_collection(collection, from, to)
       segment.reverse! if @reversed

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -103,6 +103,34 @@ HERE
     assert_template_result('3456', '{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}', assigns)
   end
 
+  def test_limiting_with_invalid_limit
+    assigns = { 'array' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] }
+    template = <<-MKUP
+      {% for i in array limit: true offset: 1 %}
+        {{ i }}
+      {% endfor %}
+    MKUP
+
+    exception = assert_raises(Liquid::ArgumentError) do
+      Template.parse(template).render!(assigns)
+    end
+    assert_equal("Liquid error: invalid integer", exception.message)
+  end
+
+  def test_limiting_with_invalid_offset
+    assigns = { 'array' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] }
+    template = <<-MKUP
+      {% for i in array limit: 1 offset: true %}
+        {{ i }}
+      {% endfor %}
+    MKUP
+
+    exception = assert_raises(Liquid::ArgumentError) do
+      Template.parse(template).render!(assigns)
+    end
+    assert_equal("Liquid error: invalid integer", exception.message)
+  end
+
   def test_dynamic_variable_limiting
     assigns = { 'array' => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0] }
     assigns['limit'] = 2


### PR DESCRIPTION
Code like

```liquid
{% for i in (1..4) limit: false offset: false %}
  {{ i }}
{% endfor %}
```

currently raises a 

```
NoMethodError: undefined method `to_i' for false:FalseClass
```

on the following line: https://github.com/Shopify/liquid/blob/c2ef247be5b742945e6cf1a0023ce84770190751/lib/liquid/tags/for.rb#L127

This is because the evaluated values for `limit` and `offset` are assumed to be integers but never validated. I've fixed this by using [`Utils.to_integer`](https://github.com/Shopify/liquid/blob/c2ef247be5b742945e6cf1a0023ce84770190751/lib/liquid/utils.rb#L36) which will raise a `Liquid::ArgumentError` instead, giving template authors some semblance of feedback.