### PR TITLE
Instrument forloop.name

### DIFF
--- a/lib/liquid/forloop_drop.rb
+++ b/lib/liquid/forloop_drop.rb
@@ -9,7 +9,12 @@ module Liquid
       @index      = 0
     end
 
-    attr_reader :name, :length, :parentloop
+    attr_reader :length, :parentloop
+
+    def name
+      Usage.increment('forloop_drop_name')
+      @name
+    end
 
     def index
       @index + 1

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -447,4 +447,20 @@ HERE
       Template.parse('{% for item in items offset:2 %}{{item}}{% endfor %}')
     end
   end
+
+  def test_instrument_forloop_drop_name
+    assigns = { 'items' => [1, 2, 3, 4, 5] }
+
+    assert_usage_increment('forloop_drop_name', times: 5) do
+      Template.parse('{% for item in items %}{{forloop.name}}{% endfor %}').render!(assigns)
+    end
+
+    assert_usage_increment('forloop_drop_name', times: 0) do
+      Template.parse('{% for item in items %}{{forloop.index}}{% endfor %}').render!(assigns)
+    end
+
+    assert_usage_increment('forloop_drop_name', times: 0) do
+      Template.parse('{% for item in items %}{{item}}{% endfor %}').render!(assigns)
+    end
+  end
 end


### PR DESCRIPTION
From discussions in https://github.com/Shopify/liquid/pull/1353#discussion_r521661534, `forloop.name` is not documented, so we might be able drop support for it. This PR instruments usage of `forloop.name`.