### PR TITLE
Extract method for raising a syntax error in the assign tag for liquid-c

### DIFF
--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -12,15 +12,20 @@ module Liquid
   class Assign < Tag
     Syntax = /(#{VariableSignature}+)\s*=\s*(.*)\s*/om
 
+    # @api private
+    def self.raise_syntax_error(parse_context)
+      raise Liquid::SyntaxError, parse_context.locale.t('errors.syntax.assign')
+    end
+
     attr_reader :to, :from
 
-    def initialize(tag_name, markup, options)
+    def initialize(tag_name, markup, parse_context)
       super
       if markup =~ Syntax
         @to   = Regexp.last_match(1)
-        @from = Variable.new(Regexp.last_match(2), options)
+        @from = Variable.new(Regexp.last_match(2), parse_context)
       else
-        raise SyntaxError, options[:locale].t('errors.syntax.assign')
+        self.class.raise_syntax_error(parse_context)
       end
     end
 


### PR DESCRIPTION
I would like to compile the assign tag directly from C code in liquid-c, but want to delegate the raising of the syntax error to ruby code.  In order to avoid duplication, it makes sense to extract the raise method in this repo so that it can be re-used.