### PR TITLE
Test against the latest ruby in CI

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.78.0
+
 AllCops:
   Exclude:
   - 'db/schema.rb'
@@ -20,7 +22,7 @@ Style/Alias:
   - prefer_alias
   - prefer_alias_method
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
@@ -30,7 +32,7 @@ Layout/AlignHash:
   - ignore_implicit
   - ignore_explicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
   - with_first_parameter
@@ -172,7 +174,7 @@ Naming/FileName:
   Regex:
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - consistent
@@ -225,7 +227,7 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Width: 2
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -233,10 +235,10 @@ Layout/IndentFirstArrayElement:
   - align_brackets
   IndentationWidth:
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   IndentationWidth:
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -340,9 +342,9 @@ Style/PercentQLiterals:
 Naming/PredicateName:
   NamePrefix:
   - is_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
-  NameWhitelist:
+  AllowedMethods:
   - is_a?
   Exclude:
   - 'spec/**/*'
@@ -467,7 +469,7 @@ Style/TernaryParentheses:
   - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
   - final_newline
@@ -478,7 +480,7 @@ Style/TrivialAccessors:
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
   - to_ary
   - to_a
   - to_c
@@ -509,7 +511,7 @@ Style/WhileUntilModifier:
 Metrics/BlockNesting:
   Max: 3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true
@@ -561,7 +563,7 @@ Lint/UnusedMethodArgument:
 Naming/AccessorMethodName:
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
 Style/ArrayJoin:
@@ -819,13 +821,13 @@ Layout/TrailingWhitespace:
 Style/UnlessElse:
   Enabled: true
 
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/VariableInterpolation:
@@ -840,7 +842,7 @@ Style/WhileUntilDo:
 Style/ZeroLengthPredicate:
   Enabled: true
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   EnforcedStyle: squiggly
 
 Lint/AmbiguousOperator:
@@ -864,7 +866,7 @@ Lint/DeprecatedClassMethods:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -891,7 +893,7 @@ Lint/FloatOutOfRange:
 Lint/FormatParameterMismatch:
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   AllowComments: true
 
 Lint/ImplicitStringConcatenation:
@@ -947,7 +949,7 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -956,13 +958,13 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Enabled: true
 
-Lint/UnneededCopEnableDirective:
+Lint/RedundantCopEnableDirective:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnreachableCode:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Lint/InheritException:
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 294
 
 # Offense count: 44

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ cache: bundler
 rvm:
   - 2.4
   - 2.5
-  - &latest_ruby 2.6
+  - 2.6
+  - &latest_ruby 2.7
+  - ruby-head
 
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :benchmark, :test do
 end
 
 group :test do
-  gem 'rubocop', '~> 0.74.0', require: false
+  gem 'rubocop', '~> 0.78.0', require: false
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do

--- a/lib/liquid/parser_switching.rb
+++ b/lib/liquid/parser_switching.rb
@@ -8,10 +8,10 @@ module Liquid
       when :lax    then lax_parse(markup)
       when :warn
         begin
-          return strict_parse_with_error_context(markup)
+          strict_parse_with_error_context(markup)
         rescue SyntaxError => e
           parse_context.warnings << e
-          return lax_parse(markup)
+          lax_parse(markup)
         end
       end
     end

--- a/performance/shopify/shop_filter.rb
+++ b/performance/shopify/shop_filter.rb
@@ -60,7 +60,7 @@ module ShopFilter
 
     case style
     when 'original'
-      return '/files/shops/random_number/' + url
+      '/files/shops/random_number/' + url
     when 'grande', 'large', 'medium', 'compact', 'small', 'thumb', 'icon'
       "/files/shops/random_number/products/#{Regexp.last_match(1)}_#{style}.#{Regexp.last_match(2)}"
     else

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -159,13 +159,13 @@ class RenderProfilingTest < Minitest::Test
     t.render!("collection" => ["one", "two"])
     leaf = t.profiler[0].children[0]
 
-    assert_operator leaf.self_time, :>, 0
+    assert_operator(leaf.self_time, :>, 0)
   end
 
   def test_profiling_supports_total_time
     t = Template.parse("{% if true %} {% increment test %} {{ test }} {% endif %}", profile: true)
     t.render!
 
-    assert_operator t.profiler[0].total_time, :>, 0
+    assert_operator(t.profiler[0].total_time, :>, 0)
   end
 end


### PR DESCRIPTION
I meant to test against ruby 2.7 and ruby-head and not allow failures in #1216 after adding handling the removal of taint checking in ruby 2.7.  Somehow I accidentally ended up removing those intentionally.

Now that ruby 2.7 is released, we should definitely make sure liquid works with it.

Closes #1209