### PR TITLE
Shift all Tag parsing into parse method

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -7,6 +7,7 @@ module Liquid
     def initialize(tag_name, markup, options)
       super
       @blank = true
+      @body = nil
     end
 
     def parse(tokens)
@@ -17,7 +18,7 @@ module Liquid
 
     # For backwards compatibility
     def render(context)
-      @body.render(context)
+      @body&.render(context)
     end
 
     def blank?

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -17,8 +17,6 @@ module Liquid
         disabled_tags.push(*tags)
       end
 
-      private :new
-
       def disabled_tags
         @disabled_tags ||= []
       end

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   class Tag
-    attr_reader :nodelist, :tag_name, :line_number, :parse_context
+    attr_reader :nodelist, :tag_name, :line_number, :parse_context, :markup
     alias_method :options, :parse_context
     include ParserSwitching
 

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -19,11 +19,11 @@ module Liquid
     attr_reader :to, :from
 
     def parse(_tokens)
-      if @markup =~ Syntax
+      if markup =~ Syntax
         @to = Regexp.last_match(1)
-        @from = Variable.new(Regexp.last_match(2), @parse_context)
+        @from = Variable.new(Regexp.last_match(2), options)
       else
-        raise SyntaxError, @parse_context[:locale].t(self.class.syntax_error_translation_key)
+        raise SyntaxError, options[:locale].t(self.class.syntax_error_translation_key)
       end
     end
 

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -18,13 +18,12 @@ module Liquid
 
     attr_reader :to, :from
 
-    def initialize(tag_name, markup, options)
-      super
-      if markup =~ Syntax
+    def parse(_tokens)
+      if @markup =~ Syntax
         @to = Regexp.last_match(1)
-        @from = Variable.new(Regexp.last_match(2), options)
+        @from = Variable.new(Regexp.last_match(2), @parse_context)
       else
-        raise SyntaxError, options[:locale].t(self.class.syntax_error_translation_key)
+        raise SyntaxError, @parse_context[:locale].t(self.class.syntax_error_translation_key)
       end
     end
 

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -15,13 +15,13 @@ module Liquid
   class Capture < Block
     Syntax = /(#{VariableSignature}+)/o
 
-    def initialize(tag_name, markup, options)
-      super
-      if markup =~ Syntax
+    def parse(_tokens)
+      if @markup =~ Syntax
         @to = Regexp.last_match(1)
       else
-        raise SyntaxError, options[:locale].t("errors.syntax.capture")
+        raise SyntaxError, @parse_context[:locale].t("errors.syntax.capture")
       end
+      super
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -16,10 +16,10 @@ module Liquid
     Syntax = /(#{VariableSignature}+)/o
 
     def parse(_tokens)
-      if @markup =~ Syntax
+      if markup =~ Syntax
         @to = Regexp.last_match(1)
       else
-        raise SyntaxError, @parse_context[:locale].t("errors.syntax.capture")
+        raise SyntaxError, options[:locale].t("errors.syntax.capture")
       end
       super
     end

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -7,18 +7,15 @@ module Liquid
 
     attr_reader :blocks, :left
 
-    def initialize(tag_name, markup, options)
-      super
+    def parse(tokens)
       @blocks = []
 
-      if markup =~ Syntax
+      if @markup =~ Syntax
         @left = Expression.parse(Regexp.last_match(1))
       else
-        raise SyntaxError, options[:locale].t("errors.syntax.case")
+        raise SyntaxError, @parse_context[:locale].t("errors.syntax.case")
       end
-    end
 
-    def parse(tokens)
       body = BlockBody.new
       body = @blocks.last.attachment while parse_body(body, tokens)
     end

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -10,7 +10,7 @@ module Liquid
     def parse(tokens)
       @blocks = []
 
-      if options =~ Syntax
+      if markup =~ Syntax
         @left = Expression.parse(Regexp.last_match(1))
       else
         raise SyntaxError, options[:locale].t("errors.syntax.case")

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -10,10 +10,10 @@ module Liquid
     def parse(tokens)
       @blocks = []
 
-      if @markup =~ Syntax
+      if options =~ Syntax
         @left = Expression.parse(Regexp.last_match(1))
       else
-        raise SyntaxError, @parse_context[:locale].t("errors.syntax.case")
+        raise SyntaxError, options[:locale].t("errors.syntax.case")
       end
 
       body = BlockBody.new

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -19,17 +19,16 @@ module Liquid
 
     attr_reader :variables
 
-    def initialize(tag_name, markup, options)
-      super
-      case markup
+    def parse(_tokens)
+      case @markup
       when NamedSyntax
         @variables = variables_from_string(Regexp.last_match(2))
         @name = Expression.parse(Regexp.last_match(1))
       when SimpleSyntax
-        @variables = variables_from_string(markup)
+        @variables = variables_from_string(@markup)
         @name = @variables.to_s
       else
-        raise SyntaxError, options[:locale].t("errors.syntax.cycle")
+        raise SyntaxError, @parse_context[:locale].t("errors.syntax.cycle")
       end
     end
 

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -25,7 +25,7 @@ module Liquid
         @variables = variables_from_string(Regexp.last_match(2))
         @name = Expression.parse(Regexp.last_match(1))
       when SimpleSyntax
-        @variables = variables_from_string(@markup)
+        @variables = variables_from_string(markup)
         @name = @variables.to_s
       else
         raise SyntaxError, options[:locale].t("errors.syntax.cycle")

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -20,7 +20,7 @@ module Liquid
     attr_reader :variables
 
     def parse(_tokens)
-      case @markup
+      case markup
       when NamedSyntax
         @variables = variables_from_string(Regexp.last_match(2))
         @name = Expression.parse(Regexp.last_match(1))
@@ -28,7 +28,7 @@ module Liquid
         @variables = variables_from_string(@markup)
         @name = @variables.to_s
       else
-        raise SyntaxError, @parse_context[:locale].t("errors.syntax.cycle")
+        raise SyntaxError, options[:locale].t("errors.syntax.cycle")
       end
     end
 

--- a/lib/liquid/tags/decrement.rb
+++ b/lib/liquid/tags/decrement.rb
@@ -21,7 +21,7 @@ module Liquid
   #
   class Decrement < Tag
     def parse(_tokens)
-      @variable = @markup.strip
+      @variable = markup.strip
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/decrement.rb
+++ b/lib/liquid/tags/decrement.rb
@@ -20,9 +20,8 @@ module Liquid
   #    Hello: -3
   #
   class Decrement < Tag
-    def initialize(tag_name, markup, options)
-      super
-      @variable = markup.strip
+    def parse(_tokens)
+      @variable = @markup.strip
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -15,11 +15,11 @@ module Liquid
     attr_reader :variable
 
     def parse(_tokens)
-      @variable = Variable.new(markup, options)
+      @variable = Variable.new(markup, parse_context)
     end
 
     def render(context)
-      variable&.render_to_output_buffer(context, +'')
+      @variable.render_to_output_buffer(context, +'')
     end
   end
 

--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -15,7 +15,7 @@ module Liquid
     attr_reader :variable
 
     def parse(_tokens)
-      @variable = Variable.new(@markup, @parse_context)
+      @variable = Variable.new(markup, options)
     end
 
     def render(context)

--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -12,13 +12,14 @@ module Liquid
   #   {% echo user | link %}
   #
   class Echo < Tag
-    def initialize(tag_name, markup, parse_context)
-      super
-      @variable = Variable.new(markup, parse_context)
+    attr_reader :variable
+
+    def parse(_tokens)
+      @variable = Variable.new(@markup, @parse_context)
     end
 
     def render(context)
-      @variable.render_to_output_buffer(context, +'')
+      variable&.render_to_output_buffer(context, +'')
     end
   end
 

--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -19,7 +19,7 @@ module Liquid
     end
 
     def render(context)
-      @variable.render_to_output_buffer(context, +'')
+      variable&.render_to_output_buffer(context, +'')
     end
   end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -52,9 +52,9 @@ module Liquid
 
     def parse(tokens)
       @from = @limit = nil
+      parse_with_selected_parser(markup)
       @for_block = BlockBody.new
       @else_block = nil
-      parse_with_selected_parser(markup)
       return unless parse_body(@for_block, tokens)
       parse_body(@else_block, tokens)
     end

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -54,7 +54,7 @@ module Liquid
       @from = @limit = nil
       @for_block = BlockBody.new
       @else_block = nil
-      parse_with_selected_parser(@markup)
+      parse_with_selected_parser(markup)
       return unless parse_body(@for_block, tokens)
       parse_body(@else_block, tokens)
     end

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -50,15 +50,11 @@ module Liquid
 
     attr_reader :collection_name, :variable_name, :limit, :from
 
-    def initialize(tag_name, markup, options)
-      super
+    def parse(tokens)
       @from = @limit = nil
-      parse_with_selected_parser(markup)
       @for_block = BlockBody.new
       @else_block = nil
-    end
-
-    def parse(tokens)
+      parse_with_selected_parser(@markup)
       return unless parse_body(@for_block, tokens)
       parse_body(@else_block, tokens)
     end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -24,7 +24,7 @@ module Liquid
 
     def parse(tokens)
       @blocks = []
-      push_block('if', @markup)
+      push_block('if', markup)
       while parse_body(@blocks.last.attachment, tokens)
       end
     end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -18,17 +18,13 @@ module Liquid
 
     attr_reader :blocks
 
-    def initialize(tag_name, markup, options)
-      super
-      @blocks = []
-      push_block('if', markup)
-    end
-
     def nodelist
       @blocks.map(&:attachment)
     end
 
     def parse(tokens)
+      @blocks = []
+      push_block('if', @markup)
       while parse_body(@blocks.last.attachment, tokens)
       end
     end

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -21,10 +21,8 @@ module Liquid
 
     attr_reader :template_name_expr, :variable_name_expr, :attributes
 
-    def initialize(tag_name, markup, options)
-      super
-
-      if markup =~ SYNTAX
+    def parse(_tokens)
+      if @markup =~ SYNTAX
 
         template_name = Regexp.last_match(1)
         variable_name = Regexp.last_match(3)
@@ -34,16 +32,13 @@ module Liquid
         @template_name_expr = Expression.parse(template_name)
         @attributes = {}
 
-        markup.scan(TagAttributes) do |key, value|
+        @markup.scan(TagAttributes) do |key, value|
           @attributes[key] = Expression.parse(value)
         end
 
       else
-        raise SyntaxError, options[:locale].t("errors.syntax.include")
+        raise SyntaxError, @parse_context[:locale].t("errors.syntax.include")
       end
-    end
-
-    def parse(_tokens)
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -22,7 +22,7 @@ module Liquid
     attr_reader :template_name_expr, :variable_name_expr, :attributes
 
     def parse(_tokens)
-      if @markup =~ SYNTAX
+      if markup =~ SYNTAX
 
         template_name = Regexp.last_match(1)
         variable_name = Regexp.last_match(3)
@@ -32,12 +32,12 @@ module Liquid
         @template_name_expr = Expression.parse(template_name)
         @attributes = {}
 
-        @markup.scan(TagAttributes) do |key, value|
+        markup.scan(TagAttributes) do |key, value|
           @attributes[key] = Expression.parse(value)
         end
 
       else
-        raise SyntaxError, @parse_context[:locale].t("errors.syntax.include")
+        raise SyntaxError, options[:locale].t("errors.syntax.include")
       end
     end
 

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -18,7 +18,7 @@ module Liquid
   #
   class Increment < Tag
     def parse(_tokens)
-      @variable = @markup.strip
+      @variable = markup.strip
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -17,9 +17,8 @@ module Liquid
   #    Hello: 2
   #
   class Increment < Tag
-    def initialize(tag_name, markup, options)
-      super
-      @variable = markup.strip
+    def parse(_tokens)
+      @variable = @markup.strip
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -6,7 +6,7 @@ module Liquid
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def parse(tokens)
-      ensure_valid_markup(@tag_name, @markup, @parse_context)
+      ensure_valid_markup(tag_name, markup, options)
       @body = +''
       while (token = tokens.shift)
         if token =~ FullTokenPossiblyInvalid
@@ -16,7 +16,7 @@ module Liquid
         @body << token unless token.empty?
       end
 
-      raise SyntaxError, parse_context.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
+      raise SyntaxError, options.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
     end
 
     def render_to_output_buffer(_context, output)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -6,7 +6,7 @@ module Liquid
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def parse(tokens)
-      ensure_valid_markup(tag_name, markup, options)
+      ensure_valid_markup(tag_name, markup, parse_context)
       @body = +''
       while (token = tokens.shift)
         if token =~ FullTokenPossiblyInvalid
@@ -16,7 +16,7 @@ module Liquid
         @body << token unless token.empty?
       end
 
-      raise SyntaxError, options.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
+      raise SyntaxError, parse_context.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
     end
 
     def render_to_output_buffer(_context, output)

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -5,13 +5,8 @@ module Liquid
     Syntax = /\A\s*\z/
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
-    def initialize(tag_name, markup, parse_context)
-      super
-
-      ensure_valid_markup(tag_name, markup, parse_context)
-    end
-
     def parse(tokens)
+      ensure_valid_markup(@tag_name, @markup, @parse_context)
       @body = +''
       while (token = tokens.shift)
         if token =~ FullTokenPossiblyInvalid

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -8,10 +8,8 @@ module Liquid
 
     attr_reader :template_name_expr, :attributes
 
-    def initialize(tag_name, markup, options)
-      super
-
-      raise SyntaxError, options[:locale].t("errors.syntax.render") unless markup =~ SYNTAX
+    def parse(_tokens)
+      raise SyntaxError, @parse_context[:locale].t("errors.syntax.render") unless @markup =~ SYNTAX
 
       template_name = Regexp.last_match(1)
       variable_name = Regexp.last_match(3)
@@ -21,7 +19,7 @@ module Liquid
       @template_name_expr = Expression.parse(template_name)
 
       @attributes = {}
-      markup.scan(TagAttributes) do |key, value|
+      @markup.scan(TagAttributes) do |key, value|
         @attributes[key] = Expression.parse(value)
       end
     end

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -9,7 +9,7 @@ module Liquid
     attr_reader :template_name_expr, :attributes
 
     def parse(_tokens)
-      raise SyntaxError, @parse_context[:locale].t("errors.syntax.render") unless @markup =~ SYNTAX
+      raise SyntaxError, options[:locale].t("errors.syntax.render") unless markup =~ SYNTAX
 
       template_name = Regexp.last_match(1)
       variable_name = Regexp.last_match(3)
@@ -19,7 +19,7 @@ module Liquid
       @template_name_expr = Expression.parse(template_name)
 
       @attributes = {}
-      @markup.scan(TagAttributes) do |key, value|
+      markup.scan(TagAttributes) do |key, value|
         @attributes[key] = Expression.parse(value)
       end
     end

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -6,18 +6,18 @@ module Liquid
 
     attr_reader :variable_name, :collection_name, :attributes
 
-    def initialize(tag_name, markup, options)
-      super
-      if markup =~ Syntax
+    def parse(_tokens)
+      if @markup =~ Syntax
         @variable_name = Regexp.last_match(1)
         @collection_name = Expression.parse(Regexp.last_match(2))
         @attributes = {}
-        markup.scan(TagAttributes) do |key, value|
+        @markup.scan(TagAttributes) do |key, value|
           @attributes[key] = Expression.parse(value)
         end
       else
-        raise SyntaxError, options[:locale].t("errors.syntax.table_row")
+        raise SyntaxError, @parse_context[:locale].t("errors.syntax.table_row")
       end
+      super
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -7,15 +7,15 @@ module Liquid
     attr_reader :variable_name, :collection_name, :attributes
 
     def parse(_tokens)
-      if @markup =~ Syntax
+      if markup =~ Syntax
         @variable_name = Regexp.last_match(1)
         @collection_name = Expression.parse(Regexp.last_match(2))
         @attributes = {}
-        @markup.scan(TagAttributes) do |key, value|
+        markup.scan(TagAttributes) do |key, value|
           @attributes[key] = Expression.parse(value)
         end
       else
-        raise SyntaxError, @parse_context[:locale].t("errors.syntax.table_row")
+        raise SyntaxError, options[:locale].t("errors.syntax.table_row")
       end
       super
     end

--- a/test/integration/tag_test.rb
+++ b/test/integration/tag_test.rb
@@ -14,7 +14,7 @@ class TagTest < Minitest::Test
 
   def test_all_tags_are_registered
     tags = Template.tags.map { |key, _tag| key }
-    expected_tags = %w(tablerow echo if break for assign ifchanged case include continue capture decrement unless increment comment raw render cycle)
-    assert_equal(expected_tags, tags)
+    expected_tags = %w(assign break capture case comment continue cycle decrement echo for if ifchanged include increment raw render tablerow unless)
+    assert_equal(expected_tags, tags.sort)
   end
 end

--- a/test/integration/tag_test.rb
+++ b/test/integration/tag_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TagTest < Minitest::Test
+  include Liquid
+
+  def test_all_tags_with_no_parse_can_render
+    Template.tags.each do |key, _tag|
+      Template.tags[key].new(key, '', ParseContext.new).render(Context.new)
+      assert_nil(nil)
+    end
+  end
+
+  def test_all_tags_are_registered
+    tags = Template.tags.map { |key, _tag| key }
+    expected_tags = %w(tablerow echo if break for assign ifchanged case include continue capture decrement unless increment comment raw render cycle)
+    assert_equal(expected_tags, tags)
+  end
+end


### PR DESCRIPTION
This is a clean up that accomplishes a few things. It doesn't add any new methods, it just shifts parsing logic inside `initialize` to `parse` which is pre-existing functionality.

## Tag initialization is now lightweight and universal

There are no tags that need an `initialize` method. By removing this it opens up the ability to dynamically create Tags outside of the normal parsing process. There is a current overlap of functionality between some tags and this moves towards the path of possibly allowing `Tag A` to wrap itself in `Tag B`.

**Example:** `render` wrapping itself with `for`

## Separation between Object creation and Parsing

By moving away from the `initialize` method, it will be easier to move tag parsing to `liquid-c`

@pushrax @Thibaut @Shopify/guardians-of-the-liquid @Shopify/liquid 