### PR TITLE
[StaticRegisters] Cache for reads

### DIFF
--- a/lib/liquid/static_registers.rb
+++ b/lib/liquid/static_registers.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module Liquid
   class StaticRegisters
+    extend Forwardable
+
     attr_reader :static, :registers
+
+    def_delegators :@cache, :[], :key?
 
     def initialize(registers = {})
       @static    = registers.is_a?(StaticRegisters) ? registers.static : registers
@@ -16,22 +22,14 @@ module Liquid
       @cache[key] = value
     end
 
-    def [](key)
-      @cache[key]
-    end
-
     def delete(key)
-      @registers.delete(key).tap do
-        @static.dup.merge(@registers)
-      end
+      deleted = @registers.delete(key)
+      @cache = @static.dup.merge(@registers)
+      deleted
     end
 
     def fetch(key, default = nil)
       key?(key) ? self[key] : default
-    end
-
-    def key?(key)
-      @cache.key?(key)
     end
   end
 end

--- a/lib/liquid/static_registers.rb
+++ b/lib/liquid/static_registers.rb
@@ -7,22 +7,23 @@ module Liquid
     def initialize(registers = {})
       @static    = registers.is_a?(StaticRegisters) ? registers.static : registers
       @registers = {}
+
+      @cache = @static.dup
     end
 
     def []=(key, value)
       @registers[key] = value
+      @cache[key] = value
     end
 
     def [](key)
-      if @registers.key?(key)
-        @registers[key]
-      else
-        @static[key]
-      end
+      @cache[key]
     end
 
     def delete(key)
-      @registers.delete(key)
+      @registers.delete(key).tap do
+        @static.dup.merge(@registers)
+      end
     end
 
     def fetch(key, default = nil)
@@ -30,7 +31,7 @@ module Liquid
     end
 
     def key?(key)
-      @registers.key?(key) || @static.key?(key)
+      @cache.key?(key)
     end
   end
 end

--- a/test/unit/static_registers_unit_test.rb
+++ b/test/unit/static_registers_unit_test.rb
@@ -41,6 +41,10 @@ class StaticRegistersUnitTest < Minitest::Test
     assert_nil(static_register.delete("unknown"))
 
     assert_equal({}, static_register.registers)
+
+    static_register[:custom] = 42
+    assert_equal(42, static_register.delete(:custom))
+    assert_nil(static_register[:custom])
   end
 
   def test_fetch


### PR DESCRIPTION
Optimization being discusses: https://github.com/Shopify/liquid/pull/1250/files#r428825865

Remove the possibly doubled hash check by creating a "at write time" cache entry.

Thoughts?