### PR TITLE
Stash exception_renderer lambda in a constant

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -42,7 +42,7 @@ module Liquid
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 
-  EXCEPTION_RENDERER_LAMBDA = ->(_e) { raise }
+  RAISE_EXCEPTION_LAMBDA = ->(_e) { raise }
 
   singleton_class.send(:attr_accessor, :cache_classes)
   self.cache_classes = true

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -42,6 +42,8 @@ module Liquid
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
   VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
 
+  EXCEPTION_RENDERER_LAMBDA = ->(_e) { raise }
+
   singleton_class.send(:attr_accessor, :cache_classes)
   self.cache_classes = true
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -41,7 +41,7 @@ module Liquid
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
-        self.exception_renderer = ->(_e) { raise }
+        self.exception_renderer = Liquid::EXCEPTION_RENDERER_LAMBDA
       end
 
       # Do this last, since it could result in this object being passed to a Proc in the environment

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -41,7 +41,7 @@ module Liquid
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors
-        self.exception_renderer = Liquid::EXCEPTION_RENDERER_LAMBDA
+        self.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
       end
 
       # Do this last, since it could result in this object being passed to a Proc in the environment

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -153,7 +153,7 @@ module Liquid
         c = args.shift
 
         if @rethrow_errors
-          c.exception_renderer = ->(_e) { raise }
+          c.exception_renderer = Liquid::EXCEPTION_RENDERER_LAMBDA
         end
 
         c

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -153,7 +153,7 @@ module Liquid
         c = args.shift
 
         if @rethrow_errors
-          c.exception_renderer = Liquid::EXCEPTION_RENDERER_LAMBDA
+          c.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
         end
 
         c


### PR DESCRIPTION
In order to avoid allocating it for every instance of `Liquid::Context` and `Liquid::Template`