### PR TITLE
utilize input's to_liquid_value on default filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -447,7 +447,7 @@ module Liquid
     #
     def default(input, default_value = '', options = {})
       options = {} unless options.is_a?(Hash)
-      false_check = options['allow_false'] ? input.nil? : !input
+      false_check = options['allow_false'] ? input.nil? : !Liquid::Utils.to_liquid_value(input)
       false_check || (input.respond_to?(:empty?) && input.empty?) ? default_value : input
     end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -694,6 +694,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal("bar", @filters.default([], "bar"))
     assert_equal("bar", @filters.default({}, "bar"))
     assert_template_result('bar', "{{ false | default: 'bar' }}")
+    assert_template_result('bar', "{{ drop | default: 'bar' }}", 'drop' => BooleanDrop.new(false))
+    assert_template_result('Yay', "{{ drop | default: 'bar' }}", 'drop' => BooleanDrop.new(true))
   end
 
   def test_default_handle_false
@@ -704,6 +706,8 @@ class StandardFiltersTest < Minitest::Test
     assert_equal("bar", @filters.default([], "bar", "allow_false" => true))
     assert_equal("bar", @filters.default({}, "bar", "allow_false" => true))
     assert_template_result('false', "{{ false | default: 'bar', allow_false: true }}")
+    assert_template_result('Nay', "{{ drop | default: 'bar', allow_false: true }}", 'drop' => BooleanDrop.new(false))
+    assert_template_result('Yay', "{{ drop | default: 'bar', allow_false: true }}", 'drop' => BooleanDrop.new(true))
   end
 
   def test_cannot_access_private_methods


### PR DESCRIPTION
## What are you trying to accomplish?
`default` needs to check the input's `to_liquid_value` for boolean evaluation.
For input, we could have a `BooleanDrop` with a false value, and currently, it will be evaluated as a true since `input` is an object.

## How are you solving this?
Evaluate `to_liquid_value` of the `input` in `default` filter.

```ruby
class BooleanDrop < Liquid::Drop
  def initialize v
    @v = v
  end

  def to_liquid_value
    @v
  end
end

Liquid::Template.parse(
  "{{ drop | default: 'bar' }}""
).render(
  "drop" => BooleanDrop.new(false),
)
# bar
```
