### PR TITLE
Stash array of tag names in a constant

### DIFF
--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -36,8 +36,11 @@ module Liquid
       end
     end
 
+    ELSE_TAG_NAMES = ['elsif', 'else'].freeze
+    private_constant :ELSE_TAG_NAMES
+
     def unknown_tag(tag, markup, tokens)
-      if ['elsif', 'else'].include?(tag)
+      if ELSE_TAG_NAMES.include?(tag)
         push_block(tag, markup)
       else
         super


### PR DESCRIPTION
Instead of allocating a new `['elsif', 'else']` for every `{% else %}` or `{% elsif %}` construct in a template, stash the array in a private constant and refer to that constant when needed.