### PR TITLE
Allow render to handle with and for correctly

### DIFF
--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   class Render < Tag
-    SYNTAX = /(#{QuotedString}+)(\s+(?:with|for)\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
+    SYNTAX = /(#{QuotedString}+)(\s+(with|for)\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
 
     disable_tags "include"
 
@@ -14,11 +14,13 @@ module Liquid
       raise SyntaxError, options[:locale].t("errors.syntax.render") unless markup =~ SYNTAX
 
       template_name = Regexp.last_match(1)
-      variable_name = Regexp.last_match(3)
+      with_or_for = Regexp.last_match(3)
+      variable_name = Regexp.last_match(4)
 
-      @alias_name = Regexp.last_match(5)
+      @alias_name = Regexp.last_match(6)
       @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
       @template_name_expr = Expression.parse(template_name)
+      @loop_variable = (with_or_for == "for")
 
       @attributes = {}
       markup.scan(TagAttributes) do |key, value|
@@ -58,7 +60,7 @@ module Liquid
       }
 
       variable = @variable_name_expr ? context.evaluate(@variable_name_expr) : nil
-      if variable.is_a?(Array)
+      if variable.respond_to?(:each) && variable.respond_to?(:count) && @loop_variable
         forloop = Liquid::ForloopDrop.new(template_name, variable.count, nil)
         variable.each { |var| render_partial_func.call(var, forloop) }
       else

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -2,7 +2,8 @@
 
 module Liquid
   class Render < Tag
-    SYNTAX = /(#{QuotedString}+)(\s+(with|for)\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
+    FOR = 'for'
+    SYNTAX = /(#{QuotedString}+)(\s+(with|#{FOR})\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
 
     disable_tags "include"
 
@@ -20,7 +21,7 @@ module Liquid
       @alias_name = Regexp.last_match(6)
       @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
       @template_name_expr = Expression.parse(template_name)
-      @loop_variable = (with_or_for == "for")
+      @for = (with_or_for == FOR)
 
       @attributes = {}
       markup.scan(TagAttributes) do |key, value|
@@ -60,7 +61,7 @@ module Liquid
       }
 
       variable = @variable_name_expr ? context.evaluate(@variable_name_expr) : nil
-      if variable.respond_to?(:each) && variable.respond_to?(:count) && @loop_variable
+      if @for && variable.respond_to?(:each) && variable.respond_to?(:count)
         forloop = Liquid::ForloopDrop.new(template_name, variable.count, nil)
         variable.each { |var| render_partial_func.call(var, forloop) }
       else

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -214,4 +214,22 @@ class RenderTagTest < Minitest::Test
     assert_template_result("Product: Draft 151cm first  index:1 Product: Element 155cm  last index:2 ",
                            "{% render 'product' for products %}", "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }])
   end
+
+  def test_render_tag_for_drop
+    Liquid::Template.file_system = StubFileSystem.new(
+      'loop' => "{{ value.foo }}",
+    )
+
+    assert_template_result("123",
+                           "{% render 'loop' for loop as value %}", "loop" => TestEnumerable.new)
+  end
+
+  def test_render_tag_with_drop
+    Liquid::Template.file_system = StubFileSystem.new(
+      'loop' => "{{ value }}",
+    )
+
+    assert_template_result("TestEnumerable",
+                           "{% render 'loop' with loop as value %}", "loop" => TestEnumerable.new)
+  end
 end


### PR DESCRIPTION
Currently `render` can only handle rendering `Array` and not `Drop` which is the most common object type in Shopify.

The basic solution was to enable `variable.respond_to?(:each)` however, this leads to maps being passed to `with` to also loop.

This PR means `with` will never loop, and `for` will loop when the object implements `each` and `count`

@Shopify/liquid @Shopify/guardians-of-the-liquid