### PR TITLE
Combine chained `append` filters into a single `append_all`

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -84,6 +84,7 @@ require 'liquid/usage'
 require 'liquid/register'
 require 'liquid/static_registers'
 require 'liquid/template_factory'
+require 'liquid/optimizer'
 
 # Load all the tags of the standard library
 #

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -5,7 +5,7 @@ module Liquid
     def self.parse(tokens, parse_context)
       doc = new(parse_context)
       doc.parse(tokens, parse_context)
-      Optimizer.new.optimize(doc)
+      doc
     end
 
     attr_reader :parse_context, :body

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -5,7 +5,7 @@ module Liquid
     def self.parse(tokens, parse_context)
       doc = new(parse_context)
       doc.parse(tokens, parse_context)
-      doc
+      Optimizer.new.optimize(doc)
     end
 
     attr_reader :parse_context, :body

--- a/lib/liquid/optimizer.rb
+++ b/lib/liquid/optimizer.rb
@@ -2,54 +2,18 @@
 
 module Liquid
   class Optimizer
-    def optimize(node)
-      case node
-      when Liquid::Template       then optimize(node.root.body)
-      when Liquid::Document       then optimize(node.body)
-      when Liquid::BlockBody      then optimize_block(node)
-      when Liquid::Variable       then optimize_variable(node)
-      when Liquid::Assign         then optimize_assign(node)
-      when Liquid::For            then optimize_for(node)
-      when Liquid::If             then optimize_if(node)
-      end
-      node
-    end
+    class << self
+      attr_accessor :enabled
 
-    def optimize_block(block)
-      block.nodelist.each { |node| optimize(node) }
-    end
+      def optimize_variable(node)
+        return unless enabled
 
-    def optimize_variable(node)
-      # Turn chained `| append: "..."| append: "..."`, into a single `append_all: [...]`
-      if node.filters.size > 1 && node.filters.all? { |f, _| f == "append" }
-        node.filters = [["append_all", node.filters.map { |f, (arg)| arg }]]
+        # Turn chained `| append: "..."| append: "..."`, into a single `append_all: [...]`
+        if node.filters.size > 1 && node.filters.all? { |f, _| f == "append" }
+          node.filters = [["append_all", node.filters.map { |f, (arg)| arg }]]
+        end
       end
     end
-
-    def optimize_assign(node)
-      optimize(node.from)
-    end
-
-    def optimize_for(node)
-      optimize(node.collection_name)
-      optimize_block(node)
-    end
-
-    def optimize_if(node)
-      node.blocks.each do |block|
-        optimize_condition(block)
-        optimize(block.attachment)
-      end
-    end
-
-    def optimize_condition(node)
-      case node
-      when Liquid::ElseCondition
-        # noop
-      when Liquid::Condition
-        optimize(node.left)
-        optimize(node.right) if node.right
-      end
-    end
+    self.enabled = true
   end
 end

--- a/lib/liquid/optimizer.rb
+++ b/lib/liquid/optimizer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Liquid
+  class Optimizer
+    def optimize(node)
+      case node
+      when Liquid::Template       then optimize(node.root.body)
+      when Liquid::Document       then optimize(node.body)
+      when Liquid::BlockBody      then optimize_block(node)
+      when Liquid::Variable       then optimize_variable(node)
+      when Liquid::Assign         then optimize_assign(node)
+      when Liquid::For            then optimize_for(node)
+      when Liquid::If             then optimize_if(node)
+      end
+      node
+    end
+
+    def optimize_block(block)
+      block.nodelist.each { |node| optimize(node) }
+    end
+
+    def optimize_variable(node)
+      # Turn chained `| append: "..."| append: "..."`, into a single `append_all: [...]`
+      if node.filters.size > 1 && node.filters.all? { |f, _| f == "append" }
+        node.filters = [["append_all", node.filters.map { |f, (arg)| arg }]]
+      end
+    end
+
+    def optimize_assign(node)
+      optimize(node.from)
+    end
+
+    def optimize_for(node)
+      optimize(node.collection_name)
+      optimize_block(node)
+    end
+
+    def optimize_if(node)
+      node.blocks.each do |block|
+        optimize_condition(block)
+        optimize(block.attachment)
+      end
+    end
+
+    def optimize_condition(node)
+      case node
+      when Liquid::ElseCondition
+        # noop
+      when Liquid::Condition
+        optimize(node.left)
+        optimize(node.right) if node.right
+      end
+    end
+  end
+end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -281,6 +281,10 @@ module Liquid
       input.to_s + string.to_s
     end
 
+    def append_all(input, *items)
+      input.to_s + items.join
+    end
+
     def concat(input, array)
       unless array.respond_to?(:to_ary)
         raise ArgumentError, "concat filter requires an array argument"

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -31,6 +31,8 @@ module Liquid
       @line_number   = parse_context.line_number
 
       parse_with_selected_parser(markup)
+
+      Optimizer.optimize_variable(self)
     end
 
     def raw

--- a/test/unit/optimizer_test.rb
+++ b/test/unit/optimizer_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class OptimizerUnitTest < Minitest::Test
+  include Liquid
+
+  def test_combines_append_filters
+    optimizer = Optimizer.new
+    var = Variable.new('hello | append: "a" | append: b', ParseContext.new)
+    var = optimizer.optimize(var)
+    assert_equal([
+      ['append_all', ["a", VariableLookup.new("b")]]
+    ], var.filters)
+  end
+end


### PR DESCRIPTION
This PR introduces the `Optimizer` class that can only optimize one thing for now: combine `| append: 'a' | append: 'b'` into a single `| append_all: ['a', 'b']` filter call.

This avoids all the intermediate allocations caused by several `append`.

Also introduce a new filter `append_all: [*items]`. (Maybe I should modify the original `append` instead?)

### Context

We discovered some merchants are using `append` like so:

```
{%- for product in collection.products -%}
  {%- for variant in product.variants -%}
    [... snip ...]
    {% assign prod = productId | append: productSku | append: productTitle | append: productPrice | append: productVendor | append: productCategory | append: productHandle | append: productVariant %}
    [... snip ...]
  {%- endfor -%}
{%- endfor -%}
```

And it's causing big slowdowns, in part because of GC. So this is a first attempt at reducing memory usage.

### Benchmark

With the following code:
```
@context['s'] = "x" * 10240
appends = "| append: 'x' " * 10
Template.parse("{{ s #{appends} }}").render(@context)
```

Results:
```
Warming up --------------------------------------
     with optimizer:     1.021k i/100ms
  without optimizer:   849.000  i/100ms
Calculating -------------------------------------
     with optimizer:     10.199k (± 1.5%) i/s -    102.100k in  10.013380s
  without optimizer:      8.523k (± 2.8%) i/s -     85.749k in  10.069714s

Comparison:
     with optimizer::    10198.7 i/s
  without optimizer::     8522.6 i/s - 1.20x  (± 0.00) slower
```

### Memory

Using `MemoryProfiler` with 1000 runs of code above:

/  | Allocated memory by `standardfilters.rb`
-- | --------------------
with optimizer | 10331000 bytes
without optimizer | 102865000 bytes

About 10x less memory