### PR TITLE
Raise when source is too large

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -15,6 +15,8 @@ module Liquid
   #   template.render('user_name' => 'bob')
   #
   class Template
+    MAX_SOURCE_CODE_BYTES = (2**24) - 1
+
     attr_accessor :root
     attr_reader :resource_limits, :warnings
 
@@ -106,6 +108,10 @@ module Liquid
     # Parse source code.
     # Returns self for easy chaining
     def parse(source, options = {})
+      if source.bytesize > MAX_SOURCE_CODE_BYTES
+        raise ArgumentError, "Source too large, max #{MAX_SOURCE_CODE_BYTES} bytes"
+      end
+
       @options      = options
       @profiling    = options[:profile]
       @line_numbers = options[:line_numbers] || @profiling

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -356,4 +356,12 @@ class TemplateTest < Minitest::Test
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('12345', result)
   end
+
+  def test_source_too_large
+    err = assert_raises(ArgumentError) do
+      Liquid::Template.parse("a" * (Liquid::Template::MAX_SOURCE_CODE_BYTES + 1))
+    end
+
+    assert_match(/Source too large, max \d+ bytes/, err.message)
+  end
 end


### PR DESCRIPTION
Raise when source is larger than 16MB in `Liquid::Template#parse`. This will let us use this assumption in liquid-c.

See Shopify/liquid-c#79.
