### PR TITLE
Update History.md with changes since last release

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,36 +2,35 @@
 
 ### Unreleased
 
-### Fixed
-* Reduce allocations (#1073, #1091, #1115, #1099, #1117, #1141, #1322, #1341) [Richard Monette, Florian Weingarten, Ashwin Maroli]
-* Improve resources limits performance (#1093, #1323) [Florian Weingarten, Dylan Thacker-Smith]
+### Features
+* Add new `{% render %}` tag (#1122) [Samuel Doiron]
+* Add support for `as` in `{% render %}` and `{% include %}` (#1181) [Mike Angell]
+* Add `{% liquid %}` and `{% echo %}` tags (#1086) [Justin Li]
+* Add [usage tracking](README.md#usage-tracking) [Mike Angell]
+* Add `Tag.disable_tags` for disabling tags that prepend `Tag::Disableable` at render time (#1162, #1274, #1275) [Mike Angell]
+* Support using a profiler for multiple renders (#1365, #1366) [Dylan Thacker-Smith]
+
+### Fixes
+* Fix catastrophic backtracking in `RANGES_REGEX` regular expression (#1357) [Dylan Thacker-Smith]
 * Make sure the for tag's limit and offset are integers (#1094) [David Cornu]
 * Invokable methods for enumerable reject include (#1151) [Thierry Joyal]
 * Allow `default` filter to handle `false` as value (#1144) [Mike Angell]
-* Remove support for taint checking (#1268) [Dylan Thacker-Smith]
-* Fix how Template overrides static registers when #render is invoked (#1258) [Feken Baboyan]
-* Handle disabled tags errors like other liquid errors (#1275) [Dylan Thacker-Smith]
 * Fix render length resource limit so it doesn't multiply nested output (#1285) [Dylan Thacker-Smith]
 * Fix duplication of text in raw tags (#1304) [Peter Zhu]
 * Fix strict parsing of find variable with a name expression (#1317) [Dylan Thacker-Smith]
 * Use monotonic time to measure durations in Liquid::Profiler (#1362) [Dylan Thacker-Smith]
-* Fix template name in profile result for render tag timing objects (#1363) [Dylan Thacker-Smith]
-* Fix catastrophic backtracking in `RANGES_REGEX` regular expression (#1357) [Dylan Thacker-Smith]
 
-### Changed
+### Breaking Changes
 * Require Ruby >= 2.4 (#1131) [Mike Angell]
-* Add new `{% render %}` tag (#1122) [Samuel Doiron]
-* Add `{% liquid %}` and `{% echo %}` tags (#1086) [Justin Li]
-* Add usage tracking (#1149) [Mike Angell]
-* Split Strainer class as a factory and a template (#1208) [Thierry Joyal]
+* Remove support for taint checking (#1268) [Dylan Thacker-Smith]
+* Split Strainer class into StrainerFactory and StrainerTemplate (#1208) [Thierry Joyal]
 * Remove handling of a nil context in the Strainer class (#1218) [Thierry Joyal]
-* StaticRegisters#fetch to raise on missing key (#1250) [Thierry Joyal]
-* Improve static registers performance (#1178, #1163, #1162, #1157) [Mike Angell]
-* Add support for `as` in `{% render %}` and `{% include %}` (#1181) [Mike Angell]
 * Handle `BlockBody#blank?` at parse time (#1287) [Dylan Thacker-Smith]
-* Pass the tag markup and tokenizer to Document#unknown_tag (#1290) [Dylan Thacker-Smith]
-* Support using a profiler for multiple renders (#1365) [Dylan Thacker-Smith]
-* Create top-level profile timing nodes for multiple template renders (#1366) [Dylan Thacker-Smith]
+* Pass the tag markup and tokenizer to `Document#unknown_tag` (#1290) [Dylan Thacker-Smith]
+
+### Performance Improvements
+* Reduce allocations (#1073, #1091, #1115, #1099, #1117, #1141, #1322, #1341) [Richard Monette, Florian Weingarten, Ashwin Maroli]
+* Improve resources limits performance (#1093, #1323) [Florian Weingarten, Dylan Thacker-Smith]
 
 ## 4.0.3 / 2019-03-12
 

--- a/History.md
+++ b/History.md
@@ -2,9 +2,36 @@
 
 ### Unreleased
 
+### Fixed
+* Reduce allocations (#1073, #1091, #1115, #1099, #1117, #1141, #1322, #1341) [Richard Monette, Florian Weingarten, Ashwin Maroli]
+* Improve resources limits performance (#1093, #1323) [Florian Weingarten, Dylan Thacker-Smith]
+* Make sure the for tag's limit and offset are integers (#1094) [David Cornu]
+* Invokable methods for enumerable reject include (#1151) [Thierry Joyal]
+* Allow `default` filter to handle `false` as value (#1144) [Mike Angell]
+* Remove support for taint checking (#1268) [Dylan Thacker-Smith]
+* Fix how Template overrides static registers when #render is invoked (#1258) [Feken Baboyan]
+* Handle disabled tags errors like other liquid errors (#1275) [Dylan Thacker-Smith]
+* Fix render length resource limit so it doesn't multiply nested output (#1285) [Dylan Thacker-Smith]
+* Fix duplication of text in raw tags (#1304) [Peter Zhu]
+* Fix strict parsing of find variable with a name expression (#1317) [Dylan Thacker-Smith]
+* Use monotonic time to measure durations in Liquid::Profiler (#1362) [Dylan Thacker-Smith]
+* Fix template name in profile result for render tag timing objects (#1363) [Dylan Thacker-Smith]
+* Fix catastrophic backtracking in `RANGES_REGEX` regular expression (#1357) [Dylan Thacker-Smith]
+
+### Changed
+* Require Ruby >= 2.4 (#1131) [Mike Angell]
+* Add new `{% render %}` tag (#1122) [Samuel Doiron]
+* Add `{% liquid %}` and `{% echo %}` tags (#1086) [Justin Li]
+* Add usage tracking (#1149) [Mike Angell]
 * Split Strainer class as a factory and a template (#1208) [Thierry Joyal]
 * Remove handling of a nil context in the Strainer class (#1218) [Thierry Joyal]
 * StaticRegisters#fetch to raise on missing key (#1250) [Thierry Joyal]
+* Improve static registers performance (#1178, #1163, #1162, #1157) [Mike Angell]
+* Add support for `as` in `{% render %}` and `{% include %}` (#1181) [Mike Angell]
+* Handle `BlockBody#blank?` at parse time (#1287) [Dylan Thacker-Smith]
+* Pass the tag markup and tokenizer to Document#unknown_tag (#1290) [Dylan Thacker-Smith]
+* Support using a profiler for multiple renders (#1365) [Dylan Thacker-Smith]
+* Create top-level profile timing nodes for multiple template renders (#1366) [Dylan Thacker-Smith]
 
 ## 4.0.3 / 2019-03-12
 


### PR DESCRIPTION
Left out internal changes that don't have user impact.

There was one security fix (#1357).