### PR TITLE
Instrument usage of floats in ranges

### DIFF
--- a/lib/liquid/range_lookup.rb
+++ b/lib/liquid/range_lookup.rb
@@ -8,6 +8,8 @@ module Liquid
       if start_obj.respond_to?(:evaluate) || end_obj.respond_to?(:evaluate)
         new(start_obj, end_obj)
       else
+        Usage.increment('range_float') if start_obj.is_a?(Float) || end_obj.is_a?(Float)
+
         start_obj.to_i..end_obj.to_i
       end
     end

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -31,15 +31,33 @@ class ExpressionTest < Minitest::Test
     assert_equal(3..4, parse_and_eval(" ( 3 .. 4 ) "))
   end
 
+  def test_instrument_range_float
+    assert_usage_increment('range_float') do
+      parse("(1.0..2.0)")
+    end
+
+    assert_usage_increment('range_float') do
+      parse("(1.0..2)")
+    end
+
+    assert_usage_increment('range_float', times: 0) do
+      parse("(1..2)")
+    end
+  end
+
   private
 
-  def parse_and_eval(markup, **assigns)
+  def parse(markup)
     if Liquid::Template.error_mode == :strict
       p = Liquid::Parser.new(markup)
       markup = p.expression
       p.consume(:end_of_string)
     end
-    expression = Liquid::Expression.parse(markup)
+    Liquid::Expression.parse(markup)
+  end
+
+  def parse_and_eval(markup, **assigns)
+    expression = parse(markup)
     context = Liquid::Context.new(assigns)
     context.evaluate(expression)
   end


### PR DESCRIPTION
From discussions in #1356, constant ranges where the endpoints are floats are converted to integers silently. We want to drop support for this so that we can have real float ranges. This PR adds instrumentation to see if anyone is using this.