### PR TITLE
Run Travis on supported versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
   - jruby-head
-#  - rbx-2
 
 sudo: false
 


### PR DESCRIPTION
Updates the build matrix to the currently supported versions of Ruby.

https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/