### PR TITLE
Fix regex for matching endraw tags

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -3,7 +3,7 @@
 module Liquid
   class Raw < Block
     Syntax = /\A\s*\z/
-    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
+    EndRawTag = /\A(.*)#{TagStart}\s*endraw.*?#{TagEnd}\z/om
 
     def initialize(tag_name, markup, parse_context)
       super
@@ -14,7 +14,7 @@ module Liquid
     def parse(tokens)
       @body = +''
       while (token = tokens.shift)
-        if token =~ FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
+        if token =~ EndRawTag
           @body << Regexp.last_match(1) if Regexp.last_match(1) != ""
           return
         end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -12,6 +12,8 @@ class RawTagTest < Minitest::Test
 
   def test_output_in_raw
     assert_template_result('{{ test }}', '{% raw %}{{ test }}{% endraw %}')
+    assert_template_result('test', '{% raw %}test{% endraw{% f %}')
+    assert_template_result('test', '{% raw %}test{% endraw{% |f %}')
   end
 
   def test_open_tag_in_raw


### PR DESCRIPTION
Liquid does not accept `{% endraw{% f %}` as a valid `endraw` tag but accepts `{% endfor{% f %}` for `endfor` tags. This is because the second capture group (i.e. `(\w+)`) matches on the `f` instead of the `endraw`.

The solution I implemented hardcodes the `endraw` tag into the regex. The only way I can think of that doesn't hardcode the `endraw` in the regex is to dynamically generate it in `Liquid::Raw#parse`, which would not be very efficient.

Note: the tests fail because `liquid-c` hasn't been updated yet.

Another problem is that the old regex would match `{% endraw{% |f %}` as a valid `endraw` tag because `|f` no longer matches the `(\w+)` capture group so it would match on `endraw`. But this fails in liquid-c because it would match on the `f`.
