### PR TITLE
Port liquid-c bug compatible whitespace trimming

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -142,7 +142,11 @@ module Liquid
       if token[2] == WhitespaceControl
         previous_token = @nodelist.last
         if previous_token.is_a?(String)
+          first_byte = previous_token.getbyte(0)
           previous_token.rstrip!
+          if previous_token.empty? && parse_context[:bug_compatible_whitespace_trimming] && first_byte
+            previous_token << first_byte
+          end
         end
       end
       parse_context.trim_whitespace = (token[-3] == WhitespaceControl)

--- a/test/integration/trim_mode_test.rb
+++ b/test/integration/trim_mode_test.rb
@@ -528,4 +528,21 @@ class TrimModeTest < Minitest::Test
     END_EXPECTED
     assert_template_result(expected, text)
   end
+
+  def test_bug_compatible_pre_trim
+    template = Liquid::Template.parse("\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
+    assert_equal("\n", template.render)
+
+    template = Liquid::Template.parse("\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal("\n", template.render)
+
+    template = Liquid::Template.parse("{{ 'B' }} \n{%- if true %}C{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal("B C", template.render)
+
+    template = Liquid::Template.parse("B\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
+    assert_equal("B", template.render)
+
+    template = Liquid::Template.parse("B\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal("B", template.render)
+  end
 end # TrimModeTest

--- a/test/integration/trim_mode_test.rb
+++ b/test/integration/trim_mode_test.rb
@@ -529,6 +529,17 @@ class TrimModeTest < Minitest::Test
     assert_template_result(expected, text)
   end
 
+  def test_pre_trim_blank_preceding_text
+    template = Liquid::Template.parse("\n{%- raw %}{% endraw %}")
+    assert_equal("", template.render)
+
+    template = Liquid::Template.parse("\n{%- if true %}{% endif %}")
+    assert_equal("", template.render)
+
+    template = Liquid::Template.parse("{{ 'B' }} \n{%- if true %}C{% endif %}")
+    assert_equal("BC", template.render)
+  end
+
   def test_bug_compatible_pre_trim
     template = Liquid::Template.parse("\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
     assert_equal("\n", template.render)


### PR DESCRIPTION
## Problem

As part of the work to integrate https://github.com/Shopify/liquid-c/pull/58, we need to opt-out of using Liquid::C::BlockBody in some code to debug verification failures as mentioned in that PR:

> As part of our storefront rewrite we have some code to debug differences in the rendered output, which is quite coupled to the liquid parse tree node ruby objects, but doesn't seem to be performance sensitive, so I added a :disable_liquid_c_nodes parse option so this can be used without disabling liquid-c globally (which wouldn't be thread-safe).

Unfortunately, using Liquid::BlockBody for parsing can result in an incompatibility with liquid-c when relying on its `bug_compatible_whitespace_trimming: true` parse option.  This is the same incompatibility issue we were seeing into when testing TruffleRuby with liquid and not liquid-c.  So I would like to port that parse option to unblock these use cases.

## Solution

The bug prevents pre-trimming from removing the first character in the preceding string token.  So we can just restore that byte after stripping if `previous_token.rstrip!` fully strips the token (i.e. `previous_token` was a non-empty blank string).

The tests were copied from the above mentioned liquid-c pull request, which we can now remove them from that repo after this is merged.