### PR TITLE
Remove lazy load stacks

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -109,26 +109,11 @@ module Liquid
     #   end
     #
     #   context['var]  #=> nil
-    #
-    # false or {} can be used to control if a new scope is needed
-    #
-    # Example:
-    #   new_scope = false
-    #   context.stack(new_scope) do
-    #      # no scope created
-    #   end
-    #
-    # Example:
-    #   new_scope = {}
-    #   context.stack(new_scope) do
-    #      # scope created
-    #   end
-    #
     def stack(new_scope = {})
-      push(new_scope) unless new_scope == false
+      push(new_scope)
       yield
     ensure
-      pop unless new_scope == false
+      pop
     end
 
     def clear_instance_assigns

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -39,16 +39,14 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      context.stack do
-        execute_else_block = true
+      execute_else_block = true
 
-        @blocks.each do |block|
-          if block.else?
-            block.attachment.render_to_output_buffer(context, output) if execute_else_block
-          elsif block.evaluate(context)
-            execute_else_block = false
-            block.attachment.render_to_output_buffer(context, output)
-          end
+      @blocks.each do |block|
+        if block.else?
+          block.attachment.render_to_output_buffer(context, output) if execute_else_block
+        elsif block.evaluate(context)
+          execute_else_block = false
+          block.attachment.render_to_output_buffer(context, output)
         end
       end
 

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -34,24 +34,22 @@ module Liquid
     def render_to_output_buffer(context, output)
       context.registers[:cycle] ||= {}
 
-      context.stack do
-        key = context.evaluate(@name)
-        iteration = context.registers[:cycle][key].to_i
+      key = context.evaluate(@name)
+      iteration = context.registers[:cycle][key].to_i
 
-        val = context.evaluate(@variables[iteration])
+      val = context.evaluate(@variables[iteration])
 
-        if val.is_a?(Array)
-          val = val.join
-        elsif !val.is_a?(String)
-          val = val.to_s
-        end
-
-        output << val
-
-        iteration += 1
-        iteration  = 0 if iteration >= @variables.size
-        context.registers[:cycle][key] = iteration
+      if val.is_a?(Array)
+        val = val.join
+      elsif !val.is_a?(String)
+        val = val.to_s
       end
+
+      output << val
+
+      iteration += 1
+      iteration  = 0 if iteration >= @variables.size
+      context.registers[:cycle][key] = iteration
 
       output
     end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -40,11 +40,9 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      context.stack do
-        @blocks.each do |block|
-          if block.evaluate(context)
-            return block.attachment.render_to_output_buffer(context, output)
-          end
+      @blocks.each do |block|
+        if block.evaluate(context)
+          return block.attachment.render_to_output_buffer(context, output)
         end
       end
 

--- a/lib/liquid/tags/ifchanged.rb
+++ b/lib/liquid/tags/ifchanged.rb
@@ -1,14 +1,12 @@
 module Liquid
   class Ifchanged < Block
     def render_to_output_buffer(context, output)
-      context.stack do
-        block_output = ''
-        super(context, block_output)
+      block_output = ''
+      super(context, block_output)
 
-        if block_output != context.registers[:ifchanged]
-          context.registers[:ifchanged] = block_output
-          output << block_output
-        end
+      if block_output != context.registers[:ifchanged]
+        context.registers[:ifchanged] = block_output
+        output << block_output
       end
 
       output

--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -7,18 +7,16 @@ module Liquid
   #
   class Unless < If
     def render_to_output_buffer(context, output)
-      context.stack do
-        # First condition is interpreted backwards ( if not )
-        first_block = @blocks.first
-        unless first_block.evaluate(context)
-          return first_block.attachment.render_to_output_buffer(context, output)
-        end
+      # First condition is interpreted backwards ( if not )
+      first_block = @blocks.first
+      unless first_block.evaluate(context)
+        return first_block.attachment.render_to_output_buffer(context, output)
+      end
 
-        # After the first condition unless works just like if
-        @blocks[1..-1].each do |block|
-          if block.evaluate(context)
-            return block.attachment.render_to_output_buffer(context, output)
-          end
+      # After the first condition unless works just like if
+      @blocks[1..-1].each do |block|
+        if block.evaluate(context)
+          return block.attachment.render_to_output_buffer(context, output)
         end
       end
 


### PR DESCRIPTION
Remove lazy load stacks and instead only create a new scope when a tag is known to need one. 

Tags already know if they need a new stack so instead of needing the additional overhead of calculating if a scope is needed this gives control to the tag to either create a new scope or not. 

~~This also allows a tag to use `context.stack(false) do` so the context.stack method can still be used when a tag may or may not need a new scope~~