### PR TITLE
Add a line to Sign the CLA as the first step in Workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@
 
 ## Workflow
 
+* [Sign the CLA](https://cla.shopify.com/)
 * Fork the Liquid repository
 * Create a new branch in your fork
 * If it makes sense, add tests for your code and/or run a performance benchmark

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,9 @@
 
 ## Workflow
 
-* [Sign the CLA](https://cla.shopify.com/)
+* [Sign the CLA](https://cla.shopify.com/) if you haven't already
 * Fork the Liquid repository
 * Create a new branch in your fork
 * If it makes sense, add tests for your code and/or run a performance benchmark
 * Make sure all tests pass (`bundle exec rake`)
 * Create a pull request
-


### PR DESCRIPTION
If a pull request is created by someone who didn't sign the CLA yet, the tests will fail. It requires the contributor to submit a new PR or add an insignificant commit (like an empty commit) to force the tests to rerun on the same PR. If we gently nudge a new contributor to sign the CLA in advance, we can help them avoid the hassle.