### PR TITLE
Build only pushes to certain branches on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 rvm:
   - 2.4
@@ -8,7 +9,6 @@ rvm:
   - ruby-head
   - jruby-head
   - truffleruby
-
 
 matrix:
   include:
@@ -20,9 +20,11 @@ matrix:
     - rvm: jruby-head
     - rvm: truffleruby
 
-cache: bundler
-
-script: bundle exec rake
+branches:
+  only:
+    - master
+    - gh-pages
+    - /.*-stable/
 
 notifications:
   disable: true


### PR DESCRIPTION
The crux of this PR is the following insertion:
```yaml
branches:
  only:
    - master
    - gh-pages
    - /.*-stable/
```
This is to prevent triggering builds for every branch push to `Shopify/liquid` repo and only trigger builds for direct-pushes and PRs to `master`, `gh-pages` and the various *stable* branches.

The other changes are misc. cleanups to the config file.