### PR TITLE
Fix support for using a String subclass for the liquid source

### DIFF
--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -5,7 +5,7 @@ module Liquid
     attr_reader :line_number, :for_liquid_tag
 
     def initialize(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
-      @source         = source
+      @source         = source.to_s.to_str
       @line_number    = line_number || (line_numbers ? 1 : nil)
       @for_liquid_tag = for_liquid_tag
       @tokens         = tokenize
@@ -24,7 +24,7 @@ module Liquid
     private
 
     def tokenize
-      return [] if @source.to_s.empty?
+      return [] if @source.empty?
 
       return @source.split("\n") if @for_liquid_tag
 

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -323,4 +323,18 @@ class TemplateTest < Minitest::Test
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('12345', result)
   end
+
+  def test_source_string_subclass
+    string_subclass = Class.new(String) do
+      # E.g. ActiveSupport::SafeBuffer does this, so don't just rely on to_s to return a String
+      def to_s
+        self
+      end
+    end
+    source = string_subclass.new("{% assign x = 2 -%} x= {{- x }}")
+    assert_instance_of(string_subclass, source)
+    output = Template.parse(source).render!
+    assert_equal("x=2", output)
+    assert_instance_of(String, output)
+  end
 end


### PR DESCRIPTION
Fixes #1420, #1390
Closes #1400

Convert the liquid source to a String class using `to_str` so that we don't have to handle string subclasses internally while still supporting String subclasses like ActiveSupport::SafeBuffer for backwards compatibility.