### PR TITLE
Pass the tag markup and tokenizer to Document#unknown_tag

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -28,8 +28,8 @@ module Liquid
       @body.nodelist
     end
 
-    def unknown_tag(tag, _params, _tokens)
-      Block.raise_unknown_tag(tag, block_name, block_delimiter, parse_context)
+    def unknown_tag(tag_name, _markup, _tokenizer)
+      Block.raise_unknown_tag(tag_name, block_name, block_delimiter, parse_context)
     end
 
     # @api private


### PR DESCRIPTION
Depends on https://github.com/Shopify/liquid/pull/1289

## Problem

Shopify is currently overriding Liquid::Document#registered_tags to implement theme section tags, since they are only supposed to be available at the top-level of the section document.  However, `registered_tags` is actually defined in Liquid::BlockBody and https://github.com/Shopify/liquid/pull/1289 will make Liquid::Document no longer inherit from Liquid::BlockBody, so we need another way to enforce this constraint.

## Solution

Liquid already has builtin context sensitive tags, such as `elsif` and `else` within the `if` tag.  These are implemented using `Liquid::Block#unknown_tag`.  Liquid::Document also has an `unknown_tag` method, but it isn't provided the markup or tokenizer needed to the information we need, so the first commit of this pull request changes `Liquid::Document#unknown_tag` to take the same parameters as `Liquid::Block#unknown_tag`.  `Liquid::Document#parse` was also changed to be more like `Liquid::Block#parse` by continuing to parse if `unknown_tag` handles the tag without raising.

The second commit merely changes the `Liquid::Block#unknown_tag` parameter names for clarify since we use `markup` elsewhere to refer to the text within the tag after the tag name and the third parameter is actually a tokenizer.