### PR TITLE
Create top-level profile timing nodes for multiple template renders

### DIFF
--- a/lib/liquid/profiler/hooks.rb
+++ b/lib/liquid/profiler/hooks.rb
@@ -4,7 +4,7 @@ module Liquid
   module BlockBodyProfilingHook
     def render_node(context, output, node)
       if (profiler = context.profiler)
-        profiler.profile_node(node, context.template_name) do
+        profiler.profile_node(context.template_name, code: node.raw, line_number: node.line_number) do
           super
         end
       else
@@ -17,7 +17,7 @@ module Liquid
   module DocumentProfilingHook
     def render_to_output_buffer(context, output)
       return super unless context.profiler
-      context.profiler.profile { super }
+      context.profiler.profile(context.template_name) { super }
     end
   end
   Document.prepend(DocumentProfilingHook)

--- a/test/integration/profiler_test.rb
+++ b/test/integration/profiler_test.rb
@@ -103,12 +103,19 @@ class ProfilerTest < Minitest::Test
     with_custom_tag('sleep', SleepTag) do
       context = Liquid::Context.new
       t = Liquid::Template.parse("{% sleep 0.001 %}", profile: true)
+      context.template_name = 'index'
       t.render!(context)
-      first_render_time = context.profiler.total_render_time
+      context.template_name = 'layout'
+      first_render_time = context.profiler.total_time
       t.render!(context)
 
+      profiler = context.profiler
+      children = profiler.children
       assert_operator(first_render_time, :>=, 0.001)
-      assert_operator(context.profiler.total_render_time, :>=, 0.001 + first_render_time)
+      assert_operator(profiler.total_time, :>=, 0.001 + first_render_time)
+      assert_equal(["index", "layout"], children.map(&:template_name))
+      assert_equal([nil, nil], children.map(&:code))
+      assert_equal(profiler.total_time, children.map(&:total_time).reduce(&:+))
     end
   end
 

--- a/test/integration/profiler_test.rb
+++ b/test/integration/profiler_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class RenderProfilingTest < Minitest::Test
+class ProfilerTest < Minitest::Test
   include Liquid
 
   class ProfilingFileSystem


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid/pull/1365 allows multiple renders to be profiled using the same profiler.  However, all the top-level timing nodes for the profiler are not grouped together for each render.  This also makes it harder to quickly find out how much time was spent with each render.

## Solution

I kept the existing behaviour for when there is only a single render on a profiler object.  If there are multiple template renders being profiled, then top-level timing objects are returned that group together each render.

To do this, I've decoupled the `profiler_node` method and `Timing` class from the Tag/Variable node objects, so we can easily create these top-level Timing objects for the template renders.