### PR TITLE
Fix benchmark for breaking change in Psych 4

### DIFF
--- a/performance/shopify/database.rb
+++ b/performance/shopify/database.rb
@@ -3,11 +3,19 @@
 require 'yaml'
 
 module Database
+  DATABASE_FILE_PATH = "#{__dir__}/vision.database.yml"
+
   # Load the standard vision toolkit database and re-arrage it to be simply exportable
   # to liquid as assigns. All this is based on Shopify
   def self.tables
     @tables ||= begin
-      db = YAML.load_file("#{__dir__}/vision.database.yml")
+      db =
+        if YAML.respond_to?(:unsafe_load_file) # Only Psych 4+ can use unsafe_load_file
+          # unsafe_load_file is needed for YAML references
+          YAML.unsafe_load_file(DATABASE_FILE_PATH)
+        else
+          YAML.load_file(DATABASE_FILE_PATH)
+        end
 
       # From vision source
       db['products'].each do |product|


### PR DESCRIPTION
Psych 4 introduces a breaking change (ruby/psych#487) where `Psych#load`/`Psych#load_file` now default to safe loading, meaning that YAML references are not allowed anymore. This commit changes the benchmark to use `Psych#unsafe_load_file` when it's available.