### PR TITLE
Add ParseTreeVisitor to Echo tag

### DIFF
--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -12,6 +12,8 @@ module Liquid
   #   {% echo user | link %}
   #
   class Echo < Tag
+    attr_reader :variable
+
     def initialize(tag_name, markup, parse_context)
       super
       @variable = Variable.new(markup, parse_context)
@@ -19,6 +21,12 @@ module Liquid
 
     def render(context)
       @variable.render_to_output_buffer(context, +'')
+    end
+
+    class ParseTreeVisitor < Liquid::ParseTreeVisitor
+      def children
+        [@node.variable]
+      end
     end
   end
 

--- a/test/unit/parse_tree_visitor_test.rb
+++ b/test/unit/parse_tree_visitor_test.rb
@@ -26,6 +26,13 @@ class ParseTreeVisitorTest < Minitest::Test
     )
   end
 
+  def test_echo
+    assert_equal(
+      ["test"],
+      visit(%({% echo test %}))
+    )
+  end
+
   def test_if_condition
     assert_equal(
       ["test"],


### PR DESCRIPTION
This PR fixes [theme-check#218](https://github.com/shopify/theme-check/issues/218), wherein variables used in echo tags are not considered used by the linter.

Our visitor cannot see the `:variable_lookup` nodes since they are being swallowed by the variable. 

This PR exposes the `@variable`'s children on the `:echo` node.