### PR TITLE
Allow an empty variable tag during strict parsing for liquid-c compat

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -63,6 +63,8 @@ module Liquid
       @filters = []
       p = Parser.new(markup)
 
+      return if p.look(:end_of_string)
+
       @name = Expression.parse(p.expression)
       while p.consume?(:pipe)
         filtername = p.consume(:id)

--- a/test/integration/parsing_quirks_test.rb
+++ b/test/integration/parsing_quirks_test.rb
@@ -118,6 +118,10 @@ class ParsingQuirksTest < Minitest::Test
     end
   end
 
+  def test_blank_variable_markup
+    assert_template_result('', "{{}}")
+  end
+
   def test_contains_in_id
     assert_template_result(' YES ', '{% if containsallshipments == true %} YES {% endif %}', 'containsallshipments' => true)
   end


### PR DESCRIPTION
## Problem

The following cause a syntax error in this gem (`Liquid syntax error: [:end_of_string] is not a valid expression in "{{}}"`) but is allowed by the strict parser in liquid-c

```ruby
Liquid::Template.parse("{{}}", error_mode: :strict).render
```

This has been the case since strict variable parsing was added to liquid-c, as can be seen by this conditional (https://github.com/Shopify/liquid-c/pull/13/files#diff-28d39ab3c9a2d3da34aa868bd292b576cb5a5ae2ea8be3aeb4bcf5bcc77985b3R15)

Unfortunately, that means switching between the liquid-c gem and the liquid gem for rendering can cause a breaking change.

## Solution

Allow this edge case for compatibility.