### PR TITLE
Fix ParseTreeVisitorTest for ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     - rvm: *latest_ruby
       script: bundle exec rake memory_profile:run
       name: Profiling Memory Usage
+  allow_failures:
+    - rvm: ruby-head
 
 branches:
   only:

--- a/test/integration/parse_tree_visitor_test.rb
+++ b/test/integration/parse_tree_visitor_test.rb
@@ -238,7 +238,7 @@ class ParseTreeVisitorTest < Minitest::Test
   def traversal(template)
     ParseTreeVisitor
       .for(Template.parse(template).root)
-      .add_callback_for(VariableLookup, &:name)
+      .add_callback_for(VariableLookup) { |node| node.name } # rubocop:disable Style/SymbolProc
   end
 
   def visit(template)


### PR DESCRIPTION
## Problem

I noticed all the test/integration/parse_tree_visitor_test.rb tests were failing on liquid-c CI and was able to reproduce the same problem in liquid itself locally.  The failures look like

```
  1) Error:
ParseTreeVisitorTest#test_variable:
ArgumentError: wrong number of arguments (given 1, expected 0)
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:28:in `block in visit'
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:27:in `map'
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:27:in `visit'
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:31:in `block in visit'
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:27:in `map'
    /Users/dylansmith/src/liquid/lib/liquid/parse_tree_visitor.rb:27:in `visit'
    test/integration/parse_tree_visitor_test.rb:245:in `visit'
    test/integration/parse_tree_visitor_test.rb:11:in `test_variable'
```

The relevant ruby change that caused this to happen is https://bugs.ruby-lang.org/issues/16260.

Previously, the arity of the symbol proc (`&:name` in this case) given to ParseTreeVisitor#add_callback_for was `-1`, so it would pass the node to the symbol proc.

Now, the arity is `-2`, which more accurately represents the fact that the first argument to the proc is required.  This causes ParseTreeVisitor#add_callback_for to decide to pass two arguments to the block. The first argument gets used as the receiver which the method referenced by the symbol calls.  The new ruby feature makes it such that additional arguments get passed along to the method, so the second block argument gets passed to the name method, but the name method doesn't take any arguments.

## Solution

Avoid using a symbol proc in the test to avoid the future ruby incompatibility.

Note that there was another unrelated ruby-head failure in a test counting object allocations.  So I'm ignoring ruby-head failures for now.  That looks like something that might need fixing upstream, but still requires deeper investigation.