### PR TITLE
Translate RangeError to Liquid::Error for truncatewords with large int

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ AllCops:
 Naming/MethodName:
   Exclude:
     - 'example/server/liquid_servlet.rb'
+
+Layout/BeginEndAlignment:
+  EnforcedStyleAlignWith: start_of_line

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -5,6 +5,7 @@ require 'bigdecimal'
 
 module Liquid
   module StandardFilters
+    MAX_INT = (1 << 31) - 1
     HTML_ESCAPE = {
       '&' => '&amp;',
       '>' => '&gt;',
@@ -93,7 +94,13 @@ module Liquid
       words = Utils.to_integer(words)
       words = 1 if words <= 0
 
-      wordlist = input.split(" ", words + 1)
+      wordlist = begin
+        input.split(" ", words + 1)
+      rescue RangeError
+        raise if words + 1 < MAX_INT
+        # e.g. integer #{words} too big to convert to `int'
+        raise Liquid::ArgumentError, "integer #{words} too big for truncatewords"
+      end
       return input if wordlist.length <= words
 
       wordlist.pop

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -178,6 +178,10 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('one two three...', @filters.truncatewords("one  two\tthree\nfour", 3))
     assert_equal('one two...', @filters.truncatewords("one two three four", 2))
     assert_equal('one...', @filters.truncatewords("one two three four", 0))
+    exception = assert_raises(Liquid::ArgumentError) do
+      @filters.truncatewords("one two three four", 1 << 31)
+    end
+    assert_equal("Liquid error: integer #{1 << 31} too big for truncatewords", exception.message)
   end
 
   def test_strip_html


### PR DESCRIPTION
## Problem

Passing a too large integer into the truncatewords filter (e.g. `{{ "" | truncatewords: 100000000000000 }}`) results in `Liquid error: internal` being output because it gets a RangeError exception that isn't a Liquid::Error.  Specifically, this is from the conversion in String#split of the integer into a C `int`, as seen by the exception message ```integer 100000000000001 too big to convert to `int'```

## Solution

Rescue the RangeError and re-raise it as a Liquid::ArgumentError if the number of words is out of range, so it doesn't get treated as an internal error and will instead output `Liquid error: integer 100000000000000 too big for truncatewords`