### PR TITLE
Fix strict parsing of find variable with a name expression

### DIFF
--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -50,7 +50,8 @@ module Liquid
       token = @tokens[@p]
       case token[0]
       when :id
-        variable_signature
+        str = consume
+        str << variable_lookups
       when :string, :number
         consume
       when :open_round
@@ -76,16 +77,19 @@ module Liquid
       str
     end
 
-    def variable_signature
-      str = consume(:id)
-      while look(:open_square)
-        str << consume
-        str << expression
-        str << consume(:close_square)
-      end
-      if look(:dot)
-        str << consume
-        str << variable_signature
+    def variable_lookups
+      str = +""
+      loop do
+        if look(:open_square)
+          str << consume
+          str << expression
+          str << consume(:close_square)
+        elsif look(:dot)
+          str << consume
+          str << consume(:id)
+        else
+          break
+        end
       end
       str
     end

--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -46,16 +46,14 @@ module Liquid
       tok[0] == type
     end
 
-    SINGLE_TOKEN_EXPRESSION_TYPES = [:string, :number].freeze
-    private_constant :SINGLE_TOKEN_EXPRESSION_TYPES
-
     def expression
       token = @tokens[@p]
-      if token[0] == :id
+      case token[0]
+      when :id
         variable_signature
-      elsif SINGLE_TOKEN_EXPRESSION_TYPES.include?(token[0])
+      when :string, :number
         consume
-      elsif token.first == :open_round
+      when :open_round
         consume
         first = expression
         consume(:dotdot)

--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -52,6 +52,11 @@ module Liquid
       when :id
         str = consume
         str << variable_lookups
+      when :open_square
+        str = consume
+        str << expression
+        str << consume(:close_square)
+        str << variable_lookups
       when :string, :number
         consume
       when :open_round

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -95,4 +95,8 @@ class VariableTest < Minitest::Test
   def test_render_symbol
     assert_template_result('bar', '{{ foo }}', 'foo' => :bar)
   end
+
+  def test_dynamic_find_var
+    assert_template_result('bar', '{{ [key] }}', 'key' => 'foo', 'foo' => 'bar')
+  end
 end


### PR DESCRIPTION
## Problem

As discussed in https://github.com/Shopify/liquid-c/pull/60#discussion_r502163710 the strict parser doesn't support finding a variable with an expression key like `{{ [x] }}`.   This seems like a bug, since I don't believe it was the intention of the strict parser to remove any features.  This is also an incompatibility with liquid-c, where its strict parser has allowed this type of dynamic find variable.

## Solution

I've added a regression test, which fails with the syntax error we were seeing without the corresponding fix.

I also turned Liquid::Parser#variable_signature into a `variable_lookups` method that no longer assumes the it starts with a dot lookup.  I've refactored Liquid::Parser#expression to use a case statement, then added the new `:open_square` case.