### PR TITLE
Remove JRuby and TruffleRuby from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ rvm:
   - &latest_ruby 2.6
   - 2.7
   - ruby-head
-  - jruby-head
-  - truffleruby
 
 matrix:
   include:
@@ -17,8 +15,6 @@ matrix:
       name: Profiling Memory Usage
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: truffleruby
 
 branches:
   only:


### PR DESCRIPTION
These are always failing due to liquid-c. They can be revisited in the future but for now, they add an additional 8-12 minutes to the CI when all other runtimes only take < 1 min.