### PR TITLE
[Exploration] Extract partial creation to a method in the render tag

### DIFF
--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -35,15 +35,10 @@ module Liquid
       template_name = context.evaluate(@template_name_expr)
       raise ArgumentError, options[:locale].t("errors.argument.include") unless template_name
 
-      partial = PartialCache.load(
-        template_name,
-        context: context,
-        parse_context: parse_context
-      )
-
       context_variable_name = @alias_name || template_name.split('/').last
 
       render_partial_func = ->(var) {
+        partial = load_partial(template_name, context)
         inner_context = context.new_isolated_subcontext
         inner_context.template_name = template_name
         inner_context.partial = true
@@ -58,6 +53,14 @@ module Liquid
       variable.is_a?(Array) ? variable.each(&render_partial_func) : render_partial_func.call(variable)
 
       output
+    end
+
+    def load_partial(template_name, context)
+      PartialCache.load(
+        template_name,
+        context: context,
+        parse_context: parse_context
+      )
     end
 
     class ParseTreeVisitor < Liquid::ParseTreeVisitor


### PR DESCRIPTION
Extract the creation of a partial in the `Render` tag to its own method so that it can be extended. 