### PR TITLE
Run workflows for pull requests from repo forks

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -1,5 +1,5 @@
 name: Liquid
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently GitHub Actions are only triggered for pull requests from branches pushed to the parent repository.

The proposed change enables Actions for pull requests from branches in forks of the main repository. 