### PR TITLE
Add total time and self time for profiling

### DIFF
--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -46,7 +46,7 @@ module Liquid
     include Enumerable
 
     class Timing
-      attr_reader :code, :partial, :line_number, :children
+      attr_reader :code, :partial, :line_number, :children, :total_time, :self_time
 
       def initialize(node, partial)
         @code        = node.respond_to?(:raw) ? node.raw : node
@@ -65,6 +65,17 @@ module Liquid
 
       def finish
         @end_time = Time.now
+        @total_time = @end_time - @start_time
+
+        if @children.size == 0
+          @self_time = @total_time
+        else
+          total_children_time = 0
+          @children.each do |child|
+            total_children_time += child.total_time
+          end
+          @self_time = @total_time - total_children_time
+        end
       end
 
       def render_time


### PR DESCRIPTION
Currently profiling data only gives timing information by displaying `end_time` and `start_time`
which is not very readable. To make sense from those times this PR adds the `total_time` and the `self_time` of each node. This information is very useful for the lighthouse plugin in development.

What these new attributes represent?
1. `self_time` = how much time was spent doing work directly in that function
2. `total-time` = how much time was spent in that function, and in the functions it called
