### PR TITLE
Use the same context class for isolated subcontexts for the require tag

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -18,8 +18,8 @@ module Liquid
     attr_accessor :exception_renderer, :template_name, :partial, :global_filter, :strict_variables, :strict_filters
 
     # rubocop:disable Metrics/ParameterLists
-    def self.build(environments: {}, outer_scope: {}, registers: {}, rethrow_errors: false, resource_limits: nil, static_environments: {})
-      new(environments, outer_scope, registers, rethrow_errors, resource_limits, static_environments)
+    def self.build(environments: {}, outer_scope: {}, registers: {}, rethrow_errors: false, resource_limits: nil, static_environments: {}, &block)
+      new(environments, outer_scope, registers, rethrow_errors, resource_limits, static_environments, &block)
     end
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil, static_environments = {})
@@ -43,6 +43,8 @@ module Liquid
       if rethrow_errors
         self.exception_renderer = Liquid::RAISE_EXCEPTION_LAMBDA
       end
+
+      yield self if block_given?
 
       # Do this last, since it could result in this object being passed to a Proc in the environment
       squash_instance_assigns_with_environments

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -135,7 +135,7 @@ module Liquid
     def new_isolated_subcontext
       check_overflow
 
-      Context.build(
+      self.class.build(
         resource_limits: resource_limits,
         static_environments: static_environments,
         registers: StaticRegisters.new(registers)


### PR DESCRIPTION
## Problem

For Shopify's storefront renderer, we use a subclass of Liquid::Context for the context.  However, currently that requires replacing (rather than wrapping) the `new_isolated_subcontext` method, so that it returns an object of the subclass, but this seems brittle due to having to essentially copy the implementation of that method.  It also overrides the `initialize` method with an incompatible signature, where doing this in a compatible way is awkward with the large number of positional arguments that accept hashes.

## Solution

Use `self.class.build` instead of `Context.build` in `new_isolated_subcontext` so that it will build an instance of the same context class.

I've also added support for a block to be given when building a context in order to initialize it before `squash_instance_assigns_with_environments` is called in the initializer, since that could potentially use the context to eagerly materialize Proc values.  This way the Liquid::Context subclass can override the build class method to extend the keyword arguments that it takes and use a block to fully initialize the context before it gets used.