### PR TITLE
Support using a profiler for multiple renders

### DIFF
--- a/lib/liquid/document.rb
+++ b/lib/liquid/document.rb
@@ -42,7 +42,7 @@ module Liquid
     end
 
     def render(context)
-      @body.render(context)
+      render_to_output_buffer(context, +'')
     end
 
     private

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -90,14 +90,20 @@ module Liquid
     def initialize
       @root_timing  = Timing.new("", nil)
       @timing_stack = [@root_timing]
+      @render_start_at = nil
+      @total_render_time = 0.0
     end
 
-    def start
-      @render_start_at = monotonic_time
-    end
-
-    def stop
-      @total_render_time = monotonic_time - @render_start_at
+    def profile
+      return yield if @render_start_at
+      started_at = monotonic_time
+      begin
+        @started_at = started_at
+        yield
+      ensure
+        @started_at = nil
+        @total_render_time += monotonic_time - started_at
+      end
     end
 
     def each(&block)

--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -14,6 +14,14 @@ module Liquid
   end
   BlockBody.prepend(BlockBodyProfilingHook)
 
+  module DocumentProfilingHook
+    def render_to_output_buffer(context, output)
+      return super unless context.profiler
+      context.profiler.profile { super }
+    end
+  end
+  Document.prepend(DocumentProfilingHook)
+
   module ContextProfilingHook
     attr_accessor :profiler
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -199,9 +199,7 @@ module Liquid
 
       begin
         # render the nodelist.
-        with_profiling(context) do
-          @root.render_to_output_buffer(context, output || +'')
-        end
+        @root.render_to_output_buffer(context, output || +'')
       rescue Liquid::MemoryError => e
         context.handle_error(e)
       ensure
@@ -222,11 +220,6 @@ module Liquid
 
     def tokenize(source)
       Tokenizer.new(source, @line_numbers)
-    end
-
-    def with_profiling(context)
-      return yield unless context.profiler
-      context.profiler.profile { yield }
     end
 
     def apply_options_to_context(context, options)

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -193,6 +193,10 @@ module Liquid
       # Retrying a render resets resource usage
       context.resource_limits.reset
 
+      if @profiling && context.profiler.nil?
+        @profiler = context.profiler = Liquid::Profiler.new
+      end
+
       begin
         # render the nodelist.
         with_profiling(context) do
@@ -221,18 +225,8 @@ module Liquid
     end
 
     def with_profiling(context)
-      if @profiling && context.profiler.nil?
-        @profiler = context.profiler = Profiler.new
-        @profiler.start
-
-        begin
-          yield
-        ensure
-          @profiler.stop
-        end
-      else
-        yield
-      end
+      return yield unless context.profiler
+      context.profiler.profile { yield }
     end
 
     def apply_options_to_context(context, options)


### PR DESCRIPTION
Branch based on https://github.com/Shopify/liquid/pull/1364

## Problem

In Shopify, we have a use case for profiling multiple renders.  For instance, we want to profile both the page content and the layout.  We also call render on document bodies in some cases, which would skip the starting of profiling.

## Solution

Move the starting and stopping of profiling into Liquid::Profiler#profile and call it from a ::LiquidDocument#render_to_output_buffer profiler hook.  Liquid::Profiler#profile handles nested rendering by checking if profiling has started, to avoid resetting the start time or double counting nested render time.  The total render time is accumulated across renders, which is now consistent with how timing nodes got accumulated in the root timing's children array.