### PR TITLE
Experiment with ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 2.5
   - &latest_ruby 2.6
   - 2.7
+  - 2.7.0-preview1
+  - 2.7.0-preview2
+  - 2.7.0-preview3
   - ruby-head
 
 matrix:
@@ -15,6 +18,9 @@ matrix:
       name: Profiling Memory Usage
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.7
+    - rvm: 2.7.0-preview2
+    - rvm: 2.7.0-preview3
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+os: [osx, linux]
 
 rvm:
   - 2.4


### PR DESCRIPTION
In https://github.com/Shopify/liquid/issues/1205 I have a failure on __ruby-2.7.0-preview3__.
Last master was built with __ruby-2.7.0-preview1__ and is green.
I cannot reproduce on OS X __ruby-2.7.0-preview1__ or __ruby-2.7.0-preview3__, installed via `ruby-install`.

Asking for travis to reproduce it for me, trying to pinpoint the issue.