### PR TITLE
Freeze the body for case tags

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -19,7 +19,7 @@ module Liquid
     end
 
     def parse(tokens)
-      body = new_body
+      body = case_body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
       @blocks.each do |condition|
         body = condition.attachment
@@ -28,6 +28,7 @@ module Liquid
           body.freeze
         end
       end
+      case_body.freeze
     end
 
     def nodelist


### PR DESCRIPTION
We support having a body for case tags, but the body is not frozen (and silently dropped). This is problematic for liquid-c. This PR freezes the body of the case tag.