### PR TITLE
Use Array#each instead of Enumerable#inject to avoid an object allocation

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -83,9 +83,11 @@ module Liquid
     end
 
     def render(context)
-      obj = @filters.inject(context.evaluate(@name)) do |output, (filter_name, filter_args, filter_kwargs)|
+      obj = context.evaluate(@name)
+
+      @filters.each do |filter_name, filter_args, filter_kwargs|
         filter_args = evaluate_filter_expressions(context, filter_args, filter_kwargs)
-        context.invoke(filter_name, output, *filter_args)
+        obj = context.invoke(filter_name, obj, *filter_args)
       end
 
       context.apply_global_filter(obj)


### PR DESCRIPTION
Enumerable#inject allocate a memo object to pass to `rb_block_call` which can be avoided by using Array#each.