### PR TITLE
Fix duplication of text in raw tags

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -14,9 +14,9 @@ module Liquid
     def parse(tokens)
       @body = +''
       while (token = tokens.shift)
-        if token =~ FullTokenPossiblyInvalid
+        if token =~ FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
           @body << Regexp.last_match(1) if Regexp.last_match(1) != ""
-          return if block_delimiter == Regexp.last_match(2)
+          return
         end
         @body << token unless token.empty?
       end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -23,6 +23,7 @@ class RawTagTest < Minitest::Test
     assert_template_result(' Foobar {% {% {% ', '{% raw %} Foobar {% {% {% {% endraw %}')
     assert_template_result(' test {% raw %} {% endraw %}', '{% raw %} test {% raw %} {% {% endraw %}endraw %}')
     assert_template_result(' Foobar {{ invalid 1', '{% raw %} Foobar {{ invalid {% endraw %}{{ 1 }}')
+    assert_template_result(' Foobar {% foo {% bar %}', '{% raw %} Foobar {% foo {% bar %}{% endraw %}')
   end
 
   def test_invalid_raw


### PR DESCRIPTION
Fix bug where some text in raw tags get duplicated.

Example:

```liquid
{% raw %} Foobar {% foo {% bar %}{% endraw %}
```

Expected output:

```liquid
 Foobar {% foo {% bar %}
```

Actual output:

```liquid
 Foobar {% foo {% foo {% bar %}
```