### PR TITLE
Add ParseTreeVisitor to RangeLookup

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -8,7 +8,7 @@ module Liquid
   #   c = Condition.new(1, '==', 1)
   #   c.evaluate #=> true
   #
-  class Condition #:nodoc:
+  class Condition # :nodoc:
     @@operators = {
       '==' => ->(cond, left, right) {  cond.send(:equal_variables, left, right) },
       '!=' => ->(cond, left, right) { !cond.send(:equal_variables, left, right) },

--- a/lib/liquid/range_lookup.rb
+++ b/lib/liquid/range_lookup.rb
@@ -12,6 +12,8 @@ module Liquid
       end
     end
 
+    attr_reader :start_obj, :end_obj
+
     def initialize(start_obj, end_obj)
       @start_obj = start_obj
       @end_obj   = end_obj
@@ -33,6 +35,12 @@ module Liquid
         input.to_i
       else
         Utils.to_integer(input)
+      end
+    end
+
+    class ParseTreeVisitor < Liquid::ParseTreeVisitor
+      def children
+        [@node.start_obj, @node.end_obj]
       end
     end
   end

--- a/test/unit/parse_tree_visitor_test.rb
+++ b/test/unit/parse_tree_visitor_test.rb
@@ -159,6 +159,13 @@ class ParseTreeVisitorTest < Minitest::Test
     )
   end
 
+  def test_for_range
+    assert_equal(
+      ["test"],
+      visit(%({% for x in (1..test) %}{% endfor %}))
+    )
+  end
+
   def test_tablerow_in
     assert_equal(
       ["test"],


### PR DESCRIPTION
Found out about this because of Shopify/theme-check#435.

The visitor was not visiting range lookups.
