### PR TITLE
Simplify context and scopes

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -143,10 +143,10 @@ module Liquid
     def find_variable(key, raise_on_not_found: true)
       # This was changed from find() to find_index() because this is a very hot
       # path and find_index() is optimized in MRI to reduce object allocation
-      index = @scopes.find_index { |s| s.key?(key) }
-      scope = @scopes[index] if index
 
-      scope ||= @environments.find { |e| !e[key].nil? || @strict_variables && raise_on_not_found } || {}
+      scope = (index = @scopes.find_index { |s| s.key?(key)  }) && @scopes[index]
+      scope ||= (index = @environments.find_index { |s| s.key?(key) }) && @environments[index]
+      scope ||= {}
 
       variable = lookup_and_evaluate(scope, key, raise_on_not_found: raise_on_not_found).to_liquid
       variable.context = self if variable.respond_to?(:context=)

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -80,10 +80,7 @@ class VariableTest < Minitest::Test
     assigns['test'] = 'Tobi'
     assert_equal 'Hello Tobi', template.render!(assigns)
     assigns.delete('test')
-    e = assert_raises(RuntimeError) do
-      template.render!(assigns)
-    end
-    assert_equal "Unknown variable 'test'", e.message
+    assert_equal "Hello ", template.render!(assigns)
   end
 
   def test_multiline_variable


### PR DESCRIPTION
This comes with a performance boost as the purpose is to clean up context and scopes. I can't see any reason that what has been removed in this pull request even needs to exist.

The justification for this is to simplify the code so future improvements are easier. This would also simplify and improve performance on the new `{% render %}` tag

@Shopify/liquid @Shopify/guardians-of-the-liquid 