### PR TITLE
Instrument invalid end tags

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -77,6 +77,9 @@ module Liquid
         body.parse(tokens, parse_context) do |end_tag_name, end_tag_params|
           @blank &&= body.blank?
 
+          # Instrument for bug 1346
+          Usage.increment("end_tag_params") if end_tag_params && !end_tag_params.empty?
+
           return false if end_tag_name == block_delimiter
           raise_tag_never_closed(block_name) unless end_tag_name
 

--- a/test/integration/block_test.rb
+++ b/test/integration/block_test.rb
@@ -55,4 +55,24 @@ class BlockTest < Minitest::Test
       assert_equal buf.object_id, output.object_id
     end
   end
+
+  def test_instrument_for_bug_1346
+    calls = []
+    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
+      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor {% foo %}")
+    end
+    assert_equal(["end_tag_params"], calls)
+
+    calls = []
+    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
+      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor test %}")
+    end
+    assert_equal(["end_tag_params"], calls)
+
+    calls = []
+    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
+      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor %}")
+    end
+    assert_equal([], calls)
+  end
 end


### PR DESCRIPTION
Add instrumentation for bug #1346. It increments `multiple_open_tags` every time the `Template` has a source with a tag that has multiple open tags before a close tag. If we know nobody is using syntax like `{% endfor {% foo %}`, then we can safely treat it as invalid syntax.