### PR TITLE
Add allowed_push_host to gemspec

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 2.5.0"
   s.required_rubygems_version = ">= 1.3.7"
 
+  s.metadata['allowed_push_host'] = 'https://rubygems.org'
+
   s.test_files  = Dir.glob("{test}/**/*")
   s.files       = Dir.glob("{lib}/**/*") + %w(LICENSE README.md)
 


### PR DESCRIPTION
Required to push gem to rubygems:

> Can't release the gem: spec.metadata['allowed_push_host'] must be defined.
-- https://shipit.shopify.io/shopify/liquid/rubygems/deploys/1147483