### PR TITLE
Simplify RANGES_REGEX to avoid backtracking issues

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -14,7 +14,7 @@ module Liquid
     DOUBLE_QUOTED_STRING = /\A\s*"(.*)"\s*\z/m
     INTEGERS_REGEX       = /\A\s*(-?\d+)\s*\z/
     FLOATS_REGEX         = /\A\s*(-?\d[\d\.]+)\s*\z/
-    RANGES_REGEX         = /\A\s*\(\s*(\S+)\s*\.\.\s*(\S+)\s*\)\s*\z/
+    RANGES_REGEX         = /\A\s*\(.*\)\s*\z/
 
     def self.parse(markup)
       case markup
@@ -25,7 +25,8 @@ module Liquid
       when INTEGERS_REGEX
         Regexp.last_match(1).to_i
       when RANGES_REGEX
-        RangeLookup.parse(Regexp.last_match(1), Regexp.last_match(2))
+        parts = markup.strip.gsub(/\A\(|\)\Z/, '').split(/\.{2,}/)
+        return RangeLookup.parse(parts[0].strip, parts[1].strip) if parts.count == 2
       when FLOATS_REGEX
         Regexp.last_match(1).to_f
       else

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -52,6 +52,19 @@ HERE
     assert_template_result(' 1  2  3 ', '{%for item in (1..foobar) %} {{item}} {%endfor%}', "foobar" => 3)
   end
 
+  def test_for_dynamic_find_var
+    assert_template_result(' 1  2  3 ', '{%for item in (bar..[key]) %} {{item}} {%endfor%}', 'key' => 'foo', 'foo' => 3, 'bar' => 1)
+  end
+
+  # Regression test for old regex that has backtracking issues
+  def test_for_regular_expression_backtracking
+    with_error_mode(:strict) do
+      assert_raises(Liquid::SyntaxError) do
+        Template.parse("{%for item in (1#{'.' * 50000})! %} {{item}} {%endfor%}")
+      end
+    end
+  end
+
   def test_for_with_hash_value_range
     foobar = { "value" => 3 }
     assert_template_result(' 1  2  3 ', '{%for item in (1..foobar.value) %} {{item}} {%endfor%}', "foobar" => foobar)


### PR DESCRIPTION
Fixes #1357

I replaced the regular expression with a much simpler one and then do the rest of the heavy lifting with a split and some basic regular expressions.

I also added a couple of tests.