### PR TITLE
Test reporting of liquid error for filter call with wrong number of arguments

### DIFF
--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -153,6 +153,15 @@ class FiltersTest < Minitest::Test
     # tap still treated as a non-existent filter
     assert_equal("1000", Template.parse("{{var | tap}}").render!('var' => 1000))
   end
+
+  def test_liquid_argument_error
+    source = "{{ '' | size: 'too many args' }}"
+    exc = assert_raises(Liquid::ArgumentError) do
+      Template.parse(source).render!
+    end
+    assert_match(/\ALiquid error: wrong number of arguments /, exc.message)
+    assert_equal(exc.message, Template.parse(source).render)
+  end
 end
 
 class FiltersInTemplate < Minitest::Test


### PR DESCRIPTION
~~Depends on the corresponding liquid-c fix (https://github.com/Shopify/liquid-c/pull/76) for CI to pass~~
~~Depends on https://github.com/Shopify/liquid/pull/1310 to fix CI on master~~

## Problem

When trying to use https://github.com/Shopify/liquid-c/pull/59 in Shopify Storefront, I noticed a CI failure that caught a problem with that PR.  Specifically, that PR failed to implement the rescue in Liquid::StrainerTemplate#invoke

https://github.com/Shopify/liquid/blob/bd34cd56138ffde819a5ceea49dfbeeb834e55e5/lib/liquid/strainer_template.rb#L49-L51

## Solution

That rescue is at least needed right now to catch filter calls with the wrong number of arguments, so I added a test for that case.  In the future, we may want to make sure filter methods explicitly do this translation for argument error exceptions, so it doesn't hide internal errors.

I added only a partial assertion for the error message, since the number of arguments it says were passed to the method and the number required includes the `input` argument, which could be confusing for a template author.  For example, without the corresponding liquid-c test fix, the error message for `| size: 'too many args'` is "wrong number of arguments (given 2, expected 1)".