### PR TITLE
Clarify that the error_mode: :warn parse option is only for strict errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ when templates are invalid. You can enable this new parser like this:
 
 ```ruby
 Liquid::Template.error_mode = :strict # Raises a SyntaxError when invalid syntax is used
-Liquid::Template.error_mode = :warn # Adds errors to template.errors but continues as normal
+Liquid::Template.error_mode = :warn # Adds strict errors to template.errors but continues as normal
 Liquid::Template.error_mode = :lax # The default mode, accepts almost anything.
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Liquid::Template.error_mode = :lax # The default mode, accepts almost anything.
 
 If you want to set the error mode only on specific templates you can pass `:error_mode` as an option to `parse`:
 ```ruby
-Liquid::Template.parse(source, :error_mode => :strict)
+Liquid::Template.parse(source, error_mode: :strict)
 ```
 This is useful for doing things like enabling strict mode only in the theme editor.
 


### PR DESCRIPTION
Fixes #1389
cc @greenfork, @bobbytables

Would this have made the documentation clear enough to avoid some of the confusion around the behaviour of `error_mode: :warn`? Do you have any other suggestions?