### PR TITLE
Ensure Template can render from a subclass of String

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -207,7 +207,7 @@ module Liquid
 
       idx = 0
       while (node = @nodelist[idx])
-        if node.instance_of?(String)
+        if node.is_a?(String)
           output << node
         else
           render_node(context, output, node)

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -193,7 +193,7 @@ module Liquid
     # Note that it is now preferred to use the `liquid` tag for this use case.
     def remove_blank_strings
       raise "remove_blank_strings only support being called on a blank block body" unless @blank
-      @nodelist.reject! { |node| node.instance_of?(String) }
+      @nodelist.reject! { |node| node.is_a?(String) }
     end
 
     def render(context)

--- a/test/integration/blank_test.rb
+++ b/test/integration/blank_test.rb
@@ -41,6 +41,10 @@ class BlankTest < Minitest::Test
     assert_template_result("", wrap_in_for(" "))
   end
 
+  def test_loops_are_blank_with_string_subclass
+    assert_template_result("", wrap_in_for(SpecialString.new(" ")))
+  end
+
   def test_if_else_are_blank
     assert_template_result("", "{% if true %} {% elsif false %} {% else %} {% endif %}")
   end
@@ -57,8 +61,16 @@ class BlankTest < Minitest::Test
     assert_template_result("", wrap(" {% comment %} whatever {% endcomment %} "))
   end
 
+  def test_comments_are_blank_string_subclass
+    assert_template_result("", wrap(SpecialString.new(" {% comment %} whatever {% endcomment %} ")))
+  end
+
   def test_captures_are_blank
     assert_template_result("", wrap(" {% capture foo %} whatever {% endcapture %} "))
+  end
+
+  def test_captures_are_blank_string_subclass
+    assert_template_result("", wrap(SpecialString.new(" {% capture foo %} whatever {% endcapture %} ")))
   end
 
   def test_nested_blocks_are_blank_but_only_if_all_children_are
@@ -105,5 +117,11 @@ class BlankTest < Minitest::Test
     assert_template_result("", wrap(" {% assign foo = 'bar' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} "))
     assert_template_result("", wrap(" {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} "))
     assert_template_result("   x  " * (N + 1), wrap(" {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} x {% endcase %} "))
+  end
+
+  def test_case_is_blank_string_subclass
+    assert_template_result("", wrap(SpecialString.new(" {% assign foo = 'bar' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} ")))
+    assert_template_result("", wrap(SpecialString.new(" {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} {% endcase %} ")))
+    assert_template_result("   x  " * (N + 1), wrap(SpecialString.new(" {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever' %} {% else %} x {% endcase %} ")))
   end
 end

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -35,6 +35,9 @@ class DropWithUndefinedMethod < Liquid::Drop
   end
 end
 
+class SpecialString < String
+end
+
 class TemplateTest < Minitest::Test
   include Liquid
 
@@ -322,5 +325,11 @@ class TemplateTest < Minitest::Test
     t = Template.parse("{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}")
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('12345', result)
+  end
+
+  def test_render_with_subclasses_of_string
+    t = Template.parse(SpecialString.new('string'))
+    result = t.render
+    assert_equal('string', result)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -167,3 +167,6 @@ class StubTemplateFactory
     Liquid::Template.new
   end
 end
+
+class SpecialString < String
+end


### PR DESCRIPTION
Currently `Template.parse().render` fails if the inputed string is not a `String` object but a subclass of `String` , eg. `ActiveSupport::SafeBuffer` used in Rails apps.

By switching `instance_of?()` to `is_a?()` when checking a node, we can avoid this.

See https://github.com/Shopify/liquid/issues/1390 for further details.