### PR TITLE
Fix template name in profile result for render tag timing objects

### DIFF
--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -102,8 +102,8 @@ module Liquid
 
     attr_reader :total_render_time
 
-    def initialize(template_name)
-      @root_timing  = Timing.new("", template_name)
+    def initialize
+      @root_timing  = Timing.new("", nil)
       @timing_stack = [@root_timing]
     end
 

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -25,7 +25,7 @@ module Liquid
   #     node.code
   #
   #     # Which template and line number of this node.
-  #     # If top level, this will be "<root>".
+  #     # The top-level template name is `nil` by default, but can be set in the Liquid::Context before rendering.
   #     node.partial
   #     node.line_number
   #
@@ -49,15 +49,15 @@ module Liquid
       attr_reader :code, :partial, :line_number, :children, :total_time, :self_time
       alias_method :render_time, :total_time
 
-      def initialize(node, partial)
+      def initialize(node, template_name)
         @code        = node.respond_to?(:raw) ? node.raw : node
-        @partial     = partial
+        @partial     = template_name
         @line_number = node.respond_to?(:line_number) ? node.line_number : nil
         @children    = []
       end
 
-      def self.start(node, partial)
-        new(node, partial).tap(&:start)
+      def self.start(node, template_name)
+        new(node, template_name).tap(&:start)
       end
 
       def start
@@ -85,22 +85,11 @@ module Liquid
       end
     end
 
-    def self.profile_node_render(node)
+    def self.profile_node_render(node, template_name)
       if Profiler.current_profile && node.respond_to?(:render)
-        Profiler.current_profile.start_node(node)
+        Profiler.current_profile.start_node(node, template_name)
         output = yield
-        Profiler.current_profile.end_node(node)
-        output
-      else
-        yield
-      end
-    end
-
-    def self.profile_children(template_name)
-      if Profiler.current_profile
-        Profiler.current_profile.push_partial(template_name)
-        output = yield
-        Profiler.current_profile.pop_partial
+        Profiler.current_profile.end_node
         output
       else
         yield
@@ -113,10 +102,8 @@ module Liquid
 
     attr_reader :total_render_time
 
-    def initialize(partial_name = "<root>")
-      @partial_stack = [partial_name]
-
-      @root_timing  = Timing.new("", current_partial)
+    def initialize(template_name)
+      @root_timing  = Timing.new("", template_name)
       @timing_stack = [@root_timing]
     end
 
@@ -142,27 +129,15 @@ module Liquid
       @root_timing.children.length
     end
 
-    def start_node(node)
-      @timing_stack.push(Timing.start(node, current_partial))
+    def start_node(node, template_name)
+      @timing_stack.push(Timing.start(node, template_name))
     end
 
-    def end_node(_node)
+    def end_node
       timing = @timing_stack.pop
       timing.finish
 
       @timing_stack.last.children << timing
-    end
-
-    def current_partial
-      @partial_stack.last
-    end
-
-    def push_partial(partial_name)
-      @partial_stack.push(partial_name)
-    end
-
-    def pop_partial
-      @partial_stack.pop
     end
 
     private

--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -3,19 +3,10 @@
 module Liquid
   module BlockBodyProfilingHook
     def render_node(context, output, node)
-      Profiler.profile_node_render(node) do
+      Profiler.profile_node_render(node, context.template_name) do
         super
       end
     end
   end
   BlockBody.prepend(BlockBodyProfilingHook)
-
-  module IncludeProfilingHook
-    def render_to_output_buffer(context, output)
-      Profiler.profile_children(context.evaluate(@template_name_expr).to_s) do
-        super
-      end
-    end
-  end
-  Include.prepend(IncludeProfilingHook)
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -220,7 +220,7 @@ module Liquid
       if @profiling && !context.partial
         raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
 
-        @profiler = Profiler.new(context.template_name)
+        @profiler = Profiler.new
         @profiler.start
 
         begin

--- a/test/integration/render_profiling_test.rb
+++ b/test/integration/render_profiling_test.rb
@@ -62,6 +62,17 @@ class RenderProfilingTest < Minitest::Test
     assert_equal(2, included_children[1].line_number)
   end
 
+  def test_profiling_render_tag
+    t = Template.parse("{% render 'a_template' %}", profile: true)
+    t.render!
+
+    render_children = t.profiler[0].children
+    render_children.each do |timing|
+      assert_equal('a_template', timing.partial)
+    end
+    assert_equal([1, 2], render_children.map(&:line_number))
+  end
+
   def test_profiling_times_the_rendering_of_tokens
     t = Template.parse("{% include 'a_template' %}", profile: true)
     t.render!


### PR DESCRIPTION
Branch based on https://github.com/Shopify/liquid/pull/1362

## Problem

Liquid profiling was relying on a profiler hook for the include tag to use the right partial name for timing objects.  However, the same hook wasn't done for the render tag.

## Solution

Use the template name from the context, which is already what was done for the top-level template name (https://github.com/Shopify/liquid/blob/1850511334c555b74232166006a19e987ae7a41d/lib/liquid/template.rb#L223) despite the documentation indicating otherwise.