### PR TITLE
Bring back silencing of errors in blank nodes for backwards compatibility

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -77,7 +77,10 @@ module Liquid
       raise
     rescue ::StandardError => e
       line_number = node.is_a?(String) ? nil : node.line_number
-      output << context.handle_error(e, line_number)
+      error_message = context.handle_error(e, line_number)
+      if node.instance_of?(Variable) || !node.blank? # conditional for backwards compatibility
+        output << error_message
+      end
     end
 
     private def parse_liquid_tag(markup, parse_context)

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -261,4 +261,12 @@ class ErrorHandlingTest < Minitest::Test
     assert_equal("Argument error:\nLiquid error (product line 1): argument error", page)
     assert_equal("product", template.errors.first.template_name)
   end
+
+  def test_bug_compatible_silencing_of_errors_in_blank_nodes
+    output = Liquid::Template.parse("{% assign x = 0 %}{% if 1 < '2' %}not blank{% assign x = 3 %}{% endif %}{{ x }}").render
+    assert_equal("Liquid error: comparison of Integer with String failed0", output)
+
+    output = Liquid::Template.parse("{% assign x = 0 %}{% if 1 < '2' %}{% assign x = 3 %}{% endif %}{{ x }}").render
+    assert_equal("0", output)
+  end
 end


### PR DESCRIPTION
## Problem

Template authors started to notice legitimate liquid errors after deploying https://github.com/Shopify/liquid/pull/1287 which previously weren't noticeable.  This was because we used to call `Liquid::BlockBody#render_node` using `render_node(context, node.blank? ? +'' : output, node)` for tags, where the throw-away `+''` string would have its errors written to it for blank tags.

## Solution

Add a conditional around the writing of the error message in the `Liquid::BlockBody#render_node` `rescue` block so blank tags don't have their errors written to the output again.