### PR TITLE
Fix tags in comment

### DIFF
--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -36,6 +36,8 @@ class StandardTagTest < Minitest::Test
     assert_template_result('', '{%comment%}{% endif %}{%endcomment%}')
     assert_template_result('', '{% comment %}{% endwhatever %}{% endcomment %}')
     assert_template_result('', '{% comment %}{% raw %} {{%%%%}}  }} { {% endcomment %} {% comment {% endraw %} {% endcomment %}')
+    assert_template_result('', '{% comment %}{% " %}{% endcomment %}')
+    assert_template_result('', '{% comment %}{%%}{% endcomment %}')
 
     assert_template_result('foobar', 'foo{%comment%}comment{%endcomment%}bar')
     assert_template_result('foobar', 'foo{% comment %}comment{% endcomment %}bar')


### PR DESCRIPTION
AFL caught a case where Liquid tags in comments were not treated as plain text. The problem is that tags like `{%%}` do not match on `FullToken` so we get parsing errors like:

```
Liquid::SyntaxError: Liquid syntax error (line 1): Tag '{%%}' was not properly terminated with regexp: /\%\}/
```
