### PR TITLE
Remove redundant comment in Liquid::Template

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -191,7 +191,6 @@ module Liquid
 
       begin
         # render the nodelist.
-        # for performance reasons we get an array back here. join will make a string out of it.
         with_profiling(context) do
           @root.render_to_output_buffer(context, output || +'')
         end


### PR DESCRIPTION
Comment doesn't reflect current implementation.