### PR TITLE
Delete redundant `type` and `media` attributes in `script_tag` & `stylesheet_tag`

### DIFF
--- a/performance/shopify/shop_filter.rb
+++ b/performance/shopify/shop_filter.rb
@@ -18,11 +18,7 @@ module ShopFilter
   end
 
   def stylesheet_tag(url, media = "all")
-    html = []
-    html << %(<link href="#{url}" rel="stylesheet")
-    html << %(media="#{media}") if media != "all"
-    html << "/>"
-    html.join(" ")
+    %(<link href="#{url}" rel="stylesheet" #{%(media="#{media}" ) unless media == 'all'}/>)
   end
 
   def link_to(link, url, title = "")


### PR DESCRIPTION
`type` on `link` and `script` should be omitted when loading CSS and JS respectively.

The `"all"` value is also implied when `media` is omitted.

### Sources

[MDN page for `script`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script):

> Omitted or a JavaScript MIME type: This indicates the script is JavaScript. The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.

[MDN page for `link`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link):

>This attribute is used to define the type of the content linked to. The value of the attribute should be a MIME type such as `text/html`, `text/css`, and so on. The common use of this attribute is to define the type of stylesheet being referenced (such as `text/css`), but given that CSS is the only stylesheet language used on the web, not only is it possible to omit the type attribute, but is actually now recommended practice. It is also used on `rel="preload"` link types, to make sure the browser only downloads file types that it supports.