### PR TITLE
Push interrupts from Continue and Break tags rather than from BlockBody

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -142,23 +142,16 @@ module Liquid
       while (node = @nodelist[idx])
         previous_output_size = output.bytesize
 
-        case node
-        when String
+        if node.instance_of?(String)
           output << node
-        when Variable
+        elsif node.instance_of?(Variable)
           render_node(context, output, node)
-        when Block
+        else
           render_node(context, node.blank? ? +'' : output, node)
-          break if context.interrupt? # might have happened in a for-block
-        when Continue, Break
           # If we get an Interrupt that means the block must stop processing. An
           # Interrupt is any command that stops block execution such as {% break %}
-          # or {% continue %}
-          context.push_interrupt(node.interrupt)
-          break
-        else # Other non-Block tags
-          render_node(context, output, node)
-          break if context.interrupt? # might have happened through an include
+          # or {% continue %}. These tags may also occur through Block or Include tags.
+          break if context.interrupt? # might have happened in a for-block
         end
         idx += 1
 

--- a/lib/liquid/tags/break.rb
+++ b/lib/liquid/tags/break.rb
@@ -11,8 +11,11 @@ module Liquid
   #    {% endfor %}
   #
   class Break < Tag
-    def interrupt
-      BreakInterrupt.new
+    INTERRUPT = BreakInterrupt.new.freeze
+
+    def render_to_output_buffer(context, output)
+      context.push_interrupt(INTERRUPT)
+      output
     end
   end
 

--- a/lib/liquid/tags/continue.rb
+++ b/lib/liquid/tags/continue.rb
@@ -11,8 +11,11 @@ module Liquid
   #    {% endfor %}
   #
   class Continue < Tag
-    def interrupt
-      ContinueInterrupt.new
+    INTERRUPT = ContinueInterrupt.new.freeze
+
+    def render_to_output_buffer(context, output)
+      context.push_interrupt(INTERRUPT)
+      output
     end
   end
 


### PR DESCRIPTION
## Problem

Liquid::BlockBody#render_to_output_buffer has unnecessary special case handling for `break` and `continue` tags in order to push an interrupt and break.

I would like to push this complexity out of the BlockBody#render_to_output_buffer since it is a hot code path and because I want to implement it in liquid-c.

## Solution

I simply moved the pushing of the interrupt to render_to_output_buffer method of the Break and Continue tag classes and changed BlockBody#render_to_output_buffer to handle these like any other tags.  There is already a conditional break for tags.

I've also merged the handling of Liquid::Block and Liquid::Tag, which only differ in that Liquid::Tag doesn't need to handle `node.blank?`.  However, `Liquid::Tag#blank?` already returns `false`, so we may as well just leverage the `node.blank?` conditional to avoid the additional `when Block` conditional.

Also, I've switched to using `node.instance_of?` for checking for `String` or `Variable` nodes, since it does a faster class equality check compared and because we don't need to support nodes that inherit from either of these classes.