### PR TITLE
add a test clearly showing and commiting to the order of and/or operations

### DIFF
--- a/test/integration/tags/if_else_tag_test.rb
+++ b/test/integration/tags/if_else_tag_test.rb
@@ -187,4 +187,49 @@ class IfElseTagTest < Minitest::Test
       assert_template_result(expected.to_s, tpl, assigns, assigns.to_s)
     end
   end
+
+  def test_operators_order
+    expected_groupings = [
+      ->(w, x, y, z) { (w && (x || (y && z))) },
+      ->(w, x, y, z) { (w || (x && (y || z))) },
+    ]
+
+    liquid_conditions = [
+      'w and x or y and z',
+      'w or x and y or z',
+    ]
+
+    conditions = (0..0b1111).map do |cond|
+      [
+        (cond & 0b1000) == 0 ? false : true,
+        (cond & 0b0100) == 0 ? false : true,
+        (cond & 0b0010) == 0 ? false : true,
+        (cond & 0b0001) == 0 ? false : true,
+      ]
+    end
+
+    expected_results = expected_groupings.map do |test|
+      conditions.map do |condition|
+        test.call(*condition)
+      end
+    end
+
+    liquid_results = liquid_conditions.map do |conditional_expression|
+      tpl = "{% if #{conditional_expression} %}true{% else %}false{% endif %}"
+      template = Liquid::Template.parse(tpl, line_numbers: true)
+      conditions.map do |condition|
+        w, x, y, z = condition
+        assigns = { 'w' => w, 'x' => x, 'y' => y, 'z' => z }
+        template.render!(assigns)
+      end.map { |r| true?(r) }
+    end
+
+    assert_equal(expected_results, liquid_results)
+  end
+
+  private
+
+  def true?(obj)
+    obj.to_s.casecmp('true').zero?
+  end
 end


### PR DESCRIPTION
In the [Liquid docs](https://shopify.github.io/liquid/basics/operators/) it says:
> In tags with more than one and or or operator, operators are checked in order from right to left.

I wasn't sure what that meant exactly so I added a test to show what exactly is the ordering and to commit to keeping that promise for backwards compatibility.