### PR TITLE
Refactor raising tag never closed error to method

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -47,6 +47,10 @@ module Liquid
       end
     end
 
+    def raise_tag_never_closed(block_name)
+      raise SyntaxError, parse_context.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
+    end
+
     def block_name
       @tag_name
     end
@@ -73,9 +77,7 @@ module Liquid
           @blank &&= body.blank?
 
           return false if end_tag_name == block_delimiter
-          unless end_tag_name
-            raise SyntaxError, parse_context.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
-          end
+          raise_tag_never_closed(block_name) unless end_tag_name
 
           # this tag is not registered with the system
           # pass it to the current block for special handling or error reporting

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -21,7 +21,7 @@ module Liquid
         @body << token unless token.empty?
       end
 
-      raise SyntaxError, parse_context.locale.t("errors.syntax.tag_never_closed", block_name: block_name)
+      raise_tag_never_closed(block_name)
     end
 
     def render_to_output_buffer(_context, output)


### PR DESCRIPTION
Refactor error raised when tag is not closed to `raise_tag_never_closed` method. This can let us directly call this method in `liquid-c`.