### PR TITLE
Add replace_last and remove_last filters

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 ## 5.0.2 (unreleased)
 
 ### Features
+* Add `remove_last`, and `replace_last` filters (#1422) [Anders Hagbard]
 * Add `base64_encode`, `base64_decode`, `base64_url_safe_encode`, and `base64_url_safe_decode` filters (#1450) [Daniel Insley]
 
 ### Fixes

--- a/History.md
+++ b/History.md
@@ -1,6 +1,9 @@
 # Liquid Change Log
 
-## 5.1.1 (unreleased)
+## 5.2.0 (unreleased)
+
+### Features
+* Add `remove_last`, and `replace_last` filters (#1422) [Anders Hagbard]
 
 ### Fixes
 * Fix some internal errors in filters from invalid input (#1476) [Dylan Thacker-Smith]
@@ -8,7 +11,6 @@
 ## 5.1.0 / 2021-09-09
 
 ### Features
-* Add `remove_last`, and `replace_last` filters (#1422) [Anders Hagbard]
 * Add `base64_encode`, `base64_decode`, `base64_url_safe_encode`, and `base64_url_safe_decode` filters (#1450) [Daniel Insley]
 * Introduce `to_liquid_value` in `Liquid::Drop` (#1441) [Michael Go]
 

--- a/History.md
+++ b/History.md
@@ -3,8 +3,7 @@
 ## 5.1.1 (unreleased)
 
 ### Fixes
-
-* Fix some internal errors in filters from invalid input [Dylan Thacker-Smith]
+* Fix some internal errors in filters from invalid input (#1476) [Dylan Thacker-Smith]
 
 ## 5.1.0 / 2021-09-09
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -308,12 +308,12 @@ module Liquid
 
     # remove the first occurrences of a substring
     def remove_first(input, string)
-      replace_first(input.to_s, string, '')
+      replace_first(input, string, '')
     end
 
     # remove the last occurences of a substring
     def remove_last(input, string)
-      replace_last(input.to_s, string, '')
+      replace_last(input, string, '')
     end
 
     # add one string to another

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -300,7 +300,7 @@ module Liquid
     def replace_last(input, string, replacement)
       start_index = input.to_s.rindex(string.to_s)
 
-      if !start_index.nil?
+      unless start_index.nil?
         end_index = start_index + replacement.to_s.length
 
         duplicate = input.to_s.dup

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -270,7 +270,7 @@ module Liquid
 
     # Replace the last occurrences of a string with another
     def replace_last(input, string, replacement = '')
-      input.to_s.reserve.sub(string.to_s.reserve, replacement.to_s.reserve).reserve
+      input.to_s.reverse.sub(string.to_s.reverse, replacement.to_s.reverse).reverse
     end
 
     # remove a substring

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -297,7 +297,7 @@ module Liquid
     end
 
     # Replace the last occurrences of a string with another
-    def replace_last(input, string, replacement = '')
+    def replace_last(input, string, replacement)
       start_index = input.to_s.rindex(string.to_s)
 
       if !start_index.nil? && start_index > -1

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -303,7 +303,7 @@ module Liquid
 
     # remove a substring
     def remove(input, string)
-      replace(input.to_s, string, '')
+      replace(input, string, '')
     end
 
     # remove the first occurrences of a substring

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -268,6 +268,11 @@ module Liquid
       input.to_s.sub(string.to_s, replacement.to_s)
     end
 
+    # Replace the last occurrences of a string with another
+    def replace_last(input, string, replacement = '')
+      input.to_s.reserve.sub(string.to_s.reserve, replacement.to_s.reserve).reserve
+    end
+
     # remove a substring
     def remove(input, string)
       input.to_s.gsub(string.to_s, '')
@@ -276,6 +281,11 @@ module Liquid
     # remove the first occurrences of a substring
     def remove_first(input, string)
       input.to_s.sub(string.to_s, '')
+    end
+
+    # remove the last occurences of a substring
+    def remove_last(input, string)
+      input.to_s.reverse.sub(string.to_s.reverse, '').reverse
     end
 
     # add one string to another

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -298,16 +298,7 @@ module Liquid
 
     # Replace the last occurrences of a string with another
     def replace_last(input, string, replacement)
-      start_index = input.to_s.rindex(string.to_s)
-
-      unless start_index.nil?
-        end_index = start_index + replacement.to_s.length
-
-        duplicate = input.to_s.dup
-        duplicate[start_index, end_index] = replacement.to_s
-
-        duplicate
-      end
+      input.to_s.sub(/.*\K#{Regexp.escape(string.to_s)}/, replacement.to_s)
     end
 
     # remove a substring

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -300,7 +300,7 @@ module Liquid
     def replace_last(input, string, replacement)
       start_index = input.to_s.rindex(string.to_s)
 
-      if !start_index.nil? && start_index > -1
+      if !start_index.nil?
         end_index = start_index + replacement.to_s.length
 
         duplicate = input.to_s.dup

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -298,7 +298,16 @@ module Liquid
 
     # Replace the last occurrences of a string with another
     def replace_last(input, string, replacement = '')
-      input.to_s.reverse.sub(string.to_s.reverse, replacement.to_s.reverse).reverse
+      start_index = input.to_s.rindex(string.to_s)
+
+      if !start_index.nil? && start_index > -1
+        end_index = start_index + replacement.to_s.length
+
+        duplicate = input.to_s.dup
+        duplicate[start_index, end_index] = replacement.to_s
+
+        duplicate
+      end
     end
 
     # remove a substring

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -303,17 +303,17 @@ module Liquid
 
     # remove a substring
     def remove(input, string)
-      input.to_s.gsub(string.to_s, '')
+      replace(input.to_s, string, '')
     end
 
     # remove the first occurrences of a substring
     def remove_first(input, string)
-      input.to_s.sub(string.to_s, '')
+      replace_first(input.to_s, string, '')
     end
 
     # remove the last occurences of a substring
     def remove_last(input, string)
-      input.to_s.reverse.sub(string.to_s.reverse, '').reverse
+      replace_last(input.to_s, string, '')
     end
 
     # add one string to another

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -298,7 +298,17 @@ module Liquid
 
     # Replace the last occurrences of a string with another
     def replace_last(input, string, replacement)
-      input.to_s.sub(/.*\K#{Regexp.escape(string.to_s)}/, replacement.to_s)
+      input = input.to_s
+      string = string.to_s
+      replacement = replacement.to_s
+
+      start_index = input.rindex(string)
+
+      return input unless start_index
+
+      output = input.dup
+      output[start_index, string.length] = replacement
+      output
     end
 
     # remove a substring

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -512,12 +512,12 @@ class StandardFiltersTest < Minitest::Test
   def test_remove
     assert_equal('   ', @filters.remove("a a a a", 'a'))
     assert_equal('   ', @filters.remove("1 1 1 1", 1))
-    assert_equal('a a a', @filters.remove_first("a a a a", 'a '))
+    assert_equal('b a a', @filters.remove_first("a b a a", 'a '))
     assert_equal(' 1 1 1', @filters.remove_first("1 1 1 1", 1))
     assert_template_result('b a a', "{{ 'a b a a' | remove_first: 'a ' }}")
     assert_equal('a a b', @filters.remove_last("a a b a", ' a'))
     assert_equal('1 1 1 ', @filters.remove_last("1 1 1 1", 1))
-    assert_template_result('a a a', "{{ 'a a a a' | remove_last: ' a' }}")
+    assert_template_result('a a b', "{{ 'a a b a' | remove_last: ' a' }}")
   end
 
   def test_pipes_in_string_arguments

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -503,10 +503,8 @@ class StandardFiltersTest < Minitest::Test
   def test_replace
     assert_equal('2 2 2 2', @filters.replace('1 1 1 1', '1', 2))
     assert_equal('2 2 2 2', @filters.replace('1 1 1 1', 1, 2))
-    assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2))
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2))
     assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}")
-    assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', '1', 2))
     assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', 1, 2))
     assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: '1', 2 }}")
   end
@@ -516,8 +514,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('   ', @filters.remove("1 1 1 1", 1))
     assert_equal('a a a', @filters.remove_first("a a a a", 'a '))
     assert_equal(' 1 1 1', @filters.remove_first("1 1 1 1", 1))
-    assert_template_result('a a a', "{{ 'a a a a' | remove_first: 'a ' }}")
-    assert_equal('a a a', @filters.remove_last("a a a a", ' a'))
+    assert_template_result('b a a', "{{ 'a b a a' | remove_first: 'a ' }}")
+    assert_equal('a a b', @filters.remove_last("a a b a", ' a'))
     assert_equal('1 1 1 ', @filters.remove_last("1 1 1 1", 1))
     assert_template_result('a a a', "{{ 'a a a a' | remove_last: ' a' }}")
   end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -855,16 +855,20 @@ class StandardFiltersTest < Minitest::Test
       ["foo", 123, nil, true, false, Drop, ["foo"], { foo: "bar" }],
     ]
     test_types.each do |first|
-      test_types.each do |other|
-        (@filters.methods - Object.methods).each do |method|
-          arg_count = @filters.method(method).arity
-          arg_count *= -1 if arg_count < 0
-          inputs = [first]
-          inputs << ([other] * (arg_count - 1)) if arg_count > 1
-          begin
-            @filters.send(method, *inputs)
-          rescue Liquid::ArgumentError, Liquid::ZeroDivisionError
-            nil
+      test_types.each do |second|
+        test_types.each do |third|
+          (@filters.methods - Object.methods).each do |method|
+            arg_count = @filters.method(method).arity
+            arg_count *= -1 if arg_count < 0
+            inputs = [first]
+            inputs << ([second] * (arg_count - 1)) if arg_count > 1
+            inputs << ([third] * (arg_count - 1)) if arg_count > 2
+
+            begin
+              @filters.send(method, *inputs)
+            rescue Liquid::ArgumentError, Liquid::ZeroDivisionError
+              nil
+            end
           end
         end
       end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -541,16 +541,22 @@ class StandardFiltersTest < Minitest::Test
   def test_replace
     assert_equal('b b b b', @filters.replace('a a a a', 'a', 'b'))
     assert_equal('2 2 2 2', @filters.replace('1 1 1 1', 1, 2))
+    assert_equal('1 1 1 1', @filters.replace('1 1 1 1', 2, 3))
     assert_equal('b a a a', @filters.replace_first('a a a a', 'a', 'b'))
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2))
+    assert_equal('1 1 1 1', @filters.replace_first('1 1 1 1', 2, 3))
     assert_equal('a a a b', @filters.replace_last('a a a a', 'a', 'b'))
     assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', 1, 2))
+    assert_equal('1 1 1 1', @filters.replace_last('1 1 1 1', 2, 3))
     assert_template_result('b b b b', "{{ 'a a a a' | replace: 'a', 'b' }}")
     assert_template_result('2 2 2 2', "{{ '1 1 1 1' | replace: 1, 2 }}")
+    assert_template_result('1 1 1 1', "{{ '1 1 1 1' | replace: 2, 3 }}")
     assert_template_result('b a a a', "{{ 'a a a a' | replace_first: 'a', 'b' }}")
     assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: 1, 2 }}")
+    assert_template_result('a a a a', "{{ 'a a a a' | replace_first: 'b', 'c' }}")
     assert_template_result('a a a b', "{{ 'a a a a' | replace_last: 'a', 'b' }}")
     assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: 1, 2 }}")
+    assert_template_result('a a a a', "{{ 'a a a a' | replace_last: 'b', 'c' }}")
   end
 
   def test_remove

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -542,35 +542,27 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('b b b b', @filters.replace('a a a a', 'a', 'b'))
     assert_equal('2 2 2 2', @filters.replace('1 1 1 1', 1, 2))
     assert_equal('1 1 1 1', @filters.replace('1 1 1 1', 2, 3))
+    assert_template_result('2 2 2 2', "{{ '1 1 1 1' | replace: '1', 2 }}")
+
     assert_equal('b a a a', @filters.replace_first('a a a a', 'a', 'b'))
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2))
     assert_equal('1 1 1 1', @filters.replace_first('1 1 1 1', 2, 3))
+    assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}")
+
     assert_equal('a a a b', @filters.replace_last('a a a a', 'a', 'b'))
     assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', 1, 2))
     assert_equal('1 1 1 1', @filters.replace_last('1 1 1 1', 2, 3))
-    assert_template_result('b b b b', "{{ 'a a a a' | replace: 'a', 'b' }}")
-    assert_template_result('2 2 2 2', "{{ '1 1 1 1' | replace: 1, 2 }}")
-    assert_template_result('1 1 1 1', "{{ '1 1 1 1' | replace: 2, 3 }}")
-    assert_template_result('b a a a', "{{ 'a a a a' | replace_first: 'a', 'b' }}")
-    assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: 1, 2 }}")
-    assert_template_result('a a a a', "{{ 'a a a a' | replace_first: 'b', 'c' }}")
-    assert_template_result('a a a b', "{{ 'a a a a' | replace_last: 'a', 'b' }}")
-    assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: 1, 2 }}")
-    assert_template_result('a a a a', "{{ 'a a a a' | replace_last: 'b', 'c' }}")
+    assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: '1', 2 }}")
   end
 
   def test_remove
     assert_equal('   ', @filters.remove("a a a a", 'a'))
-    assert_equal('   ', @filters.remove("1 1 1 1", 1))
-    assert_equal('b a a', @filters.remove_first("a b a a", 'a '))
-    assert_equal(' 1 1 1', @filters.remove_first("1 1 1 1", 1))
-    assert_equal('a a b', @filters.remove_last("a a b a", ' a'))
-    assert_equal('1 1 1 ', @filters.remove_last("1 1 1 1", 1))
-    assert_template_result('   ', "{{ 'a a a a' | remove: 'a' }}")
     assert_template_result('   ', "{{ '1 1 1 1' | remove: 1 }}")
-    assert_template_result('b a a', "{{ 'a b a a' | remove_first: 'a ' }}")
+
+    assert_equal('b a a', @filters.remove_first("a b a a", 'a '))
     assert_template_result(' 1 1 1', "{{ '1 1 1 1' | remove_first: 1 }}")
-    assert_template_result('a a b', "{{ 'a a b a' | remove_last: ' a' }}")
+
+    assert_equal('a a b', @filters.remove_last("a a b a", ' a'))
     assert_template_result('1 1 1 ', "{{ '1 1 1 1' | remove_last: 1 }}")
   end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -501,12 +501,18 @@ class StandardFiltersTest < Minitest::Test
   end
 
   def test_replace
-    assert_equal('2 2 2 2', @filters.replace('1 1 1 1', '1', 2))
+    assert_equal('b b b b', @filters.replace('a a a a', 'a', 'b'))
     assert_equal('2 2 2 2', @filters.replace('1 1 1 1', 1, 2))
+    assert_equal('b a a a', @filters.replace_first('a a a a', 'a', 'b'))
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2))
-    assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}")
+    assert_equal('a a a b', @filters.replace_last('a a a a', 'a', 'b'))
     assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', 1, 2))
-    assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: '1', 2 }}")
+    assert_template_result('b b b b', "{{ 'a a a a' | replace: 'a', 'b' }}")
+    assert_template_result('2 2 2 2', "{{ '1 1 1 1' | replace: 1, 2 }}")
+    assert_template_result('b a a a', "{{ 'a a a a' | replace_first: 'a', 'b' }}")
+    assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: 1, 2 }}")
+    assert_template_result('a a a b', "{{ 'a a a a' | replace_last: 'a', 'b' }}")
+    assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: 1, 2 }}")
   end
 
   def test_remove
@@ -514,10 +520,14 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('   ', @filters.remove("1 1 1 1", 1))
     assert_equal('b a a', @filters.remove_first("a b a a", 'a '))
     assert_equal(' 1 1 1', @filters.remove_first("1 1 1 1", 1))
-    assert_template_result('b a a', "{{ 'a b a a' | remove_first: 'a ' }}")
     assert_equal('a a b', @filters.remove_last("a a b a", ' a'))
     assert_equal('1 1 1 ', @filters.remove_last("1 1 1 1", 1))
+    assert_template_result('   ', "{{ 'a a a a' | remove: 'a' }}")
+    assert_template_result('   ', "{{ '1 1 1 1' | remove: 1 }}")
+    assert_template_result('b a a', "{{ 'a b a a' | remove_first: 'a ' }}")
+    assert_template_result(' 1 1 1', "{{ '1 1 1 1' | remove_first: 1 }}")
     assert_template_result('a a b', "{{ 'a a b a' | remove_last: ' a' }}")
+    assert_template_result('1 1 1 ', "{{ '1 1 1 1' | remove_last: 1 }}")
   end
 
   def test_pipes_in_string_arguments

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -506,6 +506,9 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', '1', 2))
     assert_equal('2 1 1 1', @filters.replace_first('1 1 1 1', 1, 2))
     assert_template_result('2 1 1 1', "{{ '1 1 1 1' | replace_first: '1', 2 }}")
+    assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', '1', 2))
+    assert_equal('1 1 1 2', @filters.replace_last('1 1 1 1', 1, 2))
+    assert_template_result('1 1 1 2', "{{ '1 1 1 1' | replace_last: '1', 2 }}")
   end
 
   def test_remove
@@ -514,6 +517,9 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('a a a', @filters.remove_first("a a a a", 'a '))
     assert_equal(' 1 1 1', @filters.remove_first("1 1 1 1", 1))
     assert_template_result('a a a', "{{ 'a a a a' | remove_first: 'a ' }}")
+    assert_equal('a a a', @filters.remove_last("a a a a", ' a'))
+    assert_equal('1 1 1 ', @filters.remove_last("1 1 1 1", 1))
+    assert_template_result('a a a', "{{ 'a a a a' | remove_last: ' a' }}")
   end
 
   def test_pipes_in_string_arguments


### PR DESCRIPTION
This PR adds two filters `replace_last` and `remove_last`. They do exactly what you think. The opposites of `replace_first` and `remove_first`.

Related issue: https://github.com/Shopify/liquid/issues/778