### PR TITLE
Stop installing the rainbow gem on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - rvm: jruby-head
 
 install:
-  - gem install rainbow -v 2.2.1
   - bundle install
 
 script: bundle exec rake


### PR DESCRIPTION
Introduced in https://github.com/Shopify/liquid/pull/851/files#diff-354f30a63fb0907d4ad57269548329e3R23 for no apparent reason.

This is currently [breaks the `ruby-head` build](https://travis-ci.org/Shopify/liquid/jobs/523188522#L517). Removing the gem [fixes it](https://travis-ci.org/Shopify/liquid/jobs/523680604) and gets the `jruby-head` build further along (but it's [now failing due to `stackprof`](https://travis-ci.org/Shopify/liquid/jobs/523680605#L562)).