### PR TITLE
Pass caller as option to file system register

### DIFF
--- a/lib/liquid/file_system.rb
+++ b/lib/liquid/file_system.rb
@@ -16,7 +16,7 @@ module Liquid
   # This will parse the template with a LocalFileSystem implementation rooted at 'template_path'.
   class BlankFileSystem
     # Called by Liquid to retrieve a template file
-    def read_template_file(_template_path)
+    def read_template_file_with_options(_template_path, _options)
       raise FileSystemError, "This liquid context does not allow includes."
     end
   end
@@ -51,7 +51,7 @@ module Liquid
       @pattern = pattern
     end
 
-    def read_template_file(template_path)
+    def read_template_file_with_options(template_path, _options)
       full_path = full_path(template_path)
       raise FileSystemError, "No such template '#{template_path}'" unless File.exist?(full_path)
 

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -2,18 +2,22 @@
 
 module Liquid
   class PartialCache
-    def self.load(template_name, context:, parse_context:)
+    def self.load(template_name, context:, parse_context:, caller:)
       cached_partials = (context.registers[:cached_partials] ||= {})
-      cached = cached_partials[template_name]
+      cached = cached_partials["#{caller}:#{template_name}"]
       return cached if cached
 
       file_system = (context.registers[:file_system] ||= Liquid::Template.file_system)
-      source      = file_system.read_template_file(template_name)
-
       parse_context.partial = true
 
+      source = if file_system.respond_to?(:read_template_file_with_options)
+        file_system.read_template_file_with_options(template_name, caller: caller)
+      else
+        file_system.read_template_file(template_name)
+      end
+
       partial = Liquid::Template.parse(source, parse_context)
-      cached_partials[template_name] = partial
+      cached_partials["#{caller}:#{template_name}"] = partial
     ensure
       parse_context.partial = false
     end

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -53,7 +53,8 @@ module Liquid
       partial = PartialCache.load(
         template_name,
         context: context,
-        parse_context: parse_context
+        parse_context: parse_context,
+        caller: :include
       )
 
       context_variable_name = @alias_name || template_name.split('/').last

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -41,7 +41,8 @@ module Liquid
       partial = PartialCache.load(
         template_name,
         context: context,
-        parse_context: parse_context
+        parse_context: parse_context,
+        caller: :render
       )
 
       context_variable_name = @alias_name || template_name.split('/').last

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -18,7 +18,7 @@ class ThemeRunner
     end
 
     # Called by Liquid to retrieve a template file
-    def read_template_file(template_path)
+    def read_template_file_with_options(template_path, _options)
       File.read(@path + '/' + template_path + '.liquid')
     end
   end

--- a/test/integration/blank_test.rb
+++ b/test/integration/blank_test.rb
@@ -10,7 +10,7 @@ class FoobarTag < Liquid::Tag
 end
 
 class BlankTestFileSystem
-  def read_template_file(template_path)
+  def read_template_file_with_options(template_path, _options)
     template_path
   end
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -242,7 +242,7 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   class TestFileSystem
-    def read_template_file(_template_path)
+    def read_template_file_with_options(_template_path, _options)
       "{{ errors.argument_error }}"
     end
   end

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -6,7 +6,7 @@ class RenderProfilingTest < Minitest::Test
   include Liquid
 
   class ProfilingFileSystem
-    def read_template_file(template_path)
+    def read_template_file_with_options(template_path, _options)
       "Rendering template {% assign template_name = '#{template_path}'%}\n{{ template_name }}"
     end
   end

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -126,6 +126,17 @@ class RenderTagTest < Minitest::Test
     assert_equal(2, file_system.file_read_count)
   end
 
+  def test_render_tag_passes_correct_caller_to_file_system
+    context = Liquid::Context.build
+    file_system = StubRestrictedFileSystem.new(
+      restricted_callers: %i(render),
+      values: { 'inaccessible_file' => 'Inaccessible' }
+    )
+    assert_equal('',
+      Template.parse("{% render 'inaccessible_file' %}").render!(context, registers: { file_system: file_system }))
+    assert_equal(:render, file_system.last_caller)
+  end
+
   def test_render_tag_within_if_statement
     Liquid::Template.file_system = StubFileSystem.new('snippet' => 'my message')
     assert_template_result('my message', '{% if true %}{% render "snippet" %}{% endif %}')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,6 +131,39 @@ class StubFileSystem
     @values          = values
   end
 
+  def read_template_file_with_options(template_path, _options)
+    @file_read_count += 1
+    @values.fetch(template_path)
+  end
+end
+
+class StubLegacyFileSystem
+  def initialize(values)
+    @values = values
+  end
+
+  def read_template_file(template_path)
+    @values.fetch(template_path)
+  end
+end
+
+class StubRestrictedFileSystem
+  attr_reader :restricted_callers, :last_caller, :file_read_count
+
+  def initialize(restricted_callers:, values:)
+    @restricted_callers = restricted_callers
+    @values             = values
+    @file_read_count    = 0
+  end
+
+  def read_template_file_with_options(template_path, options)
+    @last_caller = options[:caller]
+    return if restricted_callers.include?(@last_caller)
+
+    @file_read_count += 1
+    @values.fetch(template_path)
+  end
+
   def read_template_file(template_path)
     @file_read_count += 1
     @values.fetch(template_path)

--- a/test/unit/file_system_unit_test.rb
+++ b/test/unit/file_system_unit_test.rb
@@ -7,7 +7,7 @@ class FileSystemUnitTest < Minitest::Test
 
   def test_default
     assert_raises(FileSystemError) do
-      BlankFileSystem.new.read_template_file("dummy")
+      BlankFileSystem.new.read_template_file_with_options("dummy", {})
     end
   end
 

--- a/test/unit/partial_cache_unit_test.rb
+++ b/test/unit/partial_cache_unit_test.rb
@@ -13,7 +13,8 @@ class PartialCacheUnitTest < Minitest::Test
     partial = Liquid::PartialCache.load(
       'my_partial',
       context: context,
-      parse_context: Liquid::ParseContext.new
+      parse_context: Liquid::ParseContext.new,
+      caller: :render
     )
 
     assert_equal('my partial body', partial.render)
@@ -29,7 +30,8 @@ class PartialCacheUnitTest < Minitest::Test
       Liquid::PartialCache.load(
         'my_partial',
         context: context,
-        parse_context: Liquid::ParseContext.new
+        parse_context: Liquid::ParseContext.new,
+        caller: :render
       )
     end
 
@@ -56,14 +58,16 @@ class PartialCacheUnitTest < Minitest::Test
       Liquid::PartialCache.load(
         'my_partial',
         context: context_one,
-        parse_context: parse_context
+        parse_context: parse_context,
+        caller: :render
       )
     end
 
     Liquid::PartialCache.load(
       'my_partial',
       context: context_two,
-      parse_context: parse_context
+      parse_context: parse_context,
+      caller: :render
     )
 
     assert_equal(2, shared_file_system.file_read_count)
@@ -78,16 +82,81 @@ class PartialCacheUnitTest < Minitest::Test
     Liquid::PartialCache.load(
       'my_partial',
       context: context,
-      parse_context: Liquid::ParseContext.new(my_key: 'value one')
+      parse_context: Liquid::ParseContext.new(my_key: 'value one'),
+      caller: :render
     )
     Liquid::PartialCache.load(
       'my_partial',
       context: context,
-      parse_context: Liquid::ParseContext.new(my_key: 'value two')
+      parse_context: Liquid::ParseContext.new(my_key: 'value two'),
+      caller: :render
     )
 
     # Technically what we care about is that the file was parsed twice,
     # but measuring file reads is an OK proxy for this.
+    assert_equal(1, file_system.file_read_count)
+  end
+
+  def test_passes_caller_as_option_to_file_system
+    context = Liquid::Context.build
+    file_system = StubRestrictedFileSystem.new(
+      restricted_callers: %i(include),
+      values: { 'my_partial' => 'Inaccessible' }
+    )
+    context.registers[:file_system] = file_system
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new,
+      caller: :include
+    )
+
+    assert_equal('', partial.render)
+    assert_equal(:include, file_system.last_caller)
+  end
+
+  def test_supports_legacy_file_system_without_method_read_template_file_with_options
+    context = Liquid::Context.build
+    file_system = StubLegacyFileSystem.new('my_partial' => 'my partial body')
+    context.registers[:file_system] = file_system
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new,
+      caller: :render
+    )
+
+    assert_equal('my partial body', partial.render)
+  end
+
+  def test_caches_per_caller_type
+    context = Liquid::Context.build
+    file_system = StubRestrictedFileSystem.new(
+      restricted_callers: %i(include),
+      values: { 'my_partial' => 'my partial body' }
+    )
+    context.registers[:file_system] = file_system
+
+    2.times do
+      partial = Liquid::PartialCache.load(
+        'my_partial',
+        context: context,
+        parse_context: Liquid::ParseContext.new,
+        caller: :render
+      )
+      assert_equal('my partial body', partial.render)
+    end
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new,
+      caller: :include
+    )
+    assert_equal('', partial.render)
+
     assert_equal(1, file_system.file_read_count)
   end
 end


### PR DESCRIPTION
## Context
With the `{% include %}` tag now [deprecated](https://help.shopify.com/en/themes/liquid/tags/deprecated-tags) in Shopify, we want to restrict certain new platform features to only work with the `{% render %}` tag. To do so, we are passing the calling tag name to the file system and delegating it the responsibility of determining if the partial is supported with the given tag.

## How
* Pass the caller via an `options` hash to a newly added `read_template_file_with_options` method to the file system register. 
* To avoid breaking backwards compatibility, we only invoke `read_template_file_with_options` if the file system supports it. Otherwise fallback to the previous `read_template_file`. 
* Cache results per calling tag in `PartialCache` 

@Thibaut 