### PR TITLE
Add liquid profile attributes

### DIFF
--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -46,7 +46,7 @@ module Liquid
     include Enumerable
 
     class Timing
-      attr_reader :code, :partial, :line_number, :children
+      attr_reader :code, :partial, :line_number, :children, :total_time, :self_time
 
       def initialize(node, partial)
         @code        = node.respond_to?(:raw) ? node.raw : node
@@ -65,6 +65,17 @@ module Liquid
 
       def finish
         @end_time = Time.now
+        @total_time = @end_time - @start_time
+
+        if @children.empty?
+          @self_time = @total_time
+        else
+          total_children_time = 0
+          @children.each do |child|
+            total_children_time += child.total_time
+          end
+          @self_time = @total_time - total_children_time
+        end
       end
 
       def render_time
@@ -98,8 +109,8 @@ module Liquid
       Thread.current[:liquid_profiler]
     end
 
-    def initialize
-      @partial_stack = ["<root>"]
+    def initialize(partial_name = "<root>")
+      @partial_stack = [partial_name]
 
       @root_timing = Timing.new("", current_partial)
       @timing_stack = [@root_timing]

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -254,7 +254,7 @@ module Liquid
       if @profiling && !context.partial
         raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
 
-        @profiler = Profiler.new
+        @profiler = Profiler.new(context.template_name)
         @profiler.start
 
         begin

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -153,4 +153,19 @@ class RenderProfilingTest < Minitest::Test
     # Will profile each invocation of the for block
     assert_equal 2, t.profiler[0].children.length
   end
+
+  def test_total_time_equals_self_time_in_leaf
+    t = Template.parse("{% for item in collection %} {{ item }} {% endfor %}", profile: true)
+    t.render!("collection" => ["one", "two"])
+    leaf = t.profiler[0].children[0]
+
+    assert_equal leaf.total_time, leaf.self_time
+  end
+
+  def test_total_time_greater_than_self_time_in_node
+    t = Template.parse("{% if true %} {% increment test %} {{ test }} {% endif %}", profile: true)
+    t.render!
+
+    assert_operator t.profiler[0].total_time, :>, t.profiler[0].self_time
+  end
 end


### PR DESCRIPTION
## Why is this change needed?
Currently profiling data only gives timing information by displaying `end_time` and `start_time`
which is not very readable. These numbers are not useful to understand performance without doing some further computation on them.

## What is the change?
To make better sense out of profiling data and to make it more readable the `self_time` and `total_time` attributes are being added to the profile. Currently each node has a `total_time` which accounts for the time taken for all it's children and itself. `self_time` gives more visibility and another metric to understand liquid performance. It will be helpful to pin point a performance problem such as sorting the nodes by highest self time etc. 

### What these new attributes represent?
`self_time` = how much time was spent doing work directly in that node.
`total-time` = how much time was spent in that node, and all it's children nodes.