### PR TITLE
Fix how Template overrides static registers when #render is invoked

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -212,7 +212,7 @@ module Liquid
       end
 
       Template.registers.each do |key, register|
-        context_register[key] = register
+        context_register[key] = register unless context_register.key?(key)
       end
 
       # Retrying a render resets resource usage

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -362,6 +362,50 @@ class TemplateTest < Minitest::Test
     assert_equal('12345', result)
   end
 
+  def test_render_uses_correct_disabled_tags_instance
+    Liquid::Template.file_system = StubFileSystem.new(
+      'foo' => 'bar',
+      'test_include' => '{% include "foo" %}'
+    )
+
+    disabled_tags = DisabledTags.new
+    context = Context.build(registers: { disabled_tags: disabled_tags })
+
+    source = "{% render 'test_include' %}"
+    parse_context = Liquid::ParseContext.new(line_numbers: true, error_mode: :strict)
+    document = Document.parse(Liquid::Tokenizer.new(source, true), parse_context)
+
+    assert_equal("include usage is not allowed in this context", document.render(context))
+  end
+
+  def test_render_sets_context_static_register_when_register_key_does_exist
+    disabled_tags_for_test = DisabledTags.new
+    Template.add_register(:disabled_tags, disabled_tags_for_test)
+
+    t = Template.parse("{% if true %} Test Template {% endif %}")
+
+    context = Context.new
+    refute(context.registers.key?(:disabled_tags))
+
+    t.render(context)
+
+    assert(context.registers.key?(:disabled_tags))
+    assert_equal(disabled_tags_for_test, context.registers[:disabled_tags])
+  end
+
+  def test_render_does_not_override_context_static_register_when_register_key_exists
+    context = Context.new
+    context.registers[:random_register] = nil
+    Template.add_register(:random_register, {})
+
+    t = Template.parse("{% if true %} Test Template {% endif %}")
+
+    t.render(context)
+
+    assert_nil(context.registers[:random_register])
+    assert(context.registers.key?(:random_register))
+  end
+
   unless taint_supported?
     def test_taint_mode
       assert_raises(NotImplementedError) do


### PR DESCRIPTION
### ISSUE
When `Liquid::Template#render` is invoked, the `Template` will automatically assign `context` with a number of default registers defined in Liquid: 
https://github.com/Shopify/liquid/blob/0f820bdcb4e163ad4e8925da20e78dbb7e2382a0/lib/liquid/template.rb#L214-L216

A default register example in Liquid: 
https://github.com/Shopify/liquid/blob/18654526c8708f27efe7aa3bacfa04928e08dcf6/lib/liquid/registers/disabled_tags.rb#L31

### PROBLEM
Although assigning `context` with all necessary registers before start rendering [root node](https://github.com/Shopify/liquid/blob/18654526c8708f27efe7aa3bacfa04928e08dcf6/lib/liquid/template.rb#L225) will make sure that `context` has all the registers needed, it creates an issue in cases where the `context` is already assigned with a register populated with data that needs to be passed to nested nodes. 
### EXAMPLE
If we had a `Document` that has a render tag `{% render 'foo' %}`, then when this node is rendered, the `BlockBody` will populate `context`'s `DisabledTags` register instance with the `render node` disabled_tags https://github.com/Shopify/liquid/blob/18654526c8708f27efe7aa3bacfa04928e08dcf6/lib/liquid/block_body.rb#L178-L180
At this point, `context.registers` will have a `disabled_tags` instance populated with `{'include': 1}`.  Now, if this `foo.liquid` has `{% include 'bar' %}` **([WHICH IS NOT ALLOWED IN RENDER TAGS](https://github.com/Shopify/liquid/blob/18654526c8708f27efe7aa3bacfa04928e08dcf6/lib/liquid/tags/render.rb#L8))**, a [partial](https://github.com/Shopify/liquid/blob/18654526c8708f27efe7aa3bacfa04928e08dcf6/lib/liquid/tags/render.rb#L41) template `(Template instance)`, and inner_context (with filled `disabled_tags` instance) will be created. Once we start rendering the partial, the `Template` overrides registers, including `disabled_tags`, with the default ones. Which leads to an `include` tag being rendered in a context is it not supported. 

### Fix
Our solution allows us to keep using the pre-assinged registers in the `context`. The `Template` will only override the registers when their `keys` are not included in `context.registers`. We took into consideration the possibility of clients depending on registers assigned to `nil`. 