### PR TITLE
Freeze block body after parsing completes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ group :test do
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'pz-block-body-buffer'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'master'
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ group :test do
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'master'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'pz-block-body-buffer'
   end
 end

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -11,7 +11,7 @@ module Liquid
 
     def parse(tokens)
       @body = new_body
-      while parse_body(@body, tokens, partial: true)
+      while parse_body(@body, tokens)
       end
       @body.freeze
     end
@@ -68,9 +68,7 @@ module Liquid
     end
 
     # @api public
-    def parse_body(body, tokens, partial: false)
-      block_terminated = true
-
+    def parse_body(body, tokens)
       if parse_context.depth >= MAX_DEPTH
         raise StackLevelError, "Nesting too deep"
       end
@@ -79,10 +77,7 @@ module Liquid
         body.parse(tokens, parse_context) do |end_tag_name, end_tag_params|
           @blank &&= body.blank?
 
-          if end_tag_name == block_delimiter
-            block_terminated = false
-            next
-          end
+          return false if end_tag_name == block_delimiter
           raise_tag_never_closed(block_name) unless end_tag_name
 
           # this tag is not registered with the system
@@ -93,12 +88,7 @@ module Liquid
         parse_context.depth -= 1
       end
 
-      unless partial
-        body.remove_blank_strings if body.blank?
-        body.freeze
-      end
-
-      block_terminated
+      true
     end
   end
 end

--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -13,6 +13,7 @@ module Liquid
       @body = new_body
       while parse_body(@body, tokens)
       end
+      @body.freeze(parse_context)
     end
 
     # For backwards compatibility

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -16,11 +16,10 @@ module Liquid
     def initialize
       @nodelist = []
       @blank    = true
-      @frozen   = false
     end
 
     def parse(tokenizer, parse_context, &block)
-      raise FrozenError, "can't modify frozen Liquid::BlockBody" if @frozen
+      raise FrozenError, "can't modify frozen Liquid::BlockBody" if frozen?
 
       parse_context.line_number = tokenizer.line_number
 
@@ -31,8 +30,9 @@ module Liquid
       end
     end
 
-    def freeze(_context)
-      @frozen = true
+    def freeze
+      @nodelist.freeze
+      super
     end
 
     private def parse_for_liquid_tag(tokenizer, parse_context)
@@ -199,7 +199,7 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      raise "Can only render when frozen" unless @frozen
+      raise "Can only render when frozen" unless frozen?
 
       context.resource_limits.increment_render_score(@nodelist.length)
 

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -16,9 +16,12 @@ module Liquid
     def initialize
       @nodelist = []
       @blank    = true
+      @frozen   = false
     end
 
     def parse(tokenizer, parse_context, &block)
+      raise FrozenError, "can't modify frozen Liquid::BlockBody" if @frozen
+
       parse_context.line_number = tokenizer.line_number
 
       if tokenizer.for_liquid_tag
@@ -26,6 +29,10 @@ module Liquid
       else
         parse_for_document(tokenizer, parse_context, &block)
       end
+    end
+
+    def freeze(_context)
+      @frozen = true
     end
 
     private def parse_for_liquid_tag(tokenizer, parse_context)
@@ -192,6 +199,8 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
+      raise "Can only render when frozen" unless @frozen
+
       context.resource_limits.increment_render_score(@nodelist.length)
 
       idx = 0

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -199,7 +199,7 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      raise "Can only render when frozen" unless frozen?
+      freeze unless frozen?
 
       context.resource_limits.increment_render_score(@nodelist.length)
 

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -22,7 +22,7 @@ module Liquid
     def parse(tokenizer, parse_context)
       while parse_body(tokenizer)
       end
-      @body.freeze(parse_context)
+      @body.freeze
     rescue SyntaxError => e
       e.line_number ||= parse_context.line_number
       raise

--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -22,6 +22,7 @@ module Liquid
     def parse(tokenizer, parse_context)
       while parse_body(tokenizer)
       end
+      @body.freeze(parse_context)
     rescue SyntaxError => e
       e.line_number ||= parse_context.line_number
       raise

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -21,10 +21,10 @@ module Liquid
     def parse(tokens)
       body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
-      if blank?
-        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      @blocks.each do |condition|
+        condition.attachment.remove_blank_strings if blank?
+        condition.attachment.freeze
       end
-      @blocks.each { |condition| condition.attachment.freeze }
     end
 
     def nodelist

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -20,7 +20,11 @@ module Liquid
 
     def parse(tokens)
       body = new_body
-      body = @blocks.last.attachment while parse_body(body, tokens)
+      while parse_body(body, tokens)
+        body.freeze(parse_context)
+        body = @blocks.last.attachment
+      end
+      body.freeze(parse_context)
       if blank?
         @blocks.each { |condition| condition.attachment.remove_blank_strings }
       end

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -20,14 +20,7 @@ module Liquid
 
     def parse(tokens)
       body = new_body
-      while parse_body(body, tokens)
-        body.freeze(parse_context)
-        body = @blocks.last.attachment
-      end
-      body.freeze(parse_context)
-      if blank?
-        @blocks.each { |condition| condition.attachment.remove_blank_strings }
-      end
+      body = @blocks.last.attachment while parse_body(body, tokens)
     end
 
     def nodelist

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -21,6 +21,10 @@ module Liquid
     def parse(tokens)
       body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
+      if blank?
+        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      end
+      @blocks.each { |condition| condition.attachment.freeze }
     end
 
     def nodelist

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -61,12 +61,6 @@ module Liquid
     def parse(tokens)
       if parse_body(@for_block, tokens)
         parse_body(@else_block, tokens)
-        @else_block.freeze(parse_context)
-      end
-      @for_block.freeze(parse_context)
-      if blank?
-        @for_block.remove_blank_strings
-        @else_block&.remove_blank_strings
       end
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -61,7 +61,9 @@ module Liquid
     def parse(tokens)
       if parse_body(@for_block, tokens)
         parse_body(@else_block, tokens)
+        @else_block.freeze(parse_context)
       end
+      @for_block.freeze(parse_context)
       if blank?
         @for_block.remove_blank_strings
         @else_block&.remove_blank_strings

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -62,6 +62,12 @@ module Liquid
       if parse_body(@for_block, tokens)
         parse_body(@else_block, tokens)
       end
+      if blank?
+        @for_block.remove_blank_strings
+        @else_block&.remove_blank_strings
+      end
+      @for_block.freeze
+      @else_block&.freeze
     end
 
     def nodelist

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,6 +31,7 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
+      @blocks.each { |block| block.attachment.freeze(parse_context) }
       if blank?
         @blocks.each { |condition| condition.attachment.remove_blank_strings }
       end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,10 +31,6 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
-      @blocks.each { |block| block.attachment.freeze(parse_context) }
-      if blank?
-        @blocks.each { |condition| condition.attachment.remove_blank_strings }
-      end
     end
 
     def unknown_tag(tag, markup, tokens)

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,6 +31,10 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
+      if blank?
+        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      end
+      @blocks.each { |block| block.attachment.freeze }
     end
 
     def unknown_tag(tag, markup, tokens)

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,10 +31,10 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
-      if blank?
-        @blocks.each { |condition| condition.attachment.remove_blank_strings }
+      @blocks.each do |block|
+        block.attachment.remove_blank_strings if blank?
+        block.attachment.freeze
       end
-      @blocks.each { |block| block.attachment.freeze }
     end
 
     def unknown_tag(tag, markup, tokens)


### PR DESCRIPTION
Adds `BlockBody#freeze` that freezes the `BlockBody` to prevent modifications. Additionally, only frozen `BlockBody` can be rendered. Used in Shopify/liquid-c#102.