### PR TITLE
Parse only string expression markups

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -17,9 +17,9 @@ module Liquid
     RANGES_REGEX         = /\A\s*\(\s*(\S+)\s*\.\.\s*(\S+)\s*\)\s*\z/
 
     def self.parse(markup)
+      return markup unless markup.is_a?(String)
+
       case markup
-      when nil
-        nil
       when SINGLE_QUOTED_STRING, DOUBLE_QUOTED_STRING
         Regexp.last_match(1)
       when INTEGERS_REGEX
@@ -30,11 +30,7 @@ module Liquid
         Regexp.last_match(1).to_f
       else
         markup = markup.strip
-        if LITERALS.key?(markup)
-          LITERALS[markup]
-        else
-          VariableLookup.parse(markup)
-        end
+        LITERALS.key?(markup) ? LITERALS[markup] : VariableLookup.parse(markup)
       end
     end
   end


### PR DESCRIPTION
In the *unlikely event* that a `Liquid::Expression` markup is neither `nil`, nor `String` (say it is `false` or `true` or something else), then bail out immediately especially since `markup = markup.strip` will fail if `markup` isn't a string.

Additionally, since the conditional expressions in the `else` branch of the `case` statement are rather short, I refactored the conditional expression into a ternary expression.