### PR TITLE
Use an atomic subgroup in range regex to avoid pathological backtracking

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -14,7 +14,10 @@ module Liquid
     DOUBLE_QUOTED_STRING = /\A\s*"(.*)"\s*\z/m
     INTEGERS_REGEX       = /\A\s*(-?\d+)\s*\z/
     FLOATS_REGEX         = /\A\s*(-?\d[\d\.]+)\s*\z/
-    RANGES_REGEX         = /\A\s*\(\s*(\S+)\s*\.\.\s*(\S+)\s*\)\s*\z/
+
+    # Use an atomic group (?>...) to avoid pathological backtracing from
+    # malicious input as described in https://github.com/Shopify/liquid/issues/1357
+    RANGES_REGEX         = /\A\s*\(\s*(?>(\S+)\s*\.\.)\s*(\S+)\s*\)\s*\z/
 
     def self.parse(markup)
       case markup


### PR DESCRIPTION
Fixes #1357
cc @dee-see

Ruby uses a regular expression implementation that is susceptible to pathological backtracing from malicious input as explained in https://ruby-doc.org/core-2.7.2/Regexp.html#class-Regexp-label-Performance where an [atomic group](https://ruby-doc.org/core-2.7.2/Regexp.html#class-Regexp-label-Atomic+Grouping) is suggested as a possible fix.

I used an atomic group to avoid backtracking after greedily match the range start up to and including the `..` separator, so after that it won't backtrace if it doesn't find a range end expression.  This should preserve the exact previous behaviour of the regular expression while also avoiding performance problems.

I tested this against the tests from https://github.com/Shopify/liquid/pull/1358, which would still be useful with this implementation.