### PR TITLE
Instrument usage of offset:continue in for loops

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -198,6 +198,7 @@ module Liquid
       case key
       when 'offset'
         @from = if expr == 'continue'
+          Usage.increment('for_offset_continue')
           :continue
         else
           parse_expression(expr)

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -437,4 +437,14 @@ HERE
 
     assert(context.registers[:for_stack].empty?)
   end
+
+  def test_instrument_for_offset_continue
+    assert_usage_increment('for_offset_continue') do
+      Template.parse('{% for item in items offset:continue %}{{item}}{% endfor %}')
+    end
+
+    assert_usage_increment('for_offset_continue', times: 0) do
+      Template.parse('{% for item in items offset:2 %}{{item}}{% endfor %}')
+    end
+  end
 end


### PR DESCRIPTION
From discussions in https://github.com/Shopify/liquid/pull/1353#discussion_r521661534, `offset: continue` in liquid for loops aren't documented, so we might be able to drop support for it. This PR instruments usage of `offset: continue`.