### PR TITLE
Introduce template factory

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -80,6 +80,7 @@ require 'liquid/partial_cache'
 require 'liquid/usage'
 require 'liquid/register'
 require 'liquid/static_registers'
+require 'liquid/template_factory'
 
 # Load all the tags of the standard library
 #

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -12,7 +12,10 @@ module Liquid
 
       parse_context.partial = true
 
-      partial = Liquid::Template.parse(source, parse_context)
+      template_factory = (context.registers[:template_factory] ||= Liquid::TemplateFactory.new)
+      template = template_factory.for(template_name)
+
+      partial = template.parse(source, parse_context)
       cached_partials[template_name] = partial
     ensure
       parse_context.partial = false

--- a/lib/liquid/template_factory.rb
+++ b/lib/liquid/template_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Liquid
+  class TemplateFactory
+    def for(_template_name)
+      Liquid::Template.new
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,3 +136,16 @@ class StubFileSystem
     @values.fetch(template_path)
   end
 end
+
+class StubTemplateFactory
+  attr_reader :count
+
+  def initialize
+    @count = 0
+  end
+
+  def for(_template_name)
+    @count += 1
+    Liquid::Template.new
+  end
+end

--- a/test/unit/partial_cache_unit_test.rb
+++ b/test/unit/partial_cache_unit_test.rb
@@ -90,4 +90,39 @@ class PartialCacheUnitTest < Minitest::Test
     # but measuring file reads is an OK proxy for this.
     assert_equal(1, file_system.file_read_count)
   end
+
+  def test_uses_default_template_factory_when_no_template_factory_found_in_register
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new('my_partial' => 'my partial body'),
+      }
+    )
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new
+    )
+
+    assert_equal('my partial body', partial.render)
+  end
+
+  def test_uses_template_factory_register_if_present
+    template_factory = StubTemplateFactory.new
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new('my_partial' => 'my partial body'),
+        template_factory: template_factory,
+      }
+    )
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new
+    )
+
+    assert_equal('my partial body', partial.render)
+    assert_equal(1, template_factory.count)
+  end
 end

--- a/test/unit/template_factory_unit_test.rb
+++ b/test/unit/template_factory_unit_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TemplateFactoryUnitTest < Minitest::Test
+  include Liquid
+
+  def test_for_returns_liquid_template_instance
+    template = TemplateFactory.new.for("anything")
+    assert_instance_of(Liquid::Template, template)
+  end
+end


### PR DESCRIPTION
## Context
Currently, liquid will always use a `Liquid::Template` when rendering partials. In Shopify, we want the ability to use different templates depending on the type of partial. 

## What changed

* Use a template factory to create templates for partial
* Use template factory provided in context registers when available
* Add the ability for templates to apply context restrictions during render.

This change has no impact on backward compatibility since we have a default template factory included.