### PR TITLE
Revert instrumentation of end_tag_params and range_float

### DIFF
--- a/lib/liquid/block.rb
+++ b/lib/liquid/block.rb
@@ -77,9 +77,6 @@ module Liquid
         body.parse(tokens, parse_context) do |end_tag_name, end_tag_params|
           @blank &&= body.blank?
 
-          # Instrument for bug 1346
-          Usage.increment("end_tag_params") if end_tag_params && !end_tag_params.empty?
-
           return false if end_tag_name == block_delimiter
           raise_tag_never_closed(block_name) unless end_tag_name
 

--- a/lib/liquid/range_lookup.rb
+++ b/lib/liquid/range_lookup.rb
@@ -8,8 +8,6 @@ module Liquid
       if start_obj.respond_to?(:evaluate) || end_obj.respond_to?(:evaluate)
         new(start_obj, end_obj)
       else
-        Usage.increment('range_float') if start_obj.is_a?(Float) || end_obj.is_a?(Float)
-
         start_obj.to_i..end_obj.to_i
       end
     end

--- a/test/integration/block_test.rb
+++ b/test/integration/block_test.rb
@@ -55,24 +55,4 @@ class BlockTest < Minitest::Test
       assert_equal buf.object_id, output.object_id
     end
   end
-
-  def test_instrument_for_bug_1346
-    calls = []
-    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
-      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor {% foo %}")
-    end
-    assert_equal(["end_tag_params"], calls)
-
-    calls = []
-    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
-      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor test %}")
-    end
-    assert_equal(["end_tag_params"], calls)
-
-    calls = []
-    Liquid::Usage.stub(:increment, ->(name) { calls << name }) do
-      Liquid::Template.parse("{% for i in (1..2) %}{{ i }}{% endfor %}")
-    end
-    assert_equal([], calls)
-  end
 end

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -31,33 +31,15 @@ class ExpressionTest < Minitest::Test
     assert_equal(3..4, parse_and_eval(" ( 3 .. 4 ) "))
   end
 
-  def test_instrument_range_float
-    assert_usage_increment('range_float') do
-      parse("(1.0..2.0)")
-    end
-
-    assert_usage_increment('range_float') do
-      parse("(1.0..2)")
-    end
-
-    assert_usage_increment('range_float', times: 0) do
-      parse("(1..2)")
-    end
-  end
-
   private
 
-  def parse(markup)
+  def parse_and_eval(markup, **assigns)
     if Liquid::Template.error_mode == :strict
       p = Liquid::Parser.new(markup)
       markup = p.expression
       p.consume(:end_of_string)
     end
-    Liquid::Expression.parse(markup)
-  end
-
-  def parse_and_eval(markup, **assigns)
-    expression = parse(markup)
+    expression = Liquid::Expression.parse(markup)
     context = Liquid::Context.new(assigns)
     context.evaluate(expression)
   end


### PR DESCRIPTION
Reverts these instrumentation because we've found significant usage of them.
