### PR TITLE
Attempt to strict parse variables before lax parsing in lax error mode

### DIFF
--- a/lib/liquid/parser_switching.rb
+++ b/lib/liquid/parser_switching.rb
@@ -2,6 +2,18 @@
 
 module Liquid
   module ParserSwitching
+    def strict_parse_with_error_mode_fallback(markup)
+      strict_parse_with_error_context(markup)
+    rescue SyntaxError => e
+      case parse_context.error_mode
+      when :strict
+        raise
+      when :warn
+        parse_context.warnings << e
+      end
+      lax_parse(markup)
+    end
+
     def parse_with_selected_parser(markup)
       case parse_context.error_mode
       when :strict then strict_parse_with_error_context(markup)

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -30,7 +30,7 @@ module Liquid
       @parse_context = parse_context
       @line_number   = parse_context.line_number
 
-      parse_with_selected_parser(markup)
+      strict_parse_with_error_mode_fallback(markup)
     end
 
     def raw

--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -48,6 +48,11 @@ class AssignTest < Minitest::Test
     end
   end
 
+  def test_expression_with_whitespace_in_square_brackets
+    source = "{% assign r = a[ 'b' ] %}{{ r }}"
+    assert_template_result('result', source, 'a' => { 'b' => 'result' })
+  end
+
   def test_assign_score_exceeding_resource_limit
     t = Template.parse("{% assign foo = 42 %}{% assign bar = 23 %}")
     t.resource_limits.assign_score_limit = 1

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -21,6 +21,11 @@ class VariableTest < Minitest::Test
     assert_equal('  worked wonderfully  ', template.render!('test' => 'worked wonderfully'))
   end
 
+  def test_expression_with_whitespace_in_square_brackets
+    assert_template_result('result', "{{ a[ 'b' ] }}", 'a' => { 'b' => 'result' })
+    assert_template_result('result', "{{ a[ [ 'b' ] ] }}", 'b' => 'c', 'a' => { 'c' => 'result' })
+  end
+
   def test_ignore_unknown
     template = Template.parse(%({{ test }}))
     assert_equal('', template.render!)


### PR DESCRIPTION
Fixes #1334

## Problem

As detailed in https://github.com/Shopify/liquid/issues/1334#issuecomment-717936754, the strict parser supports recursive parsing of square bracket lookups with whitespace within the square brackets, which the lax parser doesn't support.  Liquid-c made this available by strict parsing with a lax parse fallback, but ruby liquid was using the lax parser first in lax error mode.

## Solution

Adopt the liquid-c approach of strict parsing with a lax parse fallback for Liquid::Variable for compatibility between the implementations.