### PR TITLE
Add Liquid::ParseContext#parse_expression for liquid-c node disabling

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -45,8 +45,8 @@ module Liquid
       @@operators
     end
 
-    def self.parse_expression(markup)
-      @@method_literals[markup] || Expression.parse(markup)
+    def self.parse_expression(parse_context, markup)
+      @@method_literals[markup] || parse_context.parse_expression(markup)
     end
 
     attr_reader :attachment, :child_condition

--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -23,6 +23,10 @@ module Liquid
       Liquid::BlockBody.new
     end
 
+    def parse_expression(markup)
+      Expression.parse(markup)
+    end
+
     def partial=(value)
       @partial = value
       @options = value ? partial_options : @template_options

--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -55,5 +55,11 @@ module Liquid
     def blank?
       false
     end
+
+    private
+
+    def parse_expression(markup)
+      parse_context.parse_expression(markup)
+    end
   end
 end

--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -12,7 +12,7 @@ module Liquid
       @blocks = []
 
       if markup =~ Syntax
-        @left = Expression.parse(Regexp.last_match(1))
+        @left = parse_expression(Regexp.last_match(1))
       else
         raise SyntaxError, options[:locale].t("errors.syntax.case")
       end
@@ -68,7 +68,7 @@ module Liquid
 
         markup = Regexp.last_match(2)
 
-        block = Condition.new(@left, '==', Condition.parse_expression(Regexp.last_match(1)))
+        block = Condition.new(@left, '==', Condition.parse_expression(parse_context, Regexp.last_match(1)))
         block.attach(body)
         @blocks << block
       end

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -24,7 +24,7 @@ module Liquid
       case markup
       when NamedSyntax
         @variables = variables_from_string(Regexp.last_match(2))
-        @name      = Expression.parse(Regexp.last_match(1))
+        @name      = parse_expression(Regexp.last_match(1))
       when SimpleSyntax
         @variables = variables_from_string(markup)
         @name      = @variables.to_s
@@ -61,7 +61,7 @@ module Liquid
     def variables_from_string(markup)
       markup.split(',').collect do |var|
         var =~ /\s*(#{QuotedFragment})\s*/o
-        Regexp.last_match(1) ? Expression.parse(Regexp.last_match(1)) : nil
+        Regexp.last_match(1) ? parse_expression(Regexp.last_match(1)) : nil
       end.compact
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -97,7 +97,7 @@ module Liquid
         collection_name  = Regexp.last_match(2)
         @reversed        = !!Regexp.last_match(3)
         @name            = "#{@variable_name}-#{collection_name}"
-        @collection_name = Expression.parse(collection_name)
+        @collection_name = parse_expression(collection_name)
         markup.scan(TagAttributes) do |key, value|
           set_attribute(key, value)
         end
@@ -112,7 +112,7 @@ module Liquid
       raise SyntaxError, options[:locale].t("errors.syntax.for_invalid_in") unless p.id?('in')
 
       collection_name  = p.expression
-      @collection_name = Expression.parse(collection_name)
+      @collection_name = parse_expression(collection_name)
 
       @name     = "#{@variable_name}-#{collection_name}"
       @reversed = p.id?('reversed')
@@ -198,10 +198,10 @@ module Liquid
         @from = if expr == 'continue'
           :continue
         else
-          Expression.parse(expr)
+          parse_expression(expr)
         end
       when 'limit'
-        @limit = Expression.parse(expr)
+        @limit = parse_expression(expr)
       end
     end
 

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -71,7 +71,7 @@ module Liquid
     end
 
     def parse_expression(markup)
-      Condition.parse_expression(markup)
+      Condition.parse_expression(parse_context, markup)
     end
 
     def lax_parse(markup)

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -32,12 +32,12 @@ module Liquid
         variable_name = Regexp.last_match(3)
 
         @alias_name         = Regexp.last_match(5)
-        @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
-        @template_name_expr = Expression.parse(template_name)
+        @variable_name_expr = variable_name ? parse_expression(variable_name) : nil
+        @template_name_expr = parse_expression(template_name)
         @attributes         = {}
 
         markup.scan(TagAttributes) do |key, value|
-          @attributes[key] = Expression.parse(value)
+          @attributes[key] = parse_expression(value)
         end
 
       else

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -19,13 +19,13 @@ module Liquid
       variable_name = Regexp.last_match(4)
 
       @alias_name = Regexp.last_match(6)
-      @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
-      @template_name_expr = Expression.parse(template_name)
+      @variable_name_expr = variable_name ? parse_expression(variable_name) : nil
+      @template_name_expr = parse_expression(template_name)
       @for = (with_or_for == FOR)
 
       @attributes = {}
       markup.scan(TagAttributes) do |key, value|
-        @attributes[key] = Expression.parse(value)
+        @attributes[key] = parse_expression(value)
       end
     end
 

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -10,10 +10,10 @@ module Liquid
       super
       if markup =~ Syntax
         @variable_name   = Regexp.last_match(1)
-        @collection_name = Expression.parse(Regexp.last_match(2))
+        @collection_name = parse_expression(Regexp.last_match(2))
         @attributes      = {}
         markup.scan(TagAttributes) do |key, value|
-          @attributes[key] = Expression.parse(value)
+          @attributes[key] = parse_expression(value)
         end
       else
         raise SyntaxError, options[:locale].t("errors.syntax.table_row")


### PR DESCRIPTION
## Problem

We would like to be able to measure the performance benefit of liquid VM rendering in production by disabling liquid VM compilation at runtime.  However, tags are parsing expressions with `Liquid::Expression.parse`, which doesn't give liquid-c access to the parse context in order to determine whether liquid VM compilation is enabled or not.

## Solution

Add `Liquid::ParseContext#parse_expression` and use it in the liquid tags to parse expressions.