### PR TITLE
Reduce allocations while registering Liquid tags

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -50,7 +50,9 @@ module Liquid
       private
 
       def lookup_class(name)
-        name.split("::").reject(&:empty?).reduce(Object) { |scope, const| scope.const_get(const) }
+        names = name.split("::".freeze)
+        names.reject!(&:empty?)
+        names.reduce(Object) { |scope, const| scope.const_get(const) }
       end
     end
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -50,9 +50,7 @@ module Liquid
       private
 
       def lookup_class(name)
-        names = name.split("::".freeze)
-        names.reject!(&:empty?)
-        names.reduce(Object) { |scope, const| scope.const_get(const) }
+        Object.const_get(name)
       end
     end
 


### PR DESCRIPTION
Reduce String allocations by *freezing* `"::"` and Array allocations by using `Array#reject!`