### PR TITLE
Tracking environment usage to confirm logic is needed

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -219,12 +219,16 @@ module Liquid
     def try_variable_find_in_environments(key, raise_on_not_found:)
       @environments.each do |environment|
         found_variable = lookup_and_evaluate(environment, key, raise_on_not_found: raise_on_not_found)
+        Usage.increment("environment_has_a_default_proc") if environment.default_proc
+        Usage.increment("environment_has_key_but_is_nil") if environment.key?(key) && found_variable == nil
         if !found_variable.nil? || @strict_variables && raise_on_not_found
           return found_variable
         end
       end
       @static_environments.each do |environment|
         found_variable = lookup_and_evaluate(environment, key, raise_on_not_found: raise_on_not_found)
+        Usage.increment("static_environment_has_a_default_proc") if environment.default_proc
+        Usage.increment("static_environment_has_key_but_is_nil") if environment.key?(key) && found_variable == nil
         if !found_variable.nil? || @strict_variables && raise_on_not_found
           return found_variable
         end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -219,16 +219,16 @@ module Liquid
     def try_variable_find_in_environments(key, raise_on_not_found:)
       @environments.each do |environment|
         found_variable = lookup_and_evaluate(environment, key, raise_on_not_found: raise_on_not_found)
-        Usage.increment("environment_has_a_default_proc") if environment.default_proc
-        Usage.increment("environment_has_key_but_is_nil") if environment.key?(key) && found_variable == nil
+        Usage.increment("environment_has_a_default_proc") if environment.respond_to?(:default_proc) && environment.default_proc
+        Usage.increment("environment_has_key_but_is_nil") if environment.respond_to?(:key?) && environment.key?(key) && found_variable.nil?
         if !found_variable.nil? || @strict_variables && raise_on_not_found
           return found_variable
         end
       end
       @static_environments.each do |environment|
         found_variable = lookup_and_evaluate(environment, key, raise_on_not_found: raise_on_not_found)
-        Usage.increment("static_environment_has_a_default_proc") if environment.default_proc
-        Usage.increment("static_environment_has_key_but_is_nil") if environment.key?(key) && found_variable == nil
+        Usage.increment("static_environment_has_a_default_proc") if environment.respond_to?(:default_proc) && environment.default_proc
+        Usage.increment("static_environment_has_key_but_is_nil") if environment.respond_to?(:key?) && environment.key?(key) && found_variable.nil?
         if !found_variable.nil? || @strict_variables && raise_on_not_found
           return found_variable
         end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -423,7 +423,6 @@ module Liquid
 
     def default(input, default_value = '')
       if !input || input.respond_to?(:empty?) && input.empty?
-        Usage.increment("default_filter_received_false_value") if input == false # See https://github.com/Shopify/liquid/issues/1127
         default_value
       else
         input


### PR DESCRIPTION
Confirming if this logic is needed as it seems to have been introduced incrementally and has seemed to evolve over time unnecessarily. However it may now be required behaviour.

If these report no usage these can be simplified to 
```
@environments.find { |s| s.key?(key) }
```

@samdoiron @pushrax @dylanahsmith @fw42 can someone review this. Also, a priority to turn the other test off as it is pushing very high metrics.