### PR TITLE
Handle disabled tags errors like other liquid errors

### DIFF
--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -53,5 +53,6 @@ module Liquid
   UndefinedDropMethod = Class.new(Error)
   UndefinedFilter     = Class.new(Error)
   MethodOverrideError = Class.new(Error)
+  DisabledError       = Class.new(Error)
   InternalError       = Class.new(Error)
 end

--- a/lib/liquid/tag/disableable.rb
+++ b/lib/liquid/tag/disableable.rb
@@ -5,14 +5,17 @@ module Liquid
     module Disableable
       def render_to_output_buffer(context, output)
         if context.tag_disabled?(tag_name)
-          output << disabled_error_message
+          output << disabled_error(context)
           return
         end
         super
       end
 
-      def disabled_error_message
-        "#{tag_name} #{parse_context[:locale].t('errors.disabled.tag')}"
+      def disabled_error(context)
+        # raise then rescue the exception so that the Context#exception_renderer can re-raise it
+        raise DisabledError, "#{tag_name} #{parse_context[:locale].t('errors.disabled.tag')}"
+      rescue DisabledError => exc
+        context.handle_error(exc, line_number)
       end
     end
   end

--- a/test/integration/tag/disableable_test.rb
+++ b/test/integration/tag/disableable_test.rb
@@ -24,7 +24,8 @@ class TagDisableableTest < Minitest::Test
   def test_disables_raw
     with_disableable_tags do
       with_custom_tag('disable', DisableRaw) do
-        assert_template_result 'raw usage is not allowed in this contextfoo', '{% disable %}{% raw %}Foobar{% endraw %}{% echo "foo" %}{% enddisable %}'
+        output = Template.parse('{% disable %}{% raw %}Foobar{% endraw %}{% echo "foo" %}{% enddisable %}').render
+        assert_equal('Liquid error: raw usage is not allowed in this contextfoo', output)
       end
     end
   end
@@ -32,7 +33,8 @@ class TagDisableableTest < Minitest::Test
   def test_disables_echo_and_raw
     with_disableable_tags do
       with_custom_tag('disable', DisableRawEcho) do
-        assert_template_result 'raw usage is not allowed in this contextecho usage is not allowed in this context', '{% disable %}{% raw %}Foobar{% endraw %}{% echo "foo" %}{% enddisable %}'
+        output = Template.parse('{% disable %}{% raw %}Foobar{% endraw %}{% echo "foo" %}{% enddisable %}').render
+        assert_equal('Liquid error: raw usage is not allowed in this contextLiquid error: echo usage is not allowed in this context', output)
       end
     end
   end

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -127,7 +127,10 @@ class RenderTagTest < Minitest::Test
       'test_include' => '{% include "foo" %}'
     )
 
-    assert_template_result('include usage is not allowed in this context', '{% render "test_include" %}')
+    exc = assert_raises(Liquid::DisabledError) do
+      Liquid::Template.parse('{% render "test_include" %}').render!
+    end
+    assert_equal('Liquid error: include usage is not allowed in this context', exc.message)
   end
 
   def test_includes_will_not_render_inside_nested_sibling_tags
@@ -137,7 +140,8 @@ class RenderTagTest < Minitest::Test
       'test_include' => '{% include "foo" %}'
     )
 
-    assert_template_result('include usage is not allowed in this contextinclude usage is not allowed in this context', '{% render "nested_render_with_sibling_include" %}')
+    output = Liquid::Template.parse('{% render "nested_render_with_sibling_include" %}').render
+    assert_equal('Liquid error: include usage is not allowed in this contextLiquid error: include usage is not allowed in this context', output)
   end
 
   def test_render_tag_with


### PR DESCRIPTION
Follow-up to #1274

## Problem

https://github.com/Shopify/liquid/pull/1162 introduced a new liquid runtime error, but introduces it in a way that doesn't use Liquid::Context#handle_error as is done for other liquid errors.

This results in the error being handled inconsistently, where the error is output without being able to detect it through Liquid::Context#errors or an exception from Liquid::Template#render!.  It also doesn't allow the template name or line number to be obtained to easily fine the include (or other disabled tag) that caused the error.

## Solution

Add Liquid::DisabledError and pass an instance of it to Context#handle_error to render the message or re-raise it.