### PR TITLE
Bump version to 5.0.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 # Liquid Change Log
 
-### Unreleased
+## 5.0.0 / 2021-01-06
 
 ### Features
 * Add new `{% render %}` tag (#1122) [Samuel Doiron]

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "4.0.3"
+  VERSION = "5.0.0"
 end


### PR DESCRIPTION
Follow up from #1374 to release a new gem version.

Bump major because of the numerous breaking changes.

If you add me as a gem owner (`gem owner --add macournoyer@gmail.com`) I can take care of tagging & pushing to rubygems after this is merged.