### PR TITLE
Fixes for serialization

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -21,7 +21,7 @@ module Liquid
     def parse(tokens)
       body = case_body = new_body
       body = @blocks.last.attachment while parse_body(body, tokens)
-      @blocks.each do |condition|
+      @blocks.reverse_each do |condition|
         body = condition.attachment
         unless body.frozen?
           body.remove_blank_strings if blank?

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -63,11 +63,11 @@ module Liquid
         parse_body(@else_block, tokens)
       end
       if blank?
-        @for_block.remove_blank_strings
         @else_block&.remove_blank_strings
+        @for_block.remove_blank_strings
       end
-      @for_block.freeze
       @else_block&.freeze
+      @for_block.freeze
     end
 
     def nodelist

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -31,7 +31,7 @@ module Liquid
     def parse(tokens)
       while parse_body(@blocks.last.attachment, tokens)
       end
-      @blocks.each do |block|
+      @blocks.reverse_each do |block|
         block.attachment.remove_blank_strings if blank?
         block.attachment.freeze
       end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -106,16 +106,8 @@ module Liquid
     # Parse source code.
     # Returns self for easy chaining
     def parse(source, options = {})
-      if (profiling = options[:profile])
-        raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
-      end
-
-      @options      = options
-      @profiling    = profiling
-      @line_numbers = options[:line_numbers] || profiling
-      parse_context = options.is_a?(ParseContext) ? options : ParseContext.new(options)
+      parse_context = configure_options(options)
       @root         = Document.parse(tokenize(source), parse_context)
-      @warnings     = parse_context.warnings
       self
     end
 
@@ -217,6 +209,19 @@ module Liquid
     end
 
     private
+
+    def configure_options(options)
+      if (profiling = options[:profile])
+        raise "Profiler not loaded, require 'liquid/profiler' first" unless defined?(Liquid::Profiler)
+      end
+
+      @options      = options
+      @profiling    = profiling
+      @line_numbers = options[:line_numbers] || @profiling
+      parse_context = options.is_a?(ParseContext) ? options : ParseContext.new(options)
+      @warnings     = parse_context.warnings
+      parse_context
+    end
 
     def tokenize(source)
       Tokenizer.new(source, @line_numbers)


### PR DESCRIPTION
Commit 1: Refactors setting options to a separate method in `Liquid::Template` which is reused for deserialization.

Commit 2: Freeze blocks in reverse order of creation. Serialization requires the blocks are frozen in reverse order from when it's created (because it requires that the child is frozen before the parent is frozen).
