### PR TITLE
Improve where filter tests

### DIFF
--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -770,6 +770,18 @@ class StandardFiltersTest < Minitest::Test
     assert_equal(expectation, @filters.where(input, "ok"))
   end
 
+  def test_where_string_keys
+    input = [
+      "alpha", "beta", "gamma", "delta"
+    ]
+
+    expectation = [
+      "beta"
+    ]
+
+    assert_equal(expectation, @filters.where(input, "be"))
+  end
+
   def test_where_no_key_set
     input = [
       { "handle" => "alpha", "ok" => true },


### PR DESCRIPTION
This makes sure a feature _(Which may be caused by a bug)_ is tested. I've seen this used in a few themes.

This is mainly used on tags within Shopify.

```liquid
assign tags = product.tags | where: 'some_prefix:'
```

This will get all tags starting with `some_prefix:`.