### PR TITLE
Base64 Decode & Encode Filters

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,9 @@
 
 ## 5.0.2 (unreleased)
 
+### Features
+* Add `base64_encode`, `base64_decode`, `base64_url_safe_encode`, and `base64_url_safe_decode` filters (#1450) [Daniel Insley]
+
 ### Fixes
 * Fix support for using a String subclass for the liquid source (#1421) [Dylan Thacker-Smith]
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'base64'
 require 'bigdecimal'
 
 module Liquid
@@ -61,6 +62,16 @@ module Liquid
       raise Liquid::ArgumentError, "invalid byte sequence in #{result.encoding}" unless result.valid_encoding?
 
       result
+    end
+
+    def base64_encode(input)
+      return nil if input.nil?
+      Base64.strict_encode64(input.to_s)
+    end
+
+    def base64_decode(input)
+      return nil if input.nil?
+      Base64.decode64(input.to_s)
     end
 
     def slice(input, offset, length = nil)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -69,11 +69,9 @@ module Liquid
     end
 
     def base64_decode(input)
-      begin
-        Base64.strict_decode64(input.to_s)
-      rescue ::ArgumentError
-        raise Liquid::ArgumentError, "invalid base64 provided to base64_decode"
-      end
+      Base64.strict_decode64(input.to_s)
+    rescue ::ArgumentError
+      raise Liquid::ArgumentError, "invalid base64 provided to base64_decode"
     end
 
     def base64_url_safe_encode(input)
@@ -81,11 +79,9 @@ module Liquid
     end
 
     def base64_url_safe_decode(input)
-      begin
-        Base64.urlsafe_decode64(input.to_s)
-      rescue ::ArgumentError
-        raise Liquid::ArgumentError, "invalid base64 provided to base64_url_safe_decode"
-      end
+      Base64.urlsafe_decode64(input.to_s)
+    rescue ::ArgumentError
+      raise Liquid::ArgumentError, "invalid base64 provided to base64_url_safe_decode"
     end
 
     def slice(input, offset, length = nil)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -65,13 +65,27 @@ module Liquid
     end
 
     def base64_encode(input)
-      return nil if input.nil?
       Base64.strict_encode64(input.to_s)
     end
 
     def base64_decode(input)
-      return nil if input.nil?
-      Base64.decode64(input.to_s)
+      begin
+        Base64.strict_decode64(input.to_s)
+      rescue ::ArgumentError
+        raise Liquid::ArgumentError, "invalid base64 provided to base64_decode"
+      end
+    end
+
+    def base64_url_safe_encode(input)
+      Base64.urlsafe_encode64(input.to_s)
+    end
+
+    def base64_url_safe_decode(input)
+      begin
+        Base64.urlsafe_decode64(input.to_s)
+      rescue ::ArgumentError
+        raise Liquid::ArgumentError, "invalid base64 provided to base64_url_safe_decode"
+      end
     end
 
     def slice(input, offset, length = nil)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -157,7 +157,7 @@ class StandardFiltersTest < Minitest::Test
       @filters.base64_decode("invalidbase64")
     end
 
-    assert_equal 'Liquid error: invalid base64 provided to base64_decode', exception.message
+    assert_equal('Liquid error: invalid base64 provided to base64_decode', exception.message)
   end
 
   def test_base64_url_safe_encode
@@ -176,7 +176,7 @@ class StandardFiltersTest < Minitest::Test
     exception = assert_raises(Liquid::ArgumentError) do
       @filters.base64_url_safe_decode("invalidbase64")
     end
-    assert_equal 'Liquid error: invalid base64 provided to base64_url_safe_decode', exception.message
+    assert_equal('Liquid error: invalid base64 provided to base64_url_safe_decode', exception.message)
   end
 
   def test_url_encode

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -145,6 +145,16 @@ class StandardFiltersTest < Minitest::Test
     assert_equal('&lt;strong&gt;Hulk&lt;/strong&gt;', @filters.escape_once('&lt;strong&gt;Hulk</strong>'))
   end
 
+  def test_base64_encode
+    assert_equal('b25lIHR3byB0aHJlZQ==', @filters.base64_encode('one two three'))
+    assert_nil(@filters.base64_encode(nil))
+  end
+
+  def test_base64_decode
+    assert_equal('one two three', @filters.base64_decode('b25lIHR3byB0aHJlZQ=='))
+    assert_nil(@filters.base64_decode(nil))
+  end
+
   def test_url_encode
     assert_equal('foo%2B1%40example.com', @filters.url_encode('foo+1@example.com'))
     assert_equal('1', @filters.url_encode(1))

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -147,12 +147,36 @@ class StandardFiltersTest < Minitest::Test
 
   def test_base64_encode
     assert_equal('b25lIHR3byB0aHJlZQ==', @filters.base64_encode('one two three'))
-    assert_nil(@filters.base64_encode(nil))
+    assert_equal('', @filters.base64_encode(nil))
   end
 
   def test_base64_decode
     assert_equal('one two three', @filters.base64_decode('b25lIHR3byB0aHJlZQ=='))
-    assert_nil(@filters.base64_decode(nil))
+
+    exception = assert_raises(Liquid::ArgumentError) do
+      @filters.base64_decode("invalidbase64")
+    end
+
+    assert_equal 'Liquid error: invalid base64 provided to base64_decode', exception.message
+  end
+
+  def test_base64_url_safe_encode
+    assert_equal(
+      'YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXogQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVogMTIzNDU2Nzg5MCAhQCMkJV4mKigpLT1fKy8_Ljo7W117fVx8',
+      @filters.base64_url_safe_encode('abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 !@#$%^&*()-=_+/?.:;[]{}\|')
+    )
+    assert_equal('', @filters.base64_url_safe_encode(nil))
+  end
+
+  def test_base64_url_safe_decode
+    assert_equal(
+      'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 !@#$%^&*()-=_+/?.:;[]{}\|',
+      @filters.base64_url_safe_decode('YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXogQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVogMTIzNDU2Nzg5MCAhQCMkJV4mKigpLT1fKy8_Ljo7W117fVx8')
+    )
+    exception = assert_raises(Liquid::ArgumentError) do
+      @filters.base64_url_safe_decode("invalidbase64")
+    end
+    assert_equal 'Liquid error: invalid base64 provided to base64_url_safe_decode', exception.message
   end
 
   def test_url_encode


### PR DESCRIPTION
This is a proposed new addition for a base64 encode/decode filter, as well as a URL safe version. This would allow proper JWT creation within liquid in conjunction with the `hmac_sha256` filter (which I think is in a non-public Shopify fork).

This would help mitigate quite a few issues that we've run across where we're integrating and authenticating on apps outside of Shopify to extend the functionality.

### Usage

#### base64_encode / base64_decode

```
  {{ "one two three" | base64_encode }} -> b25lIHR3byB0aHJlZQ==
  {{ "b25lIHR3byB0aHJlZQ==" | base64_decode }} -> one two three
```

#### base64_url_safe_encode / base64_url_safe_decode

```
{{ "https://shopify.com" | base64_url_safe_encode }}
{{ "aHR0cHM6Ly9zaG9waWZ5LmNvbQ==" | base64_url_safe_decode }}
```