### PR TITLE
Only use MethodLiteral in condition expressions

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -27,8 +27,30 @@ module Liquid
       end,
     }
 
+    class MethodLiteral
+      attr_reader :method_name, :to_s
+
+      def initialize(method_name, to_s)
+        @method_name = method_name
+        @to_s = to_s
+      end
+
+      def to_liquid
+        to_s
+      end
+    end
+
+    @@method_literals = {
+      'blank' => MethodLiteral.new(:blank?, '').freeze,
+      'empty' => MethodLiteral.new(:empty?, '').freeze,
+    }
+
     def self.operators
       @@operators
+    end
+
+    def self.parse_expression(markup)
+      @@method_literals[markup] || Expression.parse(markup)
     end
 
     attr_reader :attachment, :child_condition
@@ -91,7 +113,7 @@ module Liquid
     private
 
     def equal_variables(left, right)
-      if left.is_a?(Liquid::Expression::MethodLiteral)
+      if left.is_a?(MethodLiteral)
         if right.respond_to?(left.method_name)
           return right.send(left.method_name)
         else
@@ -99,7 +121,7 @@ module Liquid
         end
       end
 
-      if right.is_a?(Liquid::Expression::MethodLiteral)
+      if right.is_a?(MethodLiteral)
         if left.respond_to?(right.method_name)
           return left.send(right.method_name)
         else

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -34,10 +34,6 @@ module Liquid
         @method_name = method_name
         @to_s = to_s
       end
-
-      def to_liquid
-        to_s
-      end
     end
 
     @@method_literals = {

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -2,25 +2,12 @@
 
 module Liquid
   class Expression
-    class MethodLiteral
-      attr_reader :method_name, :to_s
-
-      def initialize(method_name, to_s)
-        @method_name = method_name
-        @to_s = to_s
-      end
-
-      def to_liquid
-        to_s
-      end
-    end
-
     LITERALS = {
       nil => nil, 'nil' => nil, 'null' => nil, '' => nil,
       'true' => true,
       'false' => false,
-      'blank' => MethodLiteral.new(:blank?, '').freeze,
-      'empty' => MethodLiteral.new(:empty?, '').freeze
+      'blank' => '',
+      'empty' => ''
     }.freeze
 
     SINGLE_QUOTED_STRING = /\A'(.*)'\z/m

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -68,7 +68,7 @@ module Liquid
 
         markup = Regexp.last_match(2)
 
-        block = Condition.new(@left, '==', Expression.parse(Regexp.last_match(1)))
+        block = Condition.new(@left, '==', Condition.parse_expression(Regexp.last_match(1)))
         block.attach(body)
         @blocks << block
       end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -67,18 +67,22 @@ module Liquid
       block.attach(new_body)
     end
 
+    def parse_expression(markup)
+      Condition.parse_expression(markup)
+    end
+
     def lax_parse(markup)
       expressions = markup.scan(ExpressionsAndOperators)
       raise SyntaxError, options[:locale].t("errors.syntax.if") unless expressions.pop =~ Syntax
 
-      condition = Condition.new(Expression.parse(Regexp.last_match(1)), Regexp.last_match(2), Expression.parse(Regexp.last_match(3)))
+      condition = Condition.new(parse_expression(Regexp.last_match(1)), Regexp.last_match(2), parse_expression(Regexp.last_match(3)))
 
       until expressions.empty?
         operator = expressions.pop.to_s.strip
 
         raise SyntaxError, options[:locale].t("errors.syntax.if") unless expressions.pop.to_s =~ Syntax
 
-        new_condition = Condition.new(Expression.parse(Regexp.last_match(1)), Regexp.last_match(2), Expression.parse(Regexp.last_match(3)))
+        new_condition = Condition.new(parse_expression(Regexp.last_match(1)), Regexp.last_match(2), parse_expression(Regexp.last_match(3)))
         raise SyntaxError, options[:locale].t("errors.syntax.if") unless BOOLEAN_OPERATORS.include?(operator)
         new_condition.send(operator, condition)
         condition = new_condition
@@ -106,9 +110,9 @@ module Liquid
     end
 
     def parse_comparison(p)
-      a = Expression.parse(p.expression)
+      a = parse_expression(p.expression)
       if (op = p.consume?(:comparison))
-        b = Expression.parse(p.expression)
+        b = parse_expression(p.expression)
         Condition.new(a, op, b)
       else
         Condition.new(a)


### PR DESCRIPTION
## Problem

The MethodLiteral literal value was added in https://github.com/Shopify/liquid/pull/592 which described it as a hacky solution:

> Not sure if this is a good fix, feels kinda hacky, but seems to work.

One way in which it is hacky is that it is only relevant for boolean comparison equality expressions and isn't relevant for all expressions.

In liquid-c (https://github.com/Shopify/liquid-c/pull/60), I would like Liquid::Expression.parse to return a Liquid::C::Expression object that can be rendered more efficiently and I would like to avoid coupling this work to these `MethodLiteral` objects.

## Solution

Add a `Liquid::Condition.parse_expression` method that wraps `Liquid::Expression.parse` so that it will return a `MethodLiteral` object for `empty` or `blank` literals and will otherwise delegate to `Liquid::Expression.parse`.  This way the values for these literals that are returned by `Liquid::Expression.parse` can just be the empty strings that `MethodLiteral#to_liquid` returns.