### PR TITLE
Align equals operator in `lib/liquid/legacy.rb`

### DIFF
--- a/lib/liquid/legacy.rb
+++ b/lib/liquid/legacy.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
 module Liquid
-  FilterSeparator = FILTER_SEPARATOR
-  ArgumentSeparator = ARGUMENT_SEPARATOR
-  FilterArgumentSeparator = FILTER_ARGUMENT_SEPARATOR
+  FilterSeparator            = FILTER_SEPARATOR
+  ArgumentSeparator          = ARGUMENT_SEPARATOR
+  FilterArgumentSeparator    = FILTER_ARGUMENT_SEPARATOR
   VariableAttributeSeparator = VARIABLE_ATTRIBUTE_SEPARATOR
-  WhitespaceControl = WHITESPACE_CONTROL
-  TagStart = TAG_START
-  TagEnd = TAG_END
-  VariableSignature = VARIABLE_SIGNATURE
-  VariableSegment = VARIABLE_SEGMENT
-  VariableStart = VARIABLE_START
-  VariableEnd = VARIABLE_END
-  VariableIncompleteEnd = VARIABLE_INCOMPLETE_END
-  QuotedString = QUOTED_STRING
-  QuotedFragment = QUOTED_FRAGMENT
-  TagAttributes = TAG_ATTRIBUTES
-  AnyStartingTag = ANY_STARTING_TAG
-  PartialTemplateParser = PARTIAL_TEMPLATE_PARSER
-  TemplateParser = TEMPLATE_PARSER
-  VariableParser = VARIABLE_PARSER
+  WhitespaceControl          = WHITESPACE_CONTROL
+  TagStart                   = TAG_START
+  TagEnd                     = TAG_END
+  VariableSignature          = VARIABLE_SIGNATURE
+  VariableSegment            = VARIABLE_SEGMENT
+  VariableStart              = VARIABLE_START
+  VariableEnd                = VARIABLE_END
+  VariableIncompleteEnd      = VARIABLE_INCOMPLETE_END
+  QuotedString               = QUOTED_STRING
+  QuotedFragment             = QUOTED_FRAGMENT
+  TagAttributes              = TAG_ATTRIBUTES
+  AnyStartingTag             = ANY_STARTING_TAG
+  PartialTemplateParser      = PARTIAL_TEMPLATE_PARSER
+  TemplateParser             = TEMPLATE_PARSER
+  VariableParser             = VARIABLE_PARSER
 
   class BlockBody
-    FullToken = FULL_TOKEN
-    ContentOfVariable = CONTENT_OF_VARIABLE
+    FullToken           = FULL_TOKEN
+    ContentOfVariable   = CONTENT_OF_VARIABLE
     WhitespaceOrNothing = WHITESPACE_OR_NOTHING
-    TAGSTART = TAG_START_STRING
-    VARSTART = VAR_START_STRING
+    TAGSTART            = TAG_START_STRING
+    VARSTART            = VAR_START_STRING
   end
 
   class Assign < Tag
@@ -52,7 +52,7 @@ module Liquid
   end
 
   class If < Block
-    Syntax = SYNTAX
+    Syntax                  = SYNTAX
     ExpressionsAndOperators = EXPRESSIONS_AND_OPERATORS
   end
 
@@ -61,7 +61,7 @@ module Liquid
   end
 
   class Raw < Block
-    Syntax = SYNTAX
+    Syntax                   = SYNTAX
     FullTokenPossiblyInvalid = FULL_TOKEN_POSSIBLY_INVALID
   end
 
@@ -70,10 +70,10 @@ module Liquid
   end
 
   class Variable
-    FilterMarkupRegex = FILTER_MARKUP_REGEX
-    FilterParser = FILTER_PARSER
-    FilterArgsRegex = FILTER_ARGS_REGEX
-    JustTagAttributes = JUST_TAG_ATTRIBUTES
+    FilterMarkupRegex        = FILTER_MARKUP_REGEX
+    FilterParser             = FILTER_PARSER
+    FilterArgsRegex          = FILTER_ARGS_REGEX
+    JustTagAttributes        = JUST_TAG_ATTRIBUTES
     MarkupWithQuotedFragment = MARKUP_WITH_QUOTED_FRAGMENT
   end
 end


### PR DESCRIPTION
@shopmike This PR is against the `fix-constants` branch for your PR.
I'm proposing this change to affect just the Legacy container without touching other code files and involving RuboCop into the mix.

P.S. I'm aware of your intention to enforce this change to the entire codebase. Doing this beforehand will reduce the diff later on and reduce churn to the `legacy.rb`