### PR TITLE
Ignore tags file to avoid conflicts with using ctags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ exclude:
   - package-lock.json
   - node_modules
   - vendor
+  - tags
 keep_files:             ["css"]
 
 # Collections


### PR DESCRIPTION
## Problem

I was getting this error when trying to build the docs

```
bundler: failed to load command: jekyll (/Users/dylants/.gem/ruby/2.6.6/bin/jekyll)
Errno::EPERM: Operation not permitted @ apply2files - /Users/dylants/src/liquid/_site/tags
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:1437:in `unlink'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:1437:in `block in remove_file'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:1442:in `platform_support'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:1436:in `remove_file'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:775:in `remove_file'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:562:in `block in rm'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:561:in `each'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/fileutils.rb:561:in `rm'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/static_file.rb:104:in `write'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:208:in `block in write'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:329:in `block (2 levels) in each_site_file'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:328:in `each'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:328:in `block in each_site_file'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:327:in `each'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:327:in `each_site_file'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:207:in `write'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/site.rb:75:in `process'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/command.rb:28:in `process_site'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/commands/build.rb:65:in `build'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/commands/build.rb:36:in `process'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
  /Users/dylants/.gem/ruby/2.6.6/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
  /Users/dylants/.gem/ruby/2.6.6/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
  /Users/dylants/.gem/ruby/2.6.6/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
  /Users/dylants/.gem/ruby/2.6.6/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
  /Users/dylants/.gem/ruby/2.6.6/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  /Users/dylants/.gem/ruby/2.6.6/gems/jekyll-3.7.4/exe/jekyll:15:in `<top (required)>'
  /Users/dylants/.gem/ruby/2.6.6/bin/jekyll:23:in `load'
  /Users/dylants/.gem/ruby/2.6.6/bin/jekyll:23:in `<top (required)>'
```

which I tracked down to being caused by a `tags` file that I generated using ctags for non-documentation development.  Jekyll was trying to include it in the site as a static file, but that was conflicting with the tags directory that was generated from `_tags` for liquid tags documentation.

This isn't hard to workaround by removing the file, but I thought I would save anyone else using ctags the same confusion that I had.

## Solution

Jekyll supports excluding files from being copied into the generated site, so I added the `tags` file to the list of files to exclude list.