### PR TITLE
Avoid direct coupling to BlockBody instances for liquid-c replacement

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -59,7 +59,7 @@ module Liquid
 
     # @api public
     def new_body
-      BlockBody.new
+      parse_context.new_block_body
     end
 
     # @api public

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -10,7 +10,7 @@ module Liquid
     end
 
     def parse(tokens)
-      @body = BlockBody.new
+      @body = new_body
       while parse_body(@body, tokens)
       end
     end
@@ -55,8 +55,14 @@ module Liquid
       @block_delimiter ||= "end#{block_name}"
     end
 
-    protected
+    private
 
+    # @api public
+    def new_body
+      BlockBody.new
+    end
+
+    # @api public
     def parse_body(body, tokens)
       if parse_context.depth >= MAX_DEPTH
         raise StackLevelError, "Nesting too deep"

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -1,15 +1,26 @@
 # frozen_string_literal: true
 
 module Liquid
-  class Document < BlockBody
+  class Document
     def self.parse(tokens, parse_context)
-      doc = new
+      doc = new(parse_context)
       doc.parse(tokens, parse_context)
       doc
     end
 
+    attr_reader :parse_context, :body
+
+    def initialize(parse_context)
+      @parse_context = parse_context
+      @body = new_body
+    end
+
+    def nodelist
+      @body.nodelist
+    end
+
     def parse(tokens, parse_context)
-      super do |end_tag_name, _end_tag_params|
+      @body.parse(tokens, parse_context) do |end_tag_name, _end_tag_params|
         unknown_tag(end_tag_name, parse_context) if end_tag_name
       end
     rescue SyntaxError => e
@@ -24,6 +35,20 @@ module Liquid
       else
         raise SyntaxError, parse_context.locale.t("errors.syntax.unknown_tag", tag: tag)
       end
+    end
+
+    def render_to_output_buffer(context, output)
+      @body.render_to_output_buffer(context, output)
+    end
+
+    def render(context)
+      @body.render(context)
+    end
+
+    private
+
+    def new_body
+      Liquid::BlockBody.new
     end
   end
 end

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -48,7 +48,7 @@ module Liquid
     private
 
     def new_body
-      Liquid::BlockBody.new
+      parse_context.new_block_body
     end
   end
 end

--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -19,6 +19,10 @@ module Liquid
       @options[option_key]
     end
 
+    def new_block_body
+      Liquid::BlockBody.new
+    end
+
     def partial=(value)
       @partial = value
       @options = value ? partial_options : @template_options

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -19,7 +19,7 @@ module Liquid
     end
 
     def parse(tokens)
-      body = BlockBody.new
+      body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
       if blank?
         @blocks.each { |condition| condition.attachment.remove_blank_strings }
@@ -59,7 +59,7 @@ module Liquid
     private
 
     def record_when_condition(markup)
-      body = BlockBody.new
+      body = new_body
 
       while markup
         unless markup =~ WhenSyntax
@@ -80,7 +80,7 @@ module Liquid
       end
 
       block = ElseCondition.new
-      block.attach(BlockBody.new)
+      block.attach(new_body)
       @blocks << block
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -54,7 +54,7 @@ module Liquid
       super
       @from = @limit = nil
       parse_with_selected_parser(markup)
-      @for_block = BlockBody.new
+      @for_block = new_body
       @else_block = nil
     end
 
@@ -74,7 +74,7 @@ module Liquid
 
     def unknown_tag(tag, markup, tokens)
       return super unless tag == 'else'
-      @else_block = BlockBody.new
+      @else_block = new_body
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -64,7 +64,7 @@ module Liquid
       end
 
       @blocks.push(block)
-      block.attach(BlockBody.new)
+      block.attach(new_body)
     end
 
     def lax_parse(markup)


### PR DESCRIPTION
## Problem

We want to use a C data structure for the block body in liquid-c (https://github.com/Shopify/liquid-c/pull/58) that will be exposed to ruby as Liquid::C::BlockBody, but currently Liquid::Document is directly coupled to Liquid::BlockBody.  There are also several places where `BlockBody.new` is used directly, which doesn't provide a clean way to override in liquid-c to use `Liquid::C::BlockBody`. instead.

## Solution

The first commit adds Liquid::Block#new_body that just returns `BlockBody.new` so that it can be overridden in liquid-c to return `Liquid::C::BlockBody.new`.

The second commit exposes some Liquid::BlockBody instance methods as class methods (raise_missing_tag_terminator, raise_missing_variable_terminator, render_node), since they don't depend on `self` and can be re-used for simplicity in liquid-c.

The third commit changes Liquid::Document to not inherit from Liquid::BlockBody, but instead to store a Liquid::BlockBody.  It also creates the block body using a `#new_body` method that can be overridden by liquid-c.