### PR TITLE
Use a private constant to stash token-types

### DIFF
--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -44,14 +44,14 @@ module Liquid
       tok[0] == type
     end
 
-    CONSUME_TOKENS = [:string, :number].freeze
-    private_constant :CONSUME_TOKENS
+    SINGLE_TOKEN_EXPRESSION_TYPES = [:string, :number].freeze
+    private_constant :SINGLE_TOKEN_EXPRESSION_TYPES
 
     def expression
       token = @tokens[@p]
       if token[0] == :id
         variable_signature
-      elsif CONSUME_TOKENS.include? token[0]
+      elsif SINGLE_TOKEN_EXPRESSION_TYPES.include? token[0]
         consume
       elsif token.first == :open_round
         consume

--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -44,7 +44,7 @@ module Liquid
       tok[0] == type
     end
 
-    CONSUME_TOKENS = [:string, :number]
+    CONSUME_TOKENS = [:string, :number].freeze
     private_constant :CONSUME_TOKENS
 
     def expression

--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -44,11 +44,14 @@ module Liquid
       tok[0] == type
     end
 
+    CONSUME_TOKENS = [:string, :number]
+    private_constant :CONSUME_TOKENS
+
     def expression
       token = @tokens[@p]
       if token[0] == :id
         variable_signature
-      elsif [:string, :number].include? token[0]
+      elsif CONSUME_TOKENS.include? token[0]
         consume
       elsif token.first == :open_round
         consume


### PR DESCRIPTION
To avoid allocating a new `[:string, :number]` each time the conditional branch is executed