### PR TITLE
Remove unused quirk allowing liquid tags to close a block it is nested in

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -29,6 +29,11 @@ module Liquid
     end
 
     def unknown_tag(tag, _params, _tokens)
+      Block.raise_unknown_tag(tag, block_name, block_delimiter, parse_context)
+    end
+
+    # @api private
+    def self.raise_unknown_tag(tag, block_name, block_delimiter, parse_context)
       if tag == 'else'
         raise SyntaxError, parse_context.locale.t("errors.syntax.unexpected_else",
           block_name: block_name)

--- a/test/integration/tags/liquid_tag_test.rb
+++ b/test/integration/tags/liquid_tag_test.rb
@@ -82,15 +82,13 @@ class LiquidTagTest < Minitest::Test
   end
 
   def test_nested_liquid_tag
-    assert_usage_increment("liquid_tag_contains_outer_tag", times: 0) do
-      assert_template_result('good', <<~LIQUID)
-        {%- if true %}
-          {%- liquid
-            echo "good"
-          %}
-        {%- endif -%}
-      LIQUID
-    end
+    assert_template_result('good', <<~LIQUID)
+      {%- if true %}
+        {%- liquid
+          echo "good"
+        %}
+      {%- endif -%}
+    LIQUID
   end
 
   def test_cannot_open_blocks_living_past_a_liquid_tag
@@ -102,14 +100,12 @@ class LiquidTagTest < Minitest::Test
     LIQUID
   end
 
-  def test_quirk_can_close_blocks_created_before_a_liquid_tag
-    assert_usage_increment("liquid_tag_contains_outer_tag") do
-      assert_template_result("42", <<~LIQUID)
-        {%- if true -%}
-        42
-        {%- liquid endif -%}
-      LIQUID
-    end
+  def test_cannot_close_blocks_created_before_a_liquid_tag
+    assert_match_syntax_error("syntax error (line 3): 'endif' is not a valid delimiter for liquid tags. use %}", <<~LIQUID)
+      {%- if true -%}
+      42
+      {%- liquid endif -%}
+    LIQUID
   end
 
   def test_liquid_tag_in_raw


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid/pull/1215 fixed a bug in handling the liquid tag, but also left a quirk along with usage instrumentation so that we avoided a breaking change until we knew the quirk wasn't needed.

> Ideally, we would have the liquid tag act more like a block, in that block tags inside should be closed inside the liquid tag and blocks outside the liquid tag should be closed outside the liquid tag. Since that could be a breaking change, I've added a usage increment so that we can see if any templates are currently relying on that behaviour.

I checked our liquid usage instrumentation and I didn't see any usage of it.

## Solution

Fix the quirk, the corresponding test and remove the usage instrumentation.

## Merge Checklist

- [x] Corresponding [liquid-c changes](https://github.com/Shopify/liquid-c/pull/57) are approved.
- [x] Revert Gemfile change to use liquid-c master again
- [x] Revert Gemfile change in liquid-c branch to have it use liquid master again
- [ ] Merge this PR along with the liquid-c change