### PR TITLE
[Liquid::Template] Cleanup file_system class variable

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 
 * Split Strainer class as a factory and a template (#1208) [Thierry Joyal]
 * Remove handling of a nil context in the Strainer class (#1218) [Thierry Joyal]
+* Cleanup file_system class variable in Liquid::Template (#1219) [Thierry Joyal]
 
 ## 4.0.3 / 2019-03-12
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   # Templates are central to liquid.
-  # Interpretating templates is a two step process. First you compile the
+  # Interpreting templates is a two step process. First you compile the
   # source code you got. During compile time some extensive error checking is performed.
   # your code should expect to get some SyntaxErrors.
   #
@@ -17,8 +17,6 @@ module Liquid
   class Template
     attr_accessor :root
     attr_reader :resource_limits, :warnings
-
-    @@file_system = BlankFileSystem.new
 
     class TagRegistry
       include Enumerable
@@ -78,17 +76,16 @@ module Liquid
         @taint_mode = mode
       end
 
+      # Sets the file system.
+      attr_writer :file_system
+
       attr_accessor :default_exception_renderer
       Template.default_exception_renderer = lambda do |exception|
         exception
       end
 
       def file_system
-        @@file_system
-      end
-
-      def file_system=(obj)
-        @@file_system = obj
+        @file_system ||= BlankFileSystem.new
       end
 
       def register_tag(name, klass)


### PR DESCRIPTION
From #1208

These class variables are so tricky to understand as they don't behave as mode developers would think about them.

As I'm iterating in this area, opening this small change to make the use of `@@` go away (align with other class level variables present in this class).

<details><summary>Example</summary>
<p>

#### yes, even hidden code blocks!

```rb
irb(main):001:0> class A
irb(main):002:1>   def self.test=(var)
irb(main):003:2>     @@test = var
irb(main):004:2>   end
irb(main):005:1>   def self.test
irb(main):006:2>     @@test ||= :a
irb(main):007:2>   end
irb(main):008:1> end
=> :test
irb(main):009:0> 
irb(main):010:0> class B < A
irb(main):011:1>   def self.test=(var)
irb(main):012:2>     @@test = var
irb(main):013:2>   end
irb(main):014:1>   def self.test
irb(main):015:2>     @@test ||= :b
irb(main):016:2>   end
irb(main):017:1> end
=> :test
irb(main):018:0> B.test
=> :b
irb(main):019:0> A.test
=> :a
irb(main):020:0> A.test = 1
=> 1
irb(main):021:0> A.test
=> 1
irb(main):022:0> B.test
=> 1
irb(main):023:0> B.test = 2
=> 2
irb(main):024:0> A.test
=> 2
irb(main):025:0> B.test
=> 2


class A
  def self.test=(var)
    @test = var
  end
  def self.test
    @test ||= :a
  end
end

class B < A
  def self.test=(var)
    @test = var
  end
  def self.test
    @test ||= :b
  end
end

irb(main):020:0> B.test
=> :b
irb(main):021:0> A.test
=> :a
irb(main):022:0> A.test = 1
=> 1
irb(main):023:0> A.test
=> 1
irb(main):024:0> B.test
=> :b
irb(main):025:0> B.test = 2
=> 2
irb(main):026:0> A.test
=> 1
irb(main):027:0> B.test
=> 2
```

</p>
</details>
