### PR TITLE
Set Context#initialize instance variables before squashing assigns

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -34,17 +34,18 @@ module Liquid
       @strict_variables    = false
       @resource_limits     = resource_limits || ResourceLimits.new(Template.default_resource_limits)
       @base_scope_depth    = 0
-      squash_instance_assigns_with_environments
+      @interrupts          = []
+      @filters             = []
+      @global_filter       = nil
+      @disabled_tags       = {}
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
         self.exception_renderer = ->(_e) { raise }
       end
 
-      @interrupts    = []
-      @filters       = []
-      @global_filter = nil
-      @disabled_tags = {}
+      # Do this last, since it could result in this object being passed to a Proc in the environment
+      squash_instance_assigns_with_environments
     end
     # rubocop:enable Metrics/ParameterLists
 


### PR DESCRIPTION
## Problem

While rebasing a liquid-c PR (https://github.com/Shopify/liquid-c/pull/60), I noticed in this test test failure

```
ContextTest#test_context_initialization_with_a_proc_in_environment:
NoMethodError: undefined method `each' for nil:NilClass
    /Users/dylants/src/liquid/lib/liquid/strainer_factory.rb:27:in `strainer_from_cache'
    /Users/dylants/src/liquid/lib/liquid/strainer_factory.rb:14:in `create'
    /Users/dylants/src/liquid/lib/liquid/context.rb:56:in `strainer'
    /Users/dylants/src/liquid/lib/liquid/context.rb:170:in `c_evaluate'
    /Users/dylants/src/liquid/lib/liquid/context.rb:170:in `[]'
    ../liquid/test/integration/context_test.rb:470:in `block in test_context_initialization_with_a_proc_in_environment'
    /Users/dylants/src/liquid/lib/liquid/context.rb:207:in `lookup_and_evaluate'
    /Users/dylants/src/liquid/lib/liquid/context.rb:271:in `block (2 levels) in squash_instance_assigns_with_environments'
    /Users/dylants/src/liquid/lib/liquid/context.rb:269:in `each'
    /Users/dylants/src/liquid/lib/liquid/context.rb:269:in `block in squash_instance_assigns_with_environments'
    /Users/dylants/src/liquid/lib/liquid/context.rb:268:in `each_key'
    /Users/dylants/src/liquid/lib/liquid/context.rb:268:in `squash_instance_assigns_with_environments'
    /Users/dylants/src/liquid/lib/liquid/context.rb:37:in `initialize'
    ../liquid/test/integration/context_test.rb:470:in `new'
    ../liquid/test/integration/context_test.rb:470:in `test_context_initialization_with_a_proc_in_environment'
```

that in `Liquid::Context#initialize` we call `squash_instance_assigns_with_environments`, which can evaluate `Proc`s in the environment, which means that we are passing in a partially initialized Context object into those `Proc` objects.

## Solution

Move the call to `squash_instance_assigns_with_environments` to the end of `Liquid::Context#initialize` so that we aren't exposing it in a partially initialized state.