### PR TITLE
Fix FrozenError for blank case tag with multiple expression when tag

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -22,8 +22,11 @@ module Liquid
       body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
       @blocks.each do |condition|
-        condition.attachment.remove_blank_strings if blank?
-        condition.attachment.freeze
+        body = condition.attachment
+        unless body.frozen?
+          body.remove_blank_strings if blank?
+          body.freeze
+        end
       end
     end
 

--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -213,6 +213,11 @@ class StandardTagTest < Minitest::Test
     assert_template_result('', code, 'condition' => 'something else')
   end
 
+  def test_case_when_comma_and_blank_body
+    code = '{% case condition %}{% when 1, 2 %} {% assign r = "result" %} {% endcase %}{{ r }}'
+    assert_template_result('result', code, 'condition' => 2)
+  end
+
   def test_assign
     assert_template_result('variable', '{% assign a = "variable"%}{{a}}')
   end


### PR DESCRIPTION
## Problem

We get a FrozenError exception for blank case tags with a multi-expression when tag.  E.g.

```liquid
{% case foo %}{% when 'a', 'b' %} {% endcase %}
```

which will result in the exception

```
	 4: from /Users/dylants/src/liquid/lib/liquid/tags/case.rb:24:in `parse'
	 3: from /Users/dylants/src/liquid/lib/liquid/tags/case.rb:24:in `each'
	 2: from /Users/dylants/src/liquid/lib/liquid/tags/case.rb:25:in `block in parse'
	 1: from /Users/dylants/src/liquid/lib/liquid/block_body.rb:194:in `remove_blank_strings'
/Users/dylants/src/liquid/lib/liquid/block_body.rb:194:in `reject!': can't modify frozen Array: [] (FrozenError)
```

## Solution

Check if the block body is frozen before trying to freeze it again for the case tag.