### PR TITLE
Remove support for taint_mode on ruby versions that don't support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,12 @@ rvm:
   - 2.4
   - 2.5
   - &latest_ruby 2.6
-  - 2.7
-  - ruby-head
 
 matrix:
   include:
     - rvm: *latest_ruby
       script: bundle exec rake memory_profile:run
       name: Profiling Memory Usage
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: 2.7
 
 branches:
   only:

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -69,7 +69,14 @@ module Liquid
       # :lax is the default, and ignores the taint flag completely
       # :warn adds a warning, but does not interrupt the rendering
       # :error raises an error when tainted output is used
-      attr_writer :taint_mode
+      # @deprecated Since it is being deprecated in ruby itself.
+      def taint_mode=(mode)
+        taint_supported = Object.new.taint.tainted?
+        if mode != :lax && !taint_supported
+          raise NotImplementedError, "#{RUBY_ENGINE} #{RUBY_VERSION} doesn't support taint checking"
+        end
+        @taint_mode = mode
+      end
 
       attr_accessor :default_exception_renderer
       Template.default_exception_renderer = lambda do |exception|

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -143,8 +143,8 @@ module Liquid
     end
 
     def taint_check(context, obj)
-      return unless obj.tainted?
       return if Template.taint_mode == :lax
+      return unless obj.tainted?
 
       @markup =~ QuotedFragment
       name = Regexp.last_match(0)

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -114,29 +114,31 @@ class DropsTest < Minitest::Test
     assert_equal('  ', tpl.render!('product' => ProductDrop.new))
   end
 
-  def test_rendering_raises_on_tainted_attr
-    with_taint_mode(:error) do
-      tpl = Liquid::Template.parse('{{ product.user_input }}')
-      assert_raises TaintedError do
-        tpl.render!('product' => ProductDrop.new)
+  if taint_supported?
+    def test_rendering_raises_on_tainted_attr
+      with_taint_mode(:error) do
+        tpl = Liquid::Template.parse('{{ product.user_input }}')
+        assert_raises TaintedError do
+          tpl.render!('product' => ProductDrop.new)
+        end
       end
     end
-  end
 
-  def test_rendering_warns_on_tainted_attr
-    with_taint_mode(:warn) do
-      tpl     = Liquid::Template.parse('{{ product.user_input }}')
-      context = Context.new('product' => ProductDrop.new)
-      tpl.render!(context)
-      assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
-      assert_equal "variable 'product.user_input' is tainted and was not escaped", context.warnings.first.to_s(false)
+    def test_rendering_warns_on_tainted_attr
+      with_taint_mode(:warn) do
+        tpl     = Liquid::Template.parse('{{ product.user_input }}')
+        context = Context.new('product' => ProductDrop.new)
+        tpl.render!(context)
+        assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
+        assert_equal "variable 'product.user_input' is tainted and was not escaped", context.warnings.first.to_s(false)
+      end
     end
-  end
 
-  def test_rendering_doesnt_raise_on_escaped_tainted_attr
-    with_taint_mode(:error) do
-      tpl = Liquid::Template.parse('{{ product.user_input | escape }}')
-      tpl.render!('product' => ProductDrop.new)
+    def test_rendering_doesnt_raise_on_escaped_tainted_attr
+      with_taint_mode(:error) do
+        tpl = Liquid::Template.parse('{{ product.user_input | escape }}')
+        tpl.render!('product' => ProductDrop.new)
+      end
     end
   end
 

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -361,4 +361,12 @@ class TemplateTest < Minitest::Test
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('12345', result)
   end
+
+  unless taint_supported?
+    def test_taint_mode
+      assert_raises(NotImplementedError) do
+        Template.taint_mode = :warn
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,10 @@ module Minitest
     def fixture(name)
       File.join(File.expand_path(__dir__), "fixtures", name)
     end
+
+    def self.taint_supported?
+      Object.new.taint.tainted?
+    end
   end
 
   module Assertions


### PR DESCRIPTION
## Problem

Ruby is deprecating support for taint checking (https://bugs.ruby-lang.org/issues/16131).  It won't immediately remove the related methods, it will just treat all objects as untainted.  This means our test suite will fail on the next version of ruby.

## Solution

Deprecate the `Template.taint_mode=` method and have it raise if the taint mode isn't supported by the version of ruby being used.  We can remove this feature in the next breaking release of liquid.

I've also wrapped taint mode tests in a conditional to prevent them from running if taint checking isn't supported by the ruby version being used.