### PR TITLE
Invokable methods for enumerable reject include?

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -67,7 +67,7 @@ module Liquid
 
         if include?(Enumerable)
           blacklist += Enumerable.public_instance_methods
-          blacklist -= [:sort, :count, :first, :min, :max, :include?]
+          blacklist -= [:sort, :count, :first, :min, :max]
         end
 
         whitelist = [:to_liquid] + (public_instance_methods - blacklist)

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -270,4 +270,11 @@ class DropsTest < Minitest::Test
     assert_equal 'ProductDrop', Liquid::Template.parse("{{ product }}").render!('product' => ProductDrop.new)
     assert_equal 'EnumerableDrop', Liquid::Template.parse('{{ collection }}').render!('collection' => EnumerableDrop.new)
   end
+
+  def test_invokable_methods
+    assert_equal %w(to_liquid catchall user_input context texts).to_set, ProductDrop.invokable_methods
+    assert_equal %w(to_liquid scopes_as_array loop_pos scopes).to_set, ContextDrop.invokable_methods
+    assert_equal %w(to_liquid size max min first count).to_set, EnumerableDrop.invokable_methods
+    assert_equal %w(to_liquid max min sort count first).to_set, RealEnumerableDrop.invokable_methods
+  end
 end # DropsTest


### PR DESCRIPTION
`include?` is a method with an arity of 1 and therefor it will never be possible to invoke it from liquid through `{{ ... }}` without generating an `ArgumentError`.

Originally added here: https://github.com/Shopify/liquid/commit/f98949117df9bea291a37794aabba20f23e22fa5

The test is still present, I presume other pieces of code changed over time to make this not an issue anymore.

`contains` is being used here:
https://github.com/Shopify/liquid/blob/806b2622da6acdfd236478a2e90bedf999868f8d/lib/liquid/condition.rb#L18-L24

While we are removing it from `invokable_methods`, the ruby object still answer to `respond_to?(:include?)` 