### PR TITLE
The code is not wrapped when reading a document from a smartphone.

### DIFF
--- a/_sass/modules/_base.scss
+++ b/_sass/modules/_base.scss
@@ -123,6 +123,7 @@ pre {
   padding: 8px 12px;
   border: 1px solid $color-blue-2;
   word-wrap: break-word;
+  white-space: pre-wrap;
 
   > code {
     border: 0;


### PR DESCRIPTION
hello.

The code is not wrapped when reading a document from a smartphone.

## before
<img width="373" alt="before" src="https://user-images.githubusercontent.com/15780027/63940028-97657700-caa3-11e9-9661-861a31a19fba.png">

## after
<img width="373" alt="after" src="https://user-images.githubusercontent.com/15780027/63940068-b237eb80-caa3-11e9-9887-fef6d37e2f33.png">
