### PR TITLE
[Travis] Optional head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     - rvm: *latest_ruby
       script: bundle exec rake memory_profile:run
       name: Profiling Memory Usage
+  allow_failures:
+    - rvm: ruby-head
 
 branches:
   only:


### PR DESCRIPTION
Ruby head is a moving target.

I think we shouldn't have it as a mandatory supported target as it creates a blocker on new code that we try to get in to have to fix unrelated code to the current changes.

Eg.: https://github.com/Shopify/liquid/pull/1250 currently fail on head.

Does not mean we shouldn't fix it, simply that it cannot be made a pre-requirement for any changes which makes it harder to contribute.