### PR TITLE
performance: Use split limit in truncatewords

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -89,13 +89,15 @@ module Liquid
 
     def truncatewords(input, words = 15, truncate_string = "...")
       return if input.nil?
-      wordlist = input.to_s.split
-      words    = Utils.to_integer(words)
+      input = input.to_s
+      words = Utils.to_integer(words)
+      words = 1 if words <= 0
 
-      l = words - 1
-      l = 0 if l < 0
+      wordlist = input.split(" ", words + 1)
+      return input if wordlist.length <= words
 
-      wordlist.length > l ? wordlist[0..l].join(" ").concat(truncate_string.to_s) : input
+      wordlist.pop
+      wordlist.join(" ").concat(truncate_string.to_s)
     end
 
     # Split input string into an array of substrings separated by given pattern.

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -175,6 +175,9 @@ class StandardFiltersTest < Minitest::Test
     )
     assert_equal("测试测试测试测试", @filters.truncatewords('测试测试测试测试', 5))
     assert_equal('one two1', @filters.truncatewords("one two three", 2, 1))
+    assert_equal('one two three...', @filters.truncatewords("one  two\tthree\nfour", 3))
+    assert_equal('one two...', @filters.truncatewords("one two three four", 2))
+    assert_equal('one...', @filters.truncatewords("one two three four", 0))
   end
 
   def test_strip_html


### PR DESCRIPTION
Closes #1313

#1313 points out that we create a lot of object allocations by splitting the input into words.  However, its approach of compiling a regular expression each time it is used also seems inefficient.  Instead, I found that just use a limit for the split call seems to provide better performance on MRI (2.7.2) in a micro-benchmark.

## Benchmark

```ruby
require 'benchmark/ips'

description = "The Arbor Draft snowboard wouldn't exist if Polynesians hadn't figured out how to surf hundreds of years ago. But the Draft does exist, and it's here to bring your urban and park riding to a new level. The board's freaky Tiki design pays homage to culture that inspired snowboarding. It's designed to spin with ease, land smoothly, lock hook-free onto rails, and take the abuse of a pavement pounding or twelve. The Draft will pop off kickers with authority and carve solidly across the pipe. The Draft features targeted Koa wood die cuts inlayed into the deck that enhance the flex pattern. Now bow down to riding's ancestors."

words = 15

use_split = lambda do
  wordlist = description.split(" ")
  if wordlist.length > words
    wordlist.first(words).join(" ").concat("...")
  else
    description
  end
end

use_split_limit = lambda do
  wordlist = description.split(" ", words + 1)
  if wordlist.length > words
    wordlist.pop
    wordlist.join(" ").concat("...")
  else
    description
  end
end

use_regex = lambda do
  str = description[/\A\s*(?:\S+\s+){#{words}}(?=\S)/]
  if str
    str.strip!
    str.gsub!(/\s{2,}/, " ")
    str.concat("...")
  else
    description
  end
end

raise 'mismatch' unless use_split.call == use_split_limit.call
raise 'mismatch' unless use_split.call == use_regex.call

Benchmark.ips do |x|
  x.report("split", &use_split)
  x.report("split limit", &use_split_limit)
  x.report("regex", &use_regex)
end
```

results

```
               split     87.625k (± 7.4%) i/s -    436.280k in   5.005086s
         split limit    337.402k (± 4.4%) i/s -      1.692M in   5.025705s
               regex     58.166k (± 5.9%) i/s -    292.850k in   5.056896s
```

When no truncation is needed then split limit becomes comparable to split without a limit.  E.g. using `words = 10000` gives

```
               split    116.311k (± 6.3%) i/s -    581.840k in   5.023560s
         split limit    114.552k (± 4.8%) i/s -    579.432k in   5.069878s
               regex     52.627k (± 3.5%) i/s -    266.628k in   5.072548s
```

When the regex has a hard coded number of words, then it does outperform split without a limit, but I was still seeing split with a limit being faster.  E.g. I used `words = 15` again and used `{15}` in the regex and got

```
               split     98.076k (± 7.4%) i/s -    489.926k in   5.028744s
         split limit    339.031k (± 6.8%) i/s -      1.709M in   5.065987s
               regex    205.278k (± 5.0%) i/s -      1.027M in   5.013896s
```

This is still suboptimal, but I think we can optimize these filters better in liquid-c in the near future.