### PR TITLE
Don't re-raise InternalErrors, make new ones instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ template.render!({ 'x' => 1}, { strict_variables: true })
 #=> Liquid::UndefinedVariable: Liquid error: undefined variable y
 ```
 
+### Internal Errors
+Internal errors are errors are raised from your drops, filters or tags. These errors are intentionally opaque so as to avoid exposing internal workings to end users. However, when you define an `exception_renderer`, it will be passed an exception, which will be an instance of `Liquid::InternalError`, and it will have a property `original_exception` which you can use for reporting and debugging.
+
 ### Usage tracking
 
 To help track usages of a feature or code path in production, we have released opt-in usage tracking. To enable this, we provide an empty `Liquid:: Usage.increment` method which you can customize to your needs. The feature is well suited to https://github.com/Shopify/statsd-instrument. However, the choice of implementation is up to you.

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -261,7 +261,7 @@ module Liquid
     end
 
     def internal_error(e)
-      # raise and catch to set backtrace and cause on exception
+      # do not raise because raise/rescue is expensive
       exc = Liquid::InternalError.new('internal')
       exc.set_backtrace(caller)
       exc.original_exception = e

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -89,7 +89,7 @@ module Liquid
     end
 
     def handle_error(e, line_number = nil)
-      e = internal_error unless e.is_a?(Liquid::Error)
+      e = internal_error(e) unless e.is_a?(Liquid::Error)
       e.template_name ||= template_name
       e.line_number   ||= line_number
       errors.push(e)
@@ -260,10 +260,11 @@ module Liquid
       base_scope_depth + @scopes.length > Block::MAX_DEPTH
     end
 
-    def internal_error
+    def internal_error(e)
       # raise and catch to set backtrace and cause on exception
-      raise Liquid::InternalError, 'internal'
-    rescue Liquid::InternalError => exc
+      exc = Liquid::InternalError.new('internal')
+      exc.set_backtrace(caller)
+      exc.original_exception = e
       exc
     end
 

--- a/lib/liquid/errors.rb
+++ b/lib/liquid/errors.rb
@@ -40,6 +40,10 @@ module Liquid
     end
   end
 
+  class InternalError < Error
+    attr_accessor :original_exception
+  end
+
   ArgumentError       = Class.new(Error)
   ContextError        = Class.new(Error)
   FileSystemError     = Class.new(Error)
@@ -54,5 +58,4 @@ module Liquid
   UndefinedFilter     = Class.new(Error)
   MethodOverrideError = Class.new(Error)
   DisabledError       = Class.new(Error)
-  InternalError       = Class.new(Error)
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -230,7 +230,7 @@ class ErrorHandlingTest < Minitest::Test
     exceptions = []
     handler    = ->(e) {
       exceptions << e
-      e.cause
+      e.original_exception
     }
 
     output = template.render({ 'errors' => ErrorDrop.new }, exception_renderer: handler)
@@ -238,7 +238,7 @@ class ErrorHandlingTest < Minitest::Test
     assert_equal('This is a runtime error: runtime error', output)
     assert_equal([Liquid::InternalError], exceptions.map(&:class))
     assert_equal(exceptions, template.errors)
-    assert_equal('#<RuntimeError: runtime error>', exceptions.first.cause.inspect)
+    assert_equal('#<RuntimeError: runtime error>', exceptions.first.original_exception.inspect)
   end
 
   class TestFileSystem


### PR DESCRIPTION
Exceptions in Ruby are slow. They've been slow for a long time.
https://simonecarletti.com/blog/2010/01/how-slow-are-ruby-exceptions/
https://www.honeybadger.io/blog/benchmarking-exceptions-in-ruby-yep-theyre-slow/

At my company we're on Ruby 2.4 and the benchmark results are much the same as in 2.2 from the Honeybadger post.

To be completely honest, this started because I did not know about `RuntimeException#cause`, and debugging instances of `Liquid::InternalError` has always confounded me. I figured "I can make Liquid marginally faster and infinitely easier to debug by adding `#original_exception`", but lo and behold, `#cause` was already around. So I guess I'll have to settle for "marginally faster and better documented."

Benchmarks haven't really budged, but I haven't delved into how that all works to see if runtime exceptions are part of the story.