### PR TITLE
Implement benchmarks for deserialization

### DIFF
--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -17,4 +17,9 @@ Benchmark.ips do |x|
   x.report("parse:") { profiler.compile }
   x.report("render:") { profiler.render }
   x.report("parse & render:") { profiler.run }
+
+  if profiler.serialization_enabled?
+    x.report("deserialize:") { profiler.deserialize }
+    x.report("deserialize & render:") { profiler.deserialize_and_render }
+  end
 end


### PR DESCRIPTION
Implement benchmarks for deserialize, and deserialize and render for Shopify/liquid-c#138.

Benchmark results:

```
              parse:    132.501  (± 3.0%) i/s -      1.326k in  10.019619s
             render:    236.153  (± 3.8%) i/s -      2.369k in  10.047556s
     parse & render:     75.737  (± 4.0%) i/s -    756.000  in  10.001978s
        deserialize:    163.091  (± 2.5%) i/s -      1.632k in  10.014565s
deserialize & render:
                         87.536  (± 2.3%) i/s -    880.000  in  10.060593s
```
