### PR TITLE
Handle BlockBody#blank? at parse time

### DIFF
--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -25,10 +25,9 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      previous_output_size = output.bytesize
-      super
-      context.scopes.last[@to] = output
-      context.resource_limits.assign_score += (output.bytesize - previous_output_size)
+      capture_output = render(context)
+      context.scopes.last[@to] = capture_output
+      context.resource_limits.assign_score += capture_output.bytesize
       output
     end
 

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -21,6 +21,9 @@ module Liquid
     def parse(tokens)
       body = BlockBody.new
       body = @blocks.last.attachment while parse_body(body, tokens)
+      if blank?
+        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      end
     end
 
     def nodelist

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -59,8 +59,13 @@ module Liquid
     end
 
     def parse(tokens)
-      return unless parse_body(@for_block, tokens)
-      parse_body(@else_block, tokens)
+      if parse_body(@for_block, tokens)
+        parse_body(@else_block, tokens)
+      end
+      if blank?
+        @for_block.remove_blank_strings
+        @else_block&.remove_blank_strings
+      end
     end
 
     def nodelist

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,6 +31,9 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
+      if blank?
+        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      end
     end
 
     def unknown_tag(tag, markup, tokens)

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -176,7 +176,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_resource_limits_hash_in_template_gets_updated_even_if_no_limits_are_set
-    t = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
+    t = Template.parse("{% for a in (1..100) %}x{% assign foo = 1 %} {% endfor %}")
     t.render!
     assert(t.resource_limits.assign_score > 0)
     assert(t.resource_limits.render_score > 0)
@@ -215,7 +215,7 @@ class TemplateTest < Minitest::Test
 
   def test_default_resource_limits_unaffected_by_render_with_context
     context = Context.new
-    t = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
+    t = Template.parse("{% for a in (1..100) %}x{% assign foo = 1 %} {% endfor %}")
     t.render!(context)
     assert(context.resource_limits.assign_score > 0)
     assert(context.resource_limits.render_score > 0)


### PR DESCRIPTION
## Problem

Liquid::BlockBody#render_to_output_buffer has special case handling for blank block bodies which seems like it should instead be handled at parse time so that rendering can be simplified.

This is another change motivated by trying to simplify Liquid::BlockBody#render_to_output_buffer in order to implement it in liquid-c.

## Solution

Previously, `BlockBody#blank?` was handled by passing in a different string to blank block tags so that the blank output didn't end up in the final output.

At first, I realized I could push this logic down to the block tags themselves, since this feature was only really important for the control flow logic block tags (`if`, `for`, `case`, `unless` tags).  However, then I further realized that the blank output was always coming raw strings, since the feature was added to handle the blank space character unintentionally included between tags used for computations (e.g. a conditional assignment or a for loop to append/concat to a string/array).

So I ended up just removing all the blank strings from the children of the relevant control flow blocks at the end of parsing these blocks.  There is no need to do this recursively, since any child blank block would have already have done the same thing.

I also had to fix the capture flag that was relying on it being given an empty string from BlockBody#render_to_output_buffer.  Instead, I used `render` in the `capture` tag to explicitly render to a separate output string to assign.