### PR TITLE
New Liquid format method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swp
 pkg
 *.rbc
+.idea
 .rvmrc
 .ruby-version
 Gemfile.lock

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -70,6 +70,21 @@ module Liquid
       render_to_output_buffer(context, '')
     end
 
+    def format(output)
+      idx = 0
+      while node = @nodelist[idx]
+        output << case node
+        when String
+          node
+        else
+          node.format
+        end
+        idx += 1
+      end
+
+      output
+    end
+
     def render_to_output_buffer(context, output)
       context.resource_limits.render_score += @nodelist.length
 

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -45,5 +45,16 @@ module Liquid
         end
       end
     end
+
+    def self.format(expression)
+      case expression
+      when String
+        "'#{expression}'"
+      when VariableLookup
+        expression.format
+      else
+        expression.to_s
+      end
+    end
   end
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -134,6 +134,11 @@ module Liquid
       self
     end
 
+    def format
+      return ''.freeze if @root.nil?
+      @root.format('')
+    end
+
     def registers
       @registers ||= {}
     end

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -35,6 +35,44 @@ module Liquid
       @markup
     end
 
+    def format
+      output = Expression.format(name)
+
+      filters.each_index do |i|
+        first_filter = true
+        output << " | #{filters[i][0]}"
+        first_sub_filter = true
+        filters[i][1].each do |j|
+          if first_filter
+            output << ':'
+            first_filter = false
+          end
+          unless first_sub_filter
+            output << ','
+          end
+          output << " "
+          output << Expression.format(j)
+          first_sub_filter = false
+        end
+        filters[i][2].each do |j, k|
+          if first_filter
+            output << ':'
+            first_filter = false
+          end
+          unless first_sub_filter
+            output << ','
+          end
+          output << " "
+          output << j
+          output << ": "
+          output << Expression.format(k)
+          first_sub_filter = false
+        end
+
+      end
+      "{{ #{output} }}"
+    end
+
     def markup_context(markup)
       "in \"{{#{markup}}}\""
     end

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -31,6 +31,21 @@ module Liquid
       end
     end
 
+    def format
+      output = name.to_s
+      @lookups.each_index do |i|
+        output << case lookups[i]
+                 when String
+                   ".#{lookups[i]}"
+                 when VariableLookup
+                   "[#{lookups[i].format}]"
+                 else
+                   ".#{lookups[i]}"
+                 end
+      end
+      output
+    end
+
     def evaluate(context)
       name = context.evaluate(@name)
       object = context.find_variable(name)

--- a/test/integration/format_test.rb
+++ b/test/integration/format_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class FormatTest < Minitest::Test
+  include Liquid
+
+  def test_string_only
+    assert_template_format('foo', 'foo')
+    assert_template_format('foo bar', 'foo bar')
+  end
+
+  def test_variable_only
+    assert_template_format('{{ foo }}', '{{foo}}')
+    assert_template_format('{{ foo.bar }}', '{{foo.bar}}')
+    assert_template_format('{{ foo.hello }}', '{{ foo["hello"] }}')
+    assert_template_format('{{ foo[hello] }}', '{{ foo[hello] }}')
+    assert_template_format('{{ foo.bar.world }}', '{{ foo["bar"].world }}')
+    assert_template_format('{{ foo }}{{ bar }}', '{{foo}}{{bar}}')
+    assert_template_format(%({{ input | substitute: first_name: surname, last_name: 'doe' }}), %({{ input | substitute: first_name: surname, last_name: 'doe' }}))
+    assert_template_format(%({{ input | substitute: hello, 'two', first_name: surname, last_name: 'doe' }}), %({{ input | substitute: hello, 'two', first_name: surname, last_name: 'doe' }}))
+    assert_template_format(%({{ input | substitute: hello, 'two', first_name: surname, last_name: 'doe' | substitute: hello, 'two', first_name: surname, last_name: 'doe' }}), %({{ input | substitute: hello, 'two', first_name: surname, last_name: 'doe' | substitute: hello, 'two', first_name: surname, last_name: 'doe' }}))
+  end
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,10 @@ module Minitest
       assert_equal expected, Template.parse(template).render!(assigns), message
     end
 
+    def assert_template_format(expected, template, message = nil)
+      assert_equal expected, Template.parse(template).format, message
+    end
+
     def assert_template_result_matches(expected, template, assigns = {}, message = nil)
       return assert_template_result(expected, template, assigns, message) unless expected.is_a? Regexp
 


### PR DESCRIPTION
# Liquid Format

`Liquid::Template.parse(template).format`

This is a work in progress but I wanted to keep visibility and start discussions around it. I'm going to spend some of my spare time on this as I believe its a strong way to move Liquid forward. There is still a fair bit to do but shouldn't take more than a couple of weeks given that I'm not spending much time on this.

## Why is this needed

1. **Removal of the :lax and :warn parsers** -  I would like to think a v5 or v6 of Liquid will deprecate both these parsing modes. The main idea behind the format command is it provides a way to parse with the :lax or :warn parsers and then output as :strict compatible syntax. So a possible way to move from v4 to v5 is simply running the format command across previous templates. An online conversion tool could also be provided for end users by liquid platforms so they convert templates outside of the system.

2. **Provides an upgrade path** - There have been requests over time for specific features that make sense in Liquid however they are impossible to implement without impacting previous templates. A simple example of this is brackets within an if statement, people currently have these in their template but they currently don't do anything, introduction of this will likely change the rendering output and the `format` tool can be a way to provide the upgrade tools to make breaking changes.

3. **Provides systems with consistent formatting** - One of the best features of Go is the inbuilt `go fmt` command. For me this shows a great example that by having an in-built format command systems can then leverage it to provide a better experience. For example a theme editor can run the format command on save and make the whitespace around tags and filters uniform so that future developers have a consistent experience.

4. **Provides a way to debug** - By running code through the format command, you actually get a chance to see how Liquid is processing your template. Its rather common to realise that for some reason Liquid is actually just ignoring most of your code.

## What's left to do

**White Space**
- [ ] Retain whitespace in an IgnoredWhitespace token so format can recover.
- [ ] Determine if a tag has white space controls

**Expressions**
- [ ] Detect when a string should be a single quote or double quote
- [ ] Handle integers
- [ ] Handle ranges 
- [ ] Handle floats
- [ ] Handle literals

**Tags**
- [ ] Assign
- [ ] Break
- [ ] Capture
- [ ] Case
- [ ] Comment
- [ ] Continue
- [ ] Cycle
- [ ] Decrement
- [ ] For
- [ ] If
- [ ] Ifchanged
- [ ] Include
- [ ] Increment
- [ ] Raw
- [ ] Table_row
- [ ] Unless

## Discussion topics

1. I decided to put these in the core of the system, I feel like this method can be forgotten if it was just a side project and its compatibility was lost. Also by putting the methods directly on tags it makes it easy to add this support to existing tags. However I would like to know if anyone thinks there is a better approach

2. The whitespace control I'm going to modify to output a tag that has an empty render method like comments but stores what that whitespace originally looked like. Any feedback or comments on this will be helpful?

@pushrax @ashmaroli @fw42 @samdoiron @dylanahsmith @Thibaut @tobi 