### PR TITLE
Implement raw tag parsing in BlockBody

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ group :test do
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'master'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'pz-raw-block-body'
   end
 end

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -12,29 +12,22 @@ module Liquid
     end
 
     def parse(tokens)
-      @body = +''
-      while (token = tokens.shift)
-        if token =~ FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
-          @body << Regexp.last_match(1) if Regexp.last_match(1) != ""
-          return
-        end
-        @body << token unless token.empty?
-      end
-
-      raise_tag_never_closed(block_name)
+      tokens.for_raw_tag = true
+      super
+    ensure
+      tokens.for_raw_tag = false
     end
 
-    def render_to_output_buffer(_context, output)
-      output << @body
-      output
+    def render_to_output_buffer(context, output)
+      @body.render_to_output_buffer(context, output)
     end
 
     def nodelist
       [@body]
     end
 
-    def blank?
-      @body.empty?
+    def unknown_tag(tag, markup, tokens)
+      # no-op
     end
 
     protected

--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -2,12 +2,14 @@
 
 module Liquid
   class Tokenizer
+    attr_accessor :for_raw_tag
     attr_reader :line_number, :for_liquid_tag
 
     def initialize(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
       @source         = source
       @line_number    = line_number || (line_numbers ? 1 : nil)
       @for_liquid_tag = for_liquid_tag
+      @for_raw_tag    = false
       @tokens         = tokenize
     end
 


### PR DESCRIPTION
When implementing serialization, I noticed that the `Raw` tag did not use a `BlockBody` for storing its body which is different than how other blocks work. This makes serialization difficult as this becomes a special case that needs to be handled.

This PR adds a parsing mode for raw tags inside `BlockBody` that parses for raw tags.
