### PR TITLE
Remove support for taint checking

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -46,7 +46,6 @@ module Liquid
   StandardError       = Class.new(Error)
   SyntaxError         = Class.new(Error)
   StackLevelError     = Class.new(Error)
-  TaintedError        = Class.new(Error)
   MemoryError         = Class.new(Error)
   ZeroDivisionError   = Class.new(Error)
   FloatDomainError    = Class.new(Error)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -41,7 +41,7 @@ module Liquid
     end
 
     def escape(input)
-      CGI.escapeHTML(input.to_s).untaint unless input.nil?
+      CGI.escapeHTML(input.to_s) unless input.nil?
     end
     alias_method :h, :escape
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -64,23 +64,6 @@ module Liquid
       attr_accessor :error_mode
       Template.error_mode = :lax
 
-      attr_reader :taint_mode
-
-      # Sets how strict the taint checker should be.
-      # :lax is the default, and ignores the taint flag completely
-      # :warn adds a warning, but does not interrupt the rendering
-      # :error raises an error when tainted output is used
-      # @deprecated Since it is being deprecated in ruby itself.
-      def taint_mode=(mode)
-        taint_supported = Object.new.taint.tainted?
-        if mode != :lax && !taint_supported
-          raise NotImplementedError, "#{RUBY_ENGINE} #{RUBY_VERSION} doesn't support taint checking"
-        end
-        @taint_mode = mode
-      end
-
-      Template.taint_mode = :lax
-
       attr_accessor :default_exception_renderer
       Template.default_exception_renderer = lambda do |exception|
         exception

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -86,9 +86,7 @@ module Liquid
         context.invoke(filter_name, output, *filter_args)
       end
 
-      obj = context.apply_global_filter(obj)
-      taint_check(context, obj)
-      obj
+      context.apply_global_filter(obj)
     end
 
     def render_to_output_buffer(context, output)
@@ -140,25 +138,6 @@ module Liquid
         parsed_args << parsed_kwargs
       end
       parsed_args
-    end
-
-    def taint_check(context, obj)
-      return if Template.taint_mode == :lax
-      return unless obj.tainted?
-
-      @markup =~ QuotedFragment
-      name = Regexp.last_match(0)
-
-      error               = TaintedError.new("variable '#{name}' is tainted and was not escaped")
-      error.line_number   = line_number
-      error.template_name = context.template_name
-
-      case Template.taint_mode
-      when :warn
-        context.warnings << error
-      when :error
-        raise error
-      end
     end
 
     class ParseTreeVisitor < Liquid::ParseTreeVisitor

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  s.add_development_dependency('rake', '~> 11.3')
+  s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('minitest')
 end

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -49,10 +49,6 @@ class ProductDrop < Liquid::Drop
     ContextDrop.new
   end
 
-  def user_input
-    (+"foo").taint
-  end
-
   protected
 
   def callmenot
@@ -112,34 +108,6 @@ class DropsTest < Minitest::Test
   def test_product_drop
     tpl = Liquid::Template.parse('  ')
     assert_equal('  ', tpl.render!('product' => ProductDrop.new))
-  end
-
-  if taint_supported?
-    def test_rendering_raises_on_tainted_attr
-      with_taint_mode(:error) do
-        tpl = Liquid::Template.parse('{{ product.user_input }}')
-        assert_raises TaintedError do
-          tpl.render!('product' => ProductDrop.new)
-        end
-      end
-    end
-
-    def test_rendering_warns_on_tainted_attr
-      with_taint_mode(:warn) do
-        tpl     = Liquid::Template.parse('{{ product.user_input }}')
-        context = Context.new('product' => ProductDrop.new)
-        tpl.render!(context)
-        assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
-        assert_equal "variable 'product.user_input' is tainted and was not escaped", context.warnings.first.to_s(false)
-      end
-    end
-
-    def test_rendering_doesnt_raise_on_escaped_tainted_attr
-      with_taint_mode(:error) do
-        tpl = Liquid::Template.parse('{{ product.user_input | escape }}')
-        tpl.render!('product' => ProductDrop.new)
-      end
-    end
   end
 
   def test_drop_does_only_respond_to_whitelisted_methods
@@ -281,7 +249,7 @@ class DropsTest < Minitest::Test
   end
 
   def test_invokable_methods
-    assert_equal(%w(to_liquid catchall user_input context texts).to_set, ProductDrop.invokable_methods)
+    assert_equal(%w(to_liquid catchall context texts).to_set, ProductDrop.invokable_methods)
     assert_equal(%w(to_liquid scopes_as_array loop_pos scopes).to_set, ContextDrop.invokable_methods)
     assert_equal(%w(to_liquid size max min first count).to_set, EnumerableDrop.invokable_methods)
     assert_equal(%w(to_liquid max min sort count first).to_set, RealEnumerableDrop.invokable_methods)

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -42,34 +42,6 @@ class RenderTagTest < Minitest::Test
     assert_template_result('', "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}")
   end
 
-  if taint_supported?
-    def test_render_sets_the_correct_template_name_for_errors
-      Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ unsafe }}')
-
-      with_taint_mode :error do
-        template = Liquid::Template.parse('{% render "snippet", unsafe: unsafe %}')
-        context  = Context.new('unsafe' => (+'unsafe').tap(&:taint))
-        template.render(context)
-
-        assert_equal [Liquid::TaintedError], template.errors.map(&:class)
-        assert_equal 'snippet', template.errors.first.template_name
-      end
-    end
-
-    def test_render_sets_the_correct_template_name_for_warnings
-      Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ unsafe }}')
-
-      with_taint_mode :warn do
-        template = Liquid::Template.parse('{% render "snippet", unsafe: unsafe %}')
-        context  = Context.new('unsafe' => (+'unsafe').tap(&:taint))
-        template.render(context)
-
-        assert_equal [Liquid::TaintedError], context.warnings.map(&:class)
-        assert_equal 'snippet', context.warnings.first.template_name
-      end
-    end
-  end
-
   def test_render_does_not_mutate_parent_scope
     Liquid::Template.file_system = StubFileSystem.new('snippet' => '{% assign inner = 1 %}')
     assert_template_result('', "{% render 'snippet' %}{{ inner }}")

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -405,12 +405,4 @@ class TemplateTest < Minitest::Test
     assert_nil(context.registers[:random_register])
     assert(context.registers.key?(:random_register))
   end
-
-  unless taint_supported?
-    def test_taint_mode
-      assert_raises(NotImplementedError) do
-        Template.taint_mode = :warn
-      end
-    end
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,10 +32,6 @@ module Minitest
     def fixture(name)
       File.join(File.expand_path(__dir__), "fixtures", name)
     end
-
-    def self.taint_supported?
-      Object.new.taint.tainted?
-    end
   end
 
   module Assertions
@@ -91,14 +87,6 @@ module Minitest
     ensure
       Liquid::StrainerFactory.send(:strainer_class_cache).clear
       Liquid::StrainerFactory.instance_variable_set(:@global_filters, original_global_filters)
-    end
-
-    def with_taint_mode(mode)
-      old_mode = Liquid::Template.taint_mode
-      Liquid::Template.taint_mode = mode
-      yield
-    ensure
-      Liquid::Template.taint_mode = old_mode
     end
 
     def with_error_mode(mode)


### PR DESCRIPTION
## Problem

Running the tests with on ruby 2.7 results in a lot of deprecation warnings like

```
.../lib/liquid/standardfilters.rb:44: warning: Object#untaint is deprecated and will be removed in Ruby 3.2.
```

which are from ruby deprecating taint checking.

I was also seeing multiple of the following deprecation warning when running the tests

```
.../.gem/ruby/2.7.1/gems/rake-11.3.0/lib/rake/application.rb:378: warning: deprecated Object#=~ is called on Proc; it always returns nil
```

## Solution

Remove support for taint checking and upgrade the development version of rake.