### PR TITLE
Fix a leaky test that set Tempate.error_mode without resetting it

### DIFF
--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -257,9 +257,8 @@ class TemplateTest < Minitest::Test
   end
 
   def test_nil_value_does_not_raise
-    Liquid::Template.error_mode = :strict
-    t                           = Template.parse("some{{x}}thing")
-    result                      = t.render!({ 'x' => nil }, strict_variables: true)
+    t      = Template.parse("some{{x}}thing", error_mode: :strict)
+    result = t.render!({ 'x' => nil }, strict_variables: true)
 
     assert_equal(0, t.errors.count)
     assert_equal('something', result)


### PR DESCRIPTION
## Problem

I tried running the tests in https://github.com/Shopify/liquid/pull/1338 without the corresponding lib changes and found that the test failures were flaky.  I tracked the reason down to a test that set `Tempate.error_mode = :lax` without resetting it, which resulted in tests that weren't tested in lax mode.

## Solution

Pass the error mode in as a parse option in that formerly leaky test.