### PR TITLE
Avoid allocating arrays of key value pairs in assign_score_of

### DIFF
--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -45,10 +45,17 @@ module Liquid
     def assign_score_of(val)
       if val.instance_of?(String)
         val.bytesize
-      elsif val.instance_of?(Array) || val.instance_of?(Hash)
+      elsif val.instance_of?(Array)
         sum = 1
         # Uses #each to avoid extra allocations.
         val.each { |child| sum += assign_score_of(child) }
+        sum
+      elsif val.instance_of?(Hash)
+        sum = 1
+        val.each do |key, entry_value|
+          sum += assign_score_of(key)
+          sum += assign_score_of(entry_value)
+        end
         sum
       else
         1

--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -88,8 +88,8 @@ class AssignTest < Minitest::Test
 
   def test_assign_score_of_hash
     assert_equal(1, assign_score_of({}))
-    assert_equal(6, assign_score_of('int' => 123))
-    assert_equal(14, assign_score_of('int' => 123, 'str' => 'abcd'))
+    assert_equal(5, assign_score_of('int' => 123))
+    assert_equal(12, assign_score_of('int' => 123, 'str' => 'abcd'))
   end
 
   private

--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -47,4 +47,32 @@ class AssignTest < Minitest::Test
       assert Template.parse("{% assign foo = ('X' | downcase) %}")
     end
   end
-end # AssignTest
+
+  def test_assign_score_exceeding_resource_limit
+    t = Template.parse("{% assign foo = 42 %}{% assign bar = 23 %}")
+    t.resource_limits.assign_score_limit = 1
+    assert_equal("Liquid error: Memory limits exceeded", t.render)
+    assert(t.resource_limits.reached?)
+
+    t.resource_limits.assign_score_limit = 2
+    assert_equal("", t.render!)
+    refute_nil(t.resource_limits.assign_score)
+  end
+
+  def test_assign_score_exceeding_limit_from_composite_object
+    t = Template.parse("{% assign foo = 'aaaa' | reverse %}")
+
+    t.resource_limits.assign_score_limit = 3
+    assert_equal("Liquid error: Memory limits exceeded", t.render)
+    assert(t.resource_limits.reached?)
+
+    t.resource_limits.assign_score_limit = 5
+    assert_equal("", t.render!)
+  end
+
+  def test_assign_score_counts_bytes_not_characters
+    t = Template.parse("{% assign foo = 'すごい' %}")
+    t.render
+    assert_equal(9, t.resource_limits.assign_score)
+  end
+end

--- a/test/integration/capture_test.rb
+++ b/test/integration/capture_test.rb
@@ -49,4 +49,10 @@ class CaptureTest < Minitest::Test
     rendered        = template.render!
     assert_equal("3-3", rendered.gsub(/\s/, ''))
   end
-end # CaptureTest
+
+  def test_increment_assign_score_by_bytes_not_characters
+    t = Template.parse("{% capture foo %}すごい{% endcapture %}")
+    t.render!
+    assert_equal(9, t.resource_limits.assign_score)
+  end
+end

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -135,38 +135,6 @@ class TemplateTest < Minitest::Test
     refute_nil(t.resource_limits.render_score)
   end
 
-  def test_resource_limits_assign_score
-    t = Template.parse("{% assign foo = 42 %}{% assign bar = 23 %}")
-    t.resource_limits.assign_score_limit = 1
-    assert_equal("Liquid error: Memory limits exceeded", t.render)
-    assert(t.resource_limits.reached?)
-
-    t.resource_limits.assign_score_limit = 2
-    assert_equal("", t.render!)
-    refute_nil(t.resource_limits.assign_score)
-  end
-
-  def test_resource_limits_assign_score_counts_bytes_not_characters
-    t = Template.parse("{% assign foo = 'すごい' %}")
-    t.render
-    assert_equal(9, t.resource_limits.assign_score)
-
-    t = Template.parse("{% capture foo %}すごい{% endcapture %}")
-    t.render
-    assert_equal(9, t.resource_limits.assign_score)
-  end
-
-  def test_resource_limits_assign_score_nested
-    t = Template.parse("{% assign foo = 'aaaa' | reverse %}")
-
-    t.resource_limits.assign_score_limit = 3
-    assert_equal("Liquid error: Memory limits exceeded", t.render)
-    assert(t.resource_limits.reached?)
-
-    t.resource_limits.assign_score_limit = 5
-    assert_equal("", t.render!)
-  end
-
   def test_resource_limits_aborts_rendering_after_first_error
     t = Template.parse("{% for a in (1..100) %} foo1 {% endfor %} bar {% for a in (1..100) %} foo2 {% endfor %}")
     t.resource_limits.render_score_limit = 50


### PR DESCRIPTION
## Problem

The purpose of the assign score resource limit is to limit how much is allocated. However, calculating the assign score of a hash was allocating arrays for each key-value pair of the hash, so we were allocating more objects by trying to limit the allocation of objects.

## Solution

Use a different code path in `assign_score_of` for a Hash so that we can call yield with a block that takes two parameters, in order to avoid forcing ruby to allocating a key-value pair.  This change also makes it clearer what is being counted.

This came initially from trying to add more comprehensive tests for the `assign_score_of` assign tag method, which are naturally included in this PR.  I created an `assign_score_of` test helper method that made it easy to test with new objects.  In the test helper, I wrapped the object in a drop so it would be more opaque to liquid, such that it makes sense to assume the object is being allocated, although technically I could have tested this by just moving the value from one variable to another where we ideally would be able to tell the the object isn't being duplicated.

I've also moved the assign score tests for the assign tag and capture tag into the test classes for these tags.