### PR TITLE
Initialize MethoLiteral with unfrozen strings

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -19,8 +19,8 @@ module Liquid
       nil => nil, 'nil' => nil, 'null' => nil, '' => nil,
       'true' => true,
       'false' => false,
-      'blank' => MethodLiteral.new(:blank?, '').freeze,
-      'empty' => MethodLiteral.new(:empty?, '').freeze
+      'blank' => MethodLiteral.new(:blank?, +'').freeze,
+      'empty' => MethodLiteral.new(:empty?, +'').freeze
     }.freeze
 
     SINGLE_QUOTED_STRING = /\A'(.*)'\z/m


### PR DESCRIPTION
To ensure backwards compatibility with state prior to https://github.com/Shopify/liquid/commit/0d26f05bb83a72e9b737ebbd81008e5631c4e85f

/cc @shopmike, @dylanahsmith, @pushrax 