### PR TITLE
Change Parser#expression to build the expression during strict parsing

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -33,7 +33,7 @@ module Liquid
         if LITERALS.key?(markup)
           LITERALS[markup]
         else
-          VariableLookup.parse(markup)
+          VariableLookup.lax_parse(markup)
         end
       end
     end

--- a/lib/liquid/range_lookup.rb
+++ b/lib/liquid/range_lookup.rb
@@ -12,6 +12,8 @@ module Liquid
       end
     end
 
+    attr_reader :start_obj, :end_obj
+
     def initialize(start_obj, end_obj)
       @start_obj = start_obj
       @end_obj   = end_obj
@@ -21,6 +23,10 @@ module Liquid
       start_int = to_integer(context.evaluate(@start_obj))
       end_int   = to_integer(context.evaluate(@end_obj))
       start_int..end_int
+    end
+
+    def ==(other)
+      self.class == other.class && start_obj == other.start_obj && end_obj == other.end_obj
     end
 
     private

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -113,10 +113,9 @@ module Liquid
       @variable_name = p.consume(:id)
       raise SyntaxError, options[:locale].t("errors.syntax.for_invalid_in") unless p.id?('in')
 
-      collection_name  = p.expression
-      @collection_name = parse_expression(collection_name)
+      @collection_name = p.expression
 
-      @name     = "#{@variable_name}-#{collection_name}"
+      @name     = "#{@variable_name}-#{@collection_name}"
       @reversed = p.id?('reversed')
 
       while p.look(:id) && p.look(:colon, 1)
@@ -124,7 +123,17 @@ module Liquid
           raise SyntaxError, options[:locale].t("errors.syntax.for_invalid_attribute")
         end
         p.consume
-        set_attribute(attribute, p.expression)
+        case attribute
+        when 'offset'
+          @from =
+            if p.id?('continue')
+              :continue
+            else
+              p.expression
+            end
+        when 'limit'
+          @limit = p.expression
+        end
       end
       p.consume(:end_of_string)
     end

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -114,12 +114,20 @@ module Liquid
     end
 
     def parse_comparison(p)
-      a = parse_expression(p.expression)
+      a = parse_operand_expression(p)
       if (op = p.consume?(:comparison))
-        b = parse_expression(p.expression)
+        b = parse_operand_expression(p)
         Condition.new(a, op, b)
       else
         Condition.new(a)
+      end
+    end
+
+    def parse_operand_expression(p)
+      if p.look(:id) && !p.look(:dot, 1) && !p.look(:open_square, 1)
+        parse_expression(p.consume)
+      else
+        p.expression
       end
     end
 

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -65,21 +65,13 @@ module Liquid
 
       return if p.look(:end_of_string)
 
-      @name = Expression.parse(p.expression)
+      @name = p.expression
       while p.consume?(:pipe)
         filtername = p.consume(:id)
-        filterargs = p.consume?(:colon) ? parse_filterargs(p) : []
-        @filters << parse_filter_expressions(filtername, filterargs)
+        filterargs = p.consume?(:colon) ? p.arguments : [[]]
+        @filters << [filtername] + filterargs
       end
       p.consume(:end_of_string)
-    end
-
-    def parse_filterargs(p)
-      # first argument
-      filterargs = [p.argument]
-      # followed by comma separated others
-      filterargs << p.argument while p.consume?(:comma)
-      filterargs
     end
 
     def render(context)

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -110,11 +110,12 @@ module Liquid
     def to_s
       str = name.dup
       lookups.each do |lookup|
-        if lookup.instance_of?(String)
-          str += '.' + lookup
-        else
-          str += '[' + lookup.to_s + ']'
-        end
+        str +=
+          if lookup.instance_of?(String)
+            '.' + lookup
+          else
+            '[' + lookup.to_s + ']'
+          end
       end
       str
     end

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -29,6 +29,12 @@ class ExpressionTest < Minitest::Test
   def test_range
     assert_equal(1..2, parse_and_eval("(1..2)"))
     assert_equal(3..4, parse_and_eval(" ( 3 .. 4 ) "))
+    assert_equal(0..0, parse_and_eval("('a'..'b')"))
+
+    with_error_mode(:strict) do
+      e = assert_raises(NoMethodError) { parse_and_eval("(1..(1..5))") }
+      assert_match(/undefined method `to_i' for 1..5:Range/, e.message)
+    end
   end
 
   private

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -36,11 +36,11 @@ class ExpressionTest < Minitest::Test
   def parse_and_eval(markup, **assigns)
     if Liquid::Template.error_mode == :strict
       p = Liquid::Parser.new(markup)
-      markup = p.expression
-      p.consume(:end_of_string)
+      p.expression
+    else
+      expression = Liquid::Expression.parse(markup)
+      context = Liquid::Context.new(assigns)
+      context.evaluate(expression)
     end
-    expression = Liquid::Expression.parse(markup)
-    context = Liquid::Context.new(assigns)
-    context.evaluate(expression)
   end
 end

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -77,7 +77,7 @@ class ConditionUnitTest < Minitest::Test
   def test_contains_works_on_arrays
     @context          = Liquid::Context.new
     @context['array'] = [1, 2, 3, 4, 5]
-    array_expr        = VariableLookup.new("array")
+    array_expr        = parse_variable_lookup("array")
 
     assert_evaluates_false(array_expr, 'contains', 0)
     assert_evaluates_true(array_expr, 'contains', 1)
@@ -91,8 +91,8 @@ class ConditionUnitTest < Minitest::Test
 
   def test_contains_returns_false_for_nil_operands
     @context = Liquid::Context.new
-    assert_evaluates_false(VariableLookup.new('not_assigned'), 'contains', '0')
-    assert_evaluates_false(0, 'contains', VariableLookup.new('not_assigned'))
+    assert_evaluates_false(parse_variable_lookup('not_assigned'), 'contains', '0')
+    assert_evaluates_false(0, 'contains', parse_variable_lookup('not_assigned'))
   end
 
   def test_contains_return_false_on_wrong_data_type
@@ -145,10 +145,19 @@ class ConditionUnitTest < Minitest::Test
     @context        = Liquid::Context.new
     @context['one'] = @context['another'] = "gnomeslab-and-or-liquid"
 
-    assert_evaluates_true(VariableLookup.new("one"), '==', VariableLookup.new("another"))
+    assert_evaluates_true(parse_variable_lookup("one"), '==', parse_variable_lookup("another"))
   end
 
   private
+
+  def parse_variable_lookup(markup)
+    if Liquid::Template.error_mode == :strict
+      p = Liquid::Parser.new(markup)
+      VariableLookup.strict_parse(p)
+    else
+      VariableLookup.lax_parse(markup)
+    end
+  end
 
   def assert_evaluates_true(left, op, right)
     assert(Condition.new(left, op, right).evaluate(@context),

--- a/test/unit/variable_lookup_unit_test.rb
+++ b/test/unit/variable_lookup_unit_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class VariableLookupUnitTest < Minitest::Test
+  include Liquid
+
+  def test_variable_lookup_parsing
+    lookup = parse_variable_lookup('a.b.c')
+    assert_equal('a', lookup.name)
+    assert_equal(['b', 'c'], lookup.lookups)
+
+    lookup = parse_variable_lookup('a[b]')
+    assert_equal('a', lookup.name)
+    assert_equal([parse_variable_lookup('b')], lookup.lookups)
+  end
+
+  def test_to_s
+    lookup = parse_variable_lookup('a.b.c')
+    assert_equal('a.b.c', lookup.to_s)
+
+    lookup = parse_variable_lookup('a[b.c].d')
+    assert_equal('a[b.c].d', lookup.to_s)
+  end
+
+  private
+
+  def parse_variable_lookup(markup)
+    if Liquid::Template.error_mode == :strict
+      p = Liquid::Parser.new(markup)
+      VariableLookup.strict_parse(p)
+    else
+      VariableLookup.lax_parse(markup)
+    end
+  end
+end

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -7,20 +7,20 @@ class VariableUnitTest < Minitest::Test
 
   def test_variable
     var = create_variable('hello')
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
   end
 
   def test_filters
     var = create_variable('hello | textileze')
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['textileze', []]], var.filters)
 
     var = create_variable('hello | textileze | paragraph')
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['textileze', []], ['paragraph', []]], var.filters)
 
     var = create_variable(%( hello | strftime: '%Y'))
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['strftime', ['%Y']]], var.filters)
 
     var = create_variable(%( 'typo' | link_to: 'Typo', true ))
@@ -44,11 +44,11 @@ class VariableUnitTest < Minitest::Test
     assert_equal([['repeat', [3, 3, 3]]], var.filters)
 
     var = create_variable(%( hello | strftime: '%Y, okay?'))
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['strftime', ['%Y, okay?']]], var.filters)
 
     var = create_variable(%( hello | things: "%Y, okay?", 'the other one'))
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['things', ['%Y, okay?', 'the other one']]], var.filters)
   end
 
@@ -60,22 +60,24 @@ class VariableUnitTest < Minitest::Test
 
   def test_filters_without_whitespace
     var = create_variable('hello | textileze | paragraph')
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['textileze', []], ['paragraph', []]], var.filters)
 
     var = create_variable('hello|textileze|paragraph')
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['textileze', []], ['paragraph', []]], var.filters)
 
     var = create_variable("hello|replace:'foo','bar'|textileze")
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['replace', ['foo', 'bar']], ['textileze', []]], var.filters)
   end
 
   def test_symbol
-    var = create_variable("http://disney.com/logo.gif | image: 'med' ", error_mode: :lax)
-    assert_equal(VariableLookup.new('http://disney.com/logo.gif'), var.name)
-    assert_equal([['image', ['med']]], var.filters)
+    with_error_mode(:lax) do
+      var = create_variable("http://disney.com/logo.gif | image: 'med' ", error_mode: :lax)
+      assert_equal(parse_variable_lookup('http://disney.com/logo.gif'), var.name)
+      assert_equal([['image', ['med']]], var.filters)
+    end
   end
 
   def test_string_to_filter
@@ -105,8 +107,8 @@ class VariableUnitTest < Minitest::Test
   end
 
   def test_dashes
-    assert_equal(VariableLookup.new('foo-bar'), create_variable('foo-bar').name)
-    assert_equal(VariableLookup.new('foo-bar-2'), create_variable('foo-bar-2').name)
+    assert_equal(parse_variable_lookup('foo-bar'), create_variable('foo-bar').name)
+    assert_equal(parse_variable_lookup('foo-bar-2'), create_variable('foo-bar-2').name)
 
     with_error_mode :strict do
       assert_raises(Liquid::SyntaxError) { create_variable('foo - bar') }
@@ -122,18 +124,18 @@ class VariableUnitTest < Minitest::Test
 
   def test_string_dot
     var = create_variable(%( test.test ))
-    assert_equal(VariableLookup.new('test.test'), var.name)
+    assert_equal(parse_variable_lookup('test.test'), var.name)
   end
 
   def test_filter_with_keyword_arguments
     var = create_variable(%( hello | things: greeting: "world", farewell: 'goodbye'))
-    assert_equal(VariableLookup.new('hello'), var.name)
+    assert_equal(parse_variable_lookup('hello'), var.name)
     assert_equal([['things', [], { 'greeting' => 'world', 'farewell' => 'goodbye' }]], var.filters)
   end
 
   def test_lax_filter_argument_parsing
     var = create_variable(%( number_of_comments | pluralize: 'comment': 'comments' ), error_mode: :lax)
-    assert_equal(VariableLookup.new('number_of_comments'), var.name)
+    assert_equal(parse_variable_lookup('number_of_comments'), var.name)
     assert_equal([['pluralize', ['comment', 'comments']]], var.filters)
   end
 
@@ -151,12 +153,21 @@ class VariableUnitTest < Minitest::Test
   end
 
   def test_variable_lookup_interface
-    lookup = VariableLookup.new('a.b.c')
+    lookup = parse_variable_lookup('a.b.c')
     assert_equal('a', lookup.name)
     assert_equal(['b', 'c'], lookup.lookups)
   end
 
   private
+
+  def parse_variable_lookup(markup)
+    if Liquid::Template.error_mode == :strict
+      p = Liquid::Parser.new(markup)
+      VariableLookup.strict_parse(p)
+    else
+      VariableLookup.lax_parse(markup)
+    end
+  end
 
   def create_variable(markup, options = {})
     Variable.new(markup, ParseContext.new(options))

--- a/test/unit/variable_unit_test.rb
+++ b/test/unit/variable_unit_test.rb
@@ -152,12 +152,6 @@ class VariableUnitTest < Minitest::Test
     assert_equal(" name_of_variable | upcase ", var.raw)
   end
 
-  def test_variable_lookup_interface
-    lookup = parse_variable_lookup('a.b.c')
-    assert_equal('a', lookup.name)
-    assert_equal(['b', 'c'], lookup.lookups)
-  end
-
   private
 
   def parse_variable_lookup(markup)


### PR DESCRIPTION
Currently, the strict parser uses `Parser#expression` to build the string and then uses `Expression.parse` to parse the built string. Since `Expression.parse` is regex based, it has trouble parsing certain things (especially statements with parenthesis for order of operations).

An example of different behaviour between liquid and liquid-c is the (invalid) range `(1..(1..5))`. Liquid-c will correctly parse the range as from `1` to `1..5`, and will raise a `NoMethodError` on `1..5` (due to calling `to_i`). But liquid parses it as a range of `1..(1` to `5)`. These two endpoints of the range will be treated as variables and passed to `RangeLookup`, which resolves both as `nil`, which Ruby resolves to the range `0..0`.