### PR TITLE
Remove support for fallback proc on last scope

### DIFF
--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -80,10 +80,7 @@ class VariableTest < Minitest::Test
     assigns['test'] = 'Tobi'
     assert_equal 'Hello Tobi', template.render!(assigns)
     assigns.delete('test')
-    e = assert_raises(RuntimeError) do
-      template.render!(assigns)
-    end
-    assert_equal "Unknown variable 'test'", e.message
+    assert_equal "Hello ", template.render!(assigns)
   end
 
   def test_multiline_variable


### PR DESCRIPTION
This was introduced but never actually used. The introduction of environments.last as the fallback for unfound variables means this functionality is already broken.

See full discussion and history of this https://github.com/Shopify/liquid/pull/1132