### PR TITLE
Scroll to the section of the page

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,7 @@
   <nav class="sidebar__nav">
     <div class="sidebar__nav-interior">
       {%- for section in sections -%}
-        <h3 class="section__header">{{ section | capitalize }}</h3>
+        <h3 class="section__header" id="{{ section }}">{{ section | capitalize }}</h3>
 
         <ul class="section__links">
         {%- for item in site[section] -%}
@@ -23,5 +23,11 @@
         </ul>
       {%- endfor -%}
     </div>
+
+    {%- if sections contains page.collection -%}
+    <script type="text/javascript">
+        document.getElementById("{{ page.collection }}").scrollIntoView();
+    </script>
+    {%- endif -%}
   </nav>
 </div>


### PR DESCRIPTION
Especially when browsing for filters, you always need to scroll the navbar to get to the filters section to click on a new one which is annoying, so I've added an `id` to the title of each section and a script to scroll to the `id` of the selected section.  
 
Another possibility would be to give an `id` to each item based on the section's name and the item's name and scroll to the selected item, but then the section's name would not necessarily be in focus.  

I've put the script in the HTML to have access to liquid variables, but maybe you want to do a different way.  

I've marked this as a draft request because this is based on the pull request #1123. It doesn't need it but the implementation would be different if #1123 wasn't accepted. Instead of using `page.collection`, we could use `page.type`. Once #1123 is closed, I'll pick the right implementation and mark it as a normal pull request.