### PR TITLE
Cleanup RuboCop configuration file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - https://shopify.github.io/ruby-style-guide/rubocop.yml
+  - 'https://shopify.github.io/ruby-style-guide/rubocop.yml'
   - .rubocop_todo.yml
 
 require: rubocop-performance
@@ -10,7 +10,7 @@ Performance:
 AllCops:
   Exclude:
     - 'vendor/bundle/**/*'
-      
+
 Naming/MethodName:
   Exclude:
     - 'example/server/liquid_servlet.rb'


### PR DESCRIPTION
@shopmike The lack of quotes on ln#2 threw the syntax-highlighting in my text-editor into a mess.
The remaining changes are just miscellaneous whitespace fixes.