### PR TITLE
Fix liquid-c integration testing

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -6,7 +6,6 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { ruby: 2.4, allowed-failure: false }
           - { ruby: 2.5, allowed-failure: false }
           - { ruby: 2.6, allowed-failure: false }
           - { ruby: 2.7, allowed-failure: false }

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,12 @@ Rake::TestTask.new(:base_test) do |t|
   t.verbose    = false
 end
 
+Rake::TestTask.new(:integration_test) do |t|
+  t.libs << 'lib' << 'test'
+  t.test_files = FileList['test/integration/**/*_test.rb']
+  t.verbose    = false
+end
+
 desc('run test suite with warn error mode')
 task :warn_test do
   ENV['LIQUID_PARSER_MODE'] = 'warn'
@@ -40,12 +46,12 @@ task :test do
     ENV['LIQUID_C'] = '1'
 
     ENV['LIQUID_PARSER_MODE'] = 'lax'
-    Rake::Task['base_test'].reenable
-    Rake::Task['base_test'].invoke
+    Rake::Task['integration_test'].reenable
+    Rake::Task['integration_test'].invoke
 
     ENV['LIQUID_PARSER_MODE'] = 'strict'
-    Rake::Task['base_test'].reenable
-    Rake::Task['base_test'].invoke
+    Rake::Task['integration_test'].reenable
+    Rake::Task['integration_test'].invoke
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task(default: [:test, :rubocop])
 
 desc('run test suite with default parser')
 Rake::TestTask.new(:base_test) do |t|
-  t.libs << '.' << 'lib' << 'test'
+  t.libs << 'lib' << 'test'
   t.test_files = FileList['test/{integration,unit}/**/*_test.rb']
   t.verbose    = false
 end

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   # s.description = "A secure, non-evaling end user template engine with aesthetic markup."
 
-  s.required_ruby_version     = ">= 2.4.0"
+  s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 1.3.7"
 
   s.test_files  = Dir.glob("{test}/**/*")


### PR DESCRIPTION
## Problem

There are a couple of changes to liquid-c that are causing failures in this repos test suite, since it tests integration with liquid-c master:
* liquid-c dropped support for ruby 2.4, since it is no longer supported upstream
* liquid-c no longer keeps compatibility with the liquid unit tests, only the integration tests.

## Solution

I've dropped ruby 2.4 support here as well for simplicity.

I've also created a test:integration rake task that is used for running the integration tests with liquid-c.  While creating that new test task, I noticed that we strangely include the root directory of the repo in the load path, even though only "lib" is only the require_path in the gemspec, so I removed this root directory from both test tasks.