### PR TITLE
Store the profiler in the context instead of a thread-local variable

### DIFF
--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -3,10 +3,25 @@
 module Liquid
   module BlockBodyProfilingHook
     def render_node(context, output, node)
-      Profiler.profile_node_render(node, context.template_name) do
+      if (profiler = context.profiler)
+        profiler.profile_node(node, context.template_name) do
+          super
+        end
+      else
         super
       end
     end
   end
   BlockBody.prepend(BlockBodyProfilingHook)
+
+  module ContextProfilingHook
+    attr_accessor :profiler
+
+    def new_isolated_subcontext
+      new_context = super
+      new_context.profiler = profiler
+      new_context
+    end
+  end
+  Context.prepend(ContextProfilingHook)
 end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -106,9 +106,13 @@ module Liquid
     # Parse source code.
     # Returns self for easy chaining
     def parse(source, options = {})
+      if (profiling = options[:profile])
+        raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
+      end
+
       @options      = options
-      @profiling    = options[:profile]
-      @line_numbers = options[:line_numbers] || @profiling
+      @profiling    = profiling
+      @line_numbers = options[:line_numbers] || profiling
       parse_context = options.is_a?(ParseContext) ? options : ParseContext.new(options)
       @root         = Document.parse(tokenize(source), parse_context)
       @warnings     = parse_context.warnings
@@ -217,10 +221,8 @@ module Liquid
     end
 
     def with_profiling(context)
-      if @profiling && !context.partial
-        raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
-
-        @profiler = Profiler.new
+      if @profiling && context.profiler.nil?
+        @profiler = context.profiler = Profiler.new
         @profiler.start
 
         begin


### PR DESCRIPTION
Branch based on https://github.com/Shopify/liquid/pull/1363

## Problem

For some reason we were using thread-local variables to store the profiler, even though we already have a context object for rendering that we can store the profiler on.  Using a thread-local variable adds additional overhead and would be more awkward to use to implement profiling in liquid-c.

## Solution

Add another hook for the Liquid::Context to add the profiler attribute and to inherit when calling `new_isolated_subcontext`.