### PR TITLE
Prevent needing to squash instance assigns

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -33,7 +33,6 @@ module Liquid
       @strict_variables    = false
       @resource_limits     = resource_limits || ResourceLimits.new(Template.default_resource_limits)
       @base_scope_depth    = 0
-      squash_instance_assigns_with_environments
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
@@ -245,16 +244,5 @@ module Liquid
     rescue Liquid::InternalError => exc
       exc
     end
-
-    def squash_instance_assigns_with_environments
-      @scopes.last.each_key do |k|
-        @environments.each do |env|
-          if env.key?(k)
-            scopes.last[k] = lookup_and_evaluate(env, k)
-            break
-          end
-        end
-      end
-    end # squash_instance_assigns_with_environments
   end # Context
 end # Liquid

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -146,6 +146,10 @@ module Liquid
       @instance_assigns ||= {}
     end
 
+    def new_outer_scope
+      @instance_assigns = {}
+    end
+
     def errors
       @errors ||= []
     end
@@ -178,11 +182,11 @@ module Liquid
         c
       when Liquid::Drop
         drop = args.shift
-        drop.context = Context.new([drop, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits)
+        drop.context = Context.new([drop, assigns, instance_assigns], new_outer_scope, registers, @rethrow_errors, @resource_limits)
       when Hash
-        Context.new([args.shift, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits)
+        Context.new([args.shift, assigns, instance_assigns], new_outer_scope, registers, @rethrow_errors, @resource_limits)
       when nil
-        Context.new(assigns, instance_assigns, registers, @rethrow_errors, @resource_limits)
+        Context.new([assigns, instance_assigns], new_outer_scope, registers, @rethrow_errors, @resource_limits)
       else
         raise ArgumentError, "Expected Hash or Liquid::Context as parameter"
       end


### PR DESCRIPTION
Instead of needing to squash instance assigns, we instead just put them at the bottom of the environment stack.

This simplifies the code base and gains extra performance by not needing to loop over scopes and environments.

@Shopify/guardians-of-the-liquid 