### PR TITLE
Add round_to_s filter with tests

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -391,6 +391,11 @@ module Liquid
       raise Liquid::FloatDomainError, e.message
     end
 
+    def round_to_s(input, n = 0)
+      result = Utils.to_number(input)
+      sprintf("%.#{n}f", result)
+    end
+
     def ceil(input)
       Utils.to_number(input).ceil.to_i
     rescue ::FloatDomainError => e

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -610,6 +610,13 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result "4", "{{ price | round }}", 'price' => NumberLikeThing.new(4.3)
   end
 
+  def test_round_to_s
+    assert_template_result "5", "{{ input | round_to_s }}", 'input' => 4.6
+    assert_template_result "4.600", "{{ input | round_to_s:3 }}", 'input' => 4.6
+    assert_template_result "Inf", "{{ 1.0 | divided_by: 0.0 | round_to_s }}"
+    assert_template_result "5", "{{ price | round_to_s }}", 'price' => NumberLikeThing.new(4.6)
+  end
+
   def test_ceil
     assert_template_result "5", "{{ input | ceil }}", 'input' => 4.6
     assert_template_result "5", "{{ '4.3' | ceil }}"


### PR DESCRIPTION
Fixes https://github.com/Shopify/liquid/issues/1087

Added `round_to_s` filter to round numbers to strings that allow additional trailing zeros.

