### PR TITLE
Fix Liquid::Template inheritance

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -119,14 +119,13 @@ module Liquid
       # To enable profiling, pass in <tt>profile: true</tt> as an option.
       # See Liquid::Profiler for more information
       def parse(source, options = {})
-        template = Template.new
-        template.parse(source, options)
+        new.parse(source, options)
       end
     end
 
     def initialize
       @rethrow_errors  = false
-      @resource_limits = ResourceLimits.new(self.class.default_resource_limits)
+      @resource_limits = ResourceLimits.new(Template.default_resource_limits)
     end
 
     # Parse source code.

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -77,4 +77,11 @@ class TemplateUnitTest < Minitest::Test
   ensure
     Template.tags.delete('fake')
   end
+
+  class TemplateSubclass < Liquid::Template
+  end
+
+  def test_template_inheritance
+    assert_equal("foo", TemplateSubclass.parse("foo").render)
+  end
 end


### PR DESCRIPTION
## Problem

We inherit from Liquid::Template in once place in Shopify core which #1223 broke by using `self.class` to access an `attr_accessor` on the class.  This is because the instance variable is only set for Liquid::Template and not its subclasses.

## Solution

Liquid::Context already use `Template.default_resource_limits` in Liquid::Context#initialize as the default in the context, so it makes sense to refer to `Template.default_resource_limits` in Template#initialize as well.

However, I don't think it makes sense for Template.parse to call Template.new directly, since that forced us to have to override the `parse` class method in the Template subclass in Shopify.

I've also added a test for template inheritance.