### PR TITLE
use Utils.to_liquid_value on conditionals

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -134,8 +134,8 @@ module Liquid
       # return this as the result.
       return context.evaluate(left) if op.nil?
 
-      left  = context.evaluate(left)
-      right = context.evaluate(right)
+      left  = Liquid::Utils.to_liquid_value(context.evaluate(left))
+      right = Liquid::Utils.to_liquid_value(context.evaluate(right))
 
       operation = self.class.operators[op] || raise(Liquid::ArgumentError, "Unknown operator #{op}")
 

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -25,6 +25,8 @@ class VariableTest < Minitest::Test
 
   def test_if_tag_calls_to_liquid_value
     assert_template_result('one', '{% if foo == 1 %}one{% endif %}', 'foo' => IntegerDrop.new('1'))
+    assert_template_result('one', '{% if 0 < foo %}one{% endif %}', 'foo' => IntegerDrop.new('1'))
+    assert_template_result('one', '{% if foo > 0 %}one{% endif %}', 'foo' => IntegerDrop.new('1'))
     assert_template_result('true', '{% if foo == true %}true{% endif %}', 'foo' => BooleanDrop.new(true))
     assert_template_result('true', '{% if foo %}true{% endif %}', 'foo' => BooleanDrop.new(true))
 


### PR DESCRIPTION
## What are you trying to accomplish?
We have found a bug where re-ordering the comparison with a `Liquid::Drop` and an `Integer` will evaluate differently.

```ruby
require 'liquid'

class IntegerDrop < Liquid::Drop
  include Comparable 

  def initialize(value)
    @value = value.to_i
  end

  def <=> other
    @value <=> other
  end

  def to_liquid_value
    @value
  end
end

template_a = "{% if int > 71 %}int is bigger than 71 {% endif %}"
template_b = "{% if 71 < int %}int is bigger than 71 {% endif %}"

Liquid::Template.parse(template_a).render('int' => IntegerDrop.new(100))
# int is bigger than 71
Liquid::Template.parse(template_b).render('int' => IntegerDrop.new(100))
# Liquid error: comparison of Integer with IntegerDrop failed
```

## How are you solving this issue
In this PR, `Condition` has been updated to utilize `Utils.to_liquid_value`.
On an evaluation, it will use the object's `to_liquid_value` for comparisons.
