### PR TITLE
[DO NOT MERGE] Introduce a liquid template factory + the ability to restrict paths in the include tag

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -80,6 +80,7 @@ require 'liquid/partial_cache'
 require 'liquid/usage'
 require 'liquid/register'
 require 'liquid/static_registers'
+require 'liquid/template_factory'
 
 # Load all the tags of the standard library
 #

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -11,7 +11,10 @@ module Liquid
       source = file_system.read_template_file(template_name)
       parse_context.partial = true
 
-      partial = Liquid::Template.parse(source, parse_context)
+      liquid_template_factory = (context.registers[:liquid_template_factory] ||= Liquid::TemplateFactory)
+      liquid_template = liquid_template_factory.for(template_name)
+
+      partial = liquid_template.parse(source, parse_context)
       cached_partials[template_name] = partial
     ensure
       parse_context.partial = false

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -44,14 +44,16 @@ module Liquid
       context_variable_name = @alias_name || template_name.split('/').last
 
       render_partial_func = ->(var) {
-        inner_context = context.new_isolated_subcontext
-        inner_context.template_name = template_name
-        inner_context.partial = true
-        @attributes.each do |key, value|
-          inner_context[key] = context.evaluate(value)
+        partial.with_context_restrictions(context) do
+          inner_context = context.new_isolated_subcontext
+          inner_context.template_name = template_name
+          inner_context.partial = true
+          @attributes.each do |key, value|
+            inner_context[key] = context.evaluate(value)
+          end
+          inner_context[context_variable_name] = var unless var.nil?
+          partial.render_to_output_buffer(inner_context, output)
         end
-        inner_context[context_variable_name] = var unless var.nil?
-        partial.render_to_output_buffer(inner_context, output)
       }
 
       variable = @variable_name_expr ? context.evaluate(@variable_name_expr) : nil

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -221,7 +221,6 @@ module Liquid
 
       # Retrying a render resets resource usage
       context.resource_limits.reset
-
       begin
         # render the nodelist.
         # for performance reasons we get an array back here. join will make a string out of it.
@@ -242,6 +241,10 @@ module Liquid
 
     def render_to_output_buffer(context, output)
       render(context, output: output)
+    end
+
+    def with_context_restrictions(_context)
+      yield
     end
 
     private

--- a/lib/liquid/template_factory.rb
+++ b/lib/liquid/template_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Liquid
+  class TemplateFactory
+    def self.for(_template_name)
+      Liquid::Template
+    end
+  end
+end


### PR DESCRIPTION
This is only meant to be an exploration and will not be merged.

1. Create liquid templates for partials using a `TemplateFactory` that can be injected via the liquid context
2. Add the ability for `Liquid::Template` to restrict the liquid context
3. Add the ability to configure `Liquid::Include` to support specific paths