### PR TITLE
CI: Test with ruby 3.0 as the latest ruby version

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -6,9 +6,8 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { ruby: 2.5, allowed-failure: false }
-          - { ruby: 2.6, allowed-failure: false }
-          - { ruby: 2.7, allowed-failure: false }
+          - { ruby: 2.5, allowed-failure: false } # minimum supported
+          - { ruby: 3.0, allowed-failure: false } # latest
           - { ruby: ruby-head, allowed-failure: true }
     name: test (${{ matrix.entry.ruby }})
     steps:

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -461,6 +461,7 @@ class ContextTest < Minitest::Test
   end
 
   def test_interrupt_avoids_object_allocations
+    @context.interrupt? # ruby 3.0.0 allocates on the first call
     assert_no_object_allocations do
       @context.interrupt?
     end


### PR DESCRIPTION
## Problem

When running the tests on ruby 3.0.0, there is a flaky object allocations test failure which can be reproduced reliably by running the flaky test in isolation

```shell
$ bundle exec ruby -Itest test/integration/context_test.rb -n test_interrupt_avoids_object_allocations
```
which gets the test failure
```
  1) Failure:
ContextTest#test_interrupt_avoids_object_allocations [test/integration/context_test.rb:464]:
Expected: 0
  Actual: 1
```

liquid-c is now running tests on ruby 3.0, but the liquid gem isn't, so I noticed the flaky test failure on liquid-c CI.

## Solution

The allocation seems to be on the first call to the method, which isn't an allocation we care about, so call the method once before measuring the object allocations in the test to avoid counting that memoized allocation.

I've also changed the test suite to run on ruby 3.0.  We also don't need to test intermediate versions, since there is no ruby version conditional code so we just need to test the earlier supported version to avoid using features added after that and test the latest ruby version to catch use of deprecated or removed features.