### PR TITLE
Expanded instructions for getting started

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', '>=180', group: :jekyll_plugins
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 To run, follow these steps:
 
-1. Download ZIP or clone in GitHub
-2. Navigate to `liquid-gh-pages` folder or checkout `gh-pages` branch
-3. Run `bundle exec jekyll serve`
-4. Open `http://127.0.0.1:4000/liquid/` in your browser
+1. [Download and install Ruby](https://www.ruby-lang.org/en/downloads)
+2. Download ZIP or clone in GitHub
+3. Navigate to `liquid-gh-pages` folder or checkout `gh-pages` branch
+4. Run `gem install bundler`
+5. Run `bundle install`
+6. Run `bundle exec jekyll serve`
+7. Open [`http://127.0.0.1:4000/liquid/`](http://127.0.0.1:4000/liquid/) in your browser


### PR DESCRIPTION
### Update README with first-time install instructions

In order to `exec jekyll` you first have to install it. The instructions are expanded to include this procedure. Some Windows-specific hints are also added.

### Install `wdm` Ruby gem in Windows

To avoid polling the file system for changes, Jekyll recommends installing the [Windows Directory Monitor](https://rubygems.org/gems/wdm) in a Windows environment. After merging this, those on Windows will need to run `bundle install` again. This shouldn't affect other environments.