### PR TITLE
Fix liquid tag nested in outer block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,10 +21,6 @@ Lint/InheritException:
 Layout/LineLength:
   Max: 294
 
-# Offense count: 1
-Metrics/BlockNesting:
-  Max: 4
-
 # Offense count: 44
 Naming/ConstantName:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,6 +21,10 @@ Lint/InheritException:
 Layout/LineLength:
   Max: 294
 
+# Offense count: 1
+Metrics/BlockNesting:
+  Max: 4
+
 # Offense count: 44
 Naming/ConstantName:
   Exclude:

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -60,6 +60,14 @@ module Liquid
       Usage.increment("liquid_tag_contains_outer_tag") unless $ERROR_INFO.is_a?(SyntaxError)
     end
 
+    private def parse_liquid_tag(markup, parse_context, &block)
+      liquid_tag_tokenizer = Tokenizer.new(markup, line_number: parse_context.line_number, for_liquid_tag: true)
+      parse_for_liquid_tag(liquid_tag_tokenizer, parse_context) do |end_tag_name, end_tag_markup|
+        next unless end_tag_name
+        self.class.unknown_tag_in_liquid_tag(end_tag_name, end_tag_markup, &block)
+      end
+    end
+
     private def parse_for_document(tokenizer, parse_context, &block)
       while (token = tokenizer.shift)
         next if token.empty?
@@ -79,11 +87,7 @@ module Liquid
           end
 
           if tag_name == 'liquid'
-            liquid_tag_tokenizer = Tokenizer.new(markup, line_number: parse_context.line_number, for_liquid_tag: true)
-            parse_for_liquid_tag(liquid_tag_tokenizer, parse_context) do |end_tag_name, end_tag_markup|
-              next unless end_tag_name
-              self.class.unknown_tag_in_liquid_tag(end_tag_name, end_tag_markup, &block)
-            end
+            parse_liquid_tag(markup, parse_context, &block)
             next
           end
 

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'English'
+
 module Liquid
   class BlockBody
     LiquidTagToken      = /\A\s*(\w+)\s*(.*?)\z/o
@@ -51,6 +53,13 @@ module Liquid
       yield nil, nil
     end
 
+    # @api private
+    def self.unknown_tag_in_liquid_tag(end_tag_name, end_tag_markup)
+      yield end_tag_name, end_tag_markup
+    ensure
+      Usage.increment("liquid_tag_contains_outer_tag") unless $ERROR_INFO.is_a?(SyntaxError)
+    end
+
     private def parse_for_document(tokenizer, parse_context, &block)
       while (token = tokenizer.shift)
         next if token.empty?
@@ -71,7 +80,11 @@ module Liquid
 
           if tag_name == 'liquid'
             liquid_tag_tokenizer = Tokenizer.new(markup, line_number: parse_context.line_number, for_liquid_tag: true)
-            next parse_for_liquid_tag(liquid_tag_tokenizer, parse_context, &block)
+            parse_for_liquid_tag(liquid_tag_tokenizer, parse_context) do |end_tag_name, end_tag_markup|
+              next unless end_tag_name
+              self.class.unknown_tag_in_liquid_tag(end_tag_name, end_tag_markup, &block)
+            end
+            next
           end
 
           unless (tag = registered_tags[tag_name])

--- a/test/integration/tags/liquid_tag_test.rb
+++ b/test/integration/tags/liquid_tag_test.rb
@@ -81,6 +81,18 @@ class LiquidTagTest < Minitest::Test
     assert_match_syntax_error("syntax error (line 3): Unknown tag 'error'", "{% liquid echo ''\n  \n error %}")
   end
 
+  def test_nested_liquid_tag
+    assert_usage_increment("liquid_tag_contains_outer_tag", times: 0) do
+      assert_template_result('good', <<~LIQUID)
+        {%- if true %}
+          {%- liquid
+            echo "good"
+          %}
+        {%- endif -%}
+      LIQUID
+    end
+  end
+
   def test_cannot_open_blocks_living_past_a_liquid_tag
     assert_match_syntax_error("syntax error (line 3): 'if' tag was never closed", <<~LIQUID)
       {%- liquid
@@ -91,11 +103,13 @@ class LiquidTagTest < Minitest::Test
   end
 
   def test_quirk_can_close_blocks_created_before_a_liquid_tag
-    assert_template_result("42", <<~LIQUID)
-      {%- if true -%}
-      42
-      {%- liquid endif -%}
-    LIQUID
+    assert_usage_increment("liquid_tag_contains_outer_tag") do
+      assert_template_result("42", <<~LIQUID)
+        {%- if true -%}
+        42
+        {%- liquid endif -%}
+      LIQUID
+    end
   end
 
   def test_liquid_tag_in_raw


### PR DESCRIPTION
Fixes #1214

## Problem

The liquid tag seems to have intentionally implemented some weird quirks which made it kind of act like a block and kind of not, as demonstrated by the [test_cannot_open_blocks_living_past_a_liquid_tag and test_quirk_can_close_blocks_created_before_a_liquid_tag tests](https://github.com/Shopify/liquid/blob/6c6382ed69e639e238e4f5088c88a9a828190012/test/integration/tags/liquid_tag_test.rb#L84-L99).  To support the quirk of closing outer block tags, the liquid block body yielded to delegate the handling of end tags, making it behave unlike a block tag.  To support the former test, it yielded a `nil` end tag at the end of the liquid tag to indicate that there weren't any further tokens.  However, that end tag was also being delegated to any block tag around the liquid tag, which prevented the outer block tag from being properly terminated outside the liquid tag.

## Solution

To fix #1214, I stopped delegating the `nil` end tag to the outer block tag.

Ideally, we would have the liquid tag act more like a block, in that block tags inside should be closed inside the liquid tag and blocks outside the liquid tag should be closed outside the liquid tag.  Since that could be a breaking change, I've added a usage increment so that we can see if any templates are currently relying on that behaviour.