### PR TITLE
Support float in variable range

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ group :test do
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'master'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'pz-range-var-float'
   end
 end

--- a/lib/liquid/range_lookup.rb
+++ b/lib/liquid/range_lookup.rb
@@ -29,7 +29,7 @@ module Liquid
       case input
       when Integer
         input
-      when NilClass, String
+      when NilClass, String, Float
         input.to_i
       else
         Utils.to_integer(input)

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -29,6 +29,7 @@ class ExpressionTest < Minitest::Test
   def test_range
     assert_equal(1..2, parse_and_eval("(1..2)"))
     assert_equal(3..4, parse_and_eval(" ( 3 .. 4 ) "))
+    assert_equal(1..2, parse_and_eval("(1.1..2.2)"))
   end
 
   private

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -50,6 +50,7 @@ HERE
 
   def test_for_with_variable_range
     assert_template_result(' 1  2  3 ', '{%for item in (1..foobar) %} {{item}} {%endfor%}', "foobar" => 3)
+    assert_template_result(' 1  2  3 ', '{%for item in (x..y) %} {{item}} {%endfor%}', "x" => 1.1, "y" => 3.3)
   end
 
   def test_for_with_hash_value_range


### PR DESCRIPTION
Ranges with floats get converted to ranges of integers (e.g. `1.1..5.5` gets converted to range `1..5`) but this is not the case with ranges of variables (e.g. if `x == 1.1` and `y == 5.5`, `x..y` results in a `Liquid error: invalid integer`). This is because  floats are not handled in `RangeLookup#to_integer` so it delegates to `Utils.to_integer(input)`, which first converts the float to a string and then tries to convert it back to an integer.