### PR TITLE
Fix some internal errors in filters from invalid input.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 # Liquid Change Log
 
+## 5.1.1 (unreleased)
+
+### Fixes
+
+* Fix some internal errors in filters from invalid input [Dylan Thacker-Smith]
+
 ## 5.1.0 / 2021-09-09
 
 ### Features

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -259,8 +259,8 @@ class StandardFiltersTest < Minitest::Test
       { "price" => 1, "handle" => "gamma" },
       { "price" => 2, "handle" => "epsilon" },
       { "price" => 4, "handle" => "alpha" },
-      { "handle" => "delta" },
       { "handle" => "beta" },
+      { "handle" => "delta" },
     ]
     assert_equal(expectation, @filters.sort(input, "price"))
   end
@@ -852,19 +852,14 @@ class StandardFiltersTest < Minitest::Test
       { 1 => "bar" },
       ["foo", 123, nil, true, false, Drop, ["foo"], { foo: "bar" }],
     ]
-    test_types.each do |first|
-      test_types.each do |other|
-        (@filters.methods - Object.methods).each do |method|
-          arg_count = @filters.method(method).arity
-          arg_count *= -1 if arg_count < 0
-          inputs = [first]
-          inputs << ([other] * (arg_count - 1)) if arg_count > 1
-          begin
-            @filters.send(method, *inputs)
-          rescue Liquid::ArgumentError, Liquid::ZeroDivisionError
-            nil
-          end
-        end
+    StandardFilters.public_instance_methods(false).each do |method|
+      arg_count = @filters.method(method).arity
+      arg_count *= -1 if arg_count < 0
+
+      test_types.repeated_permutation(arg_count) do |args|
+        @filters.send(method, *args)
+      rescue Liquid::Error
+        nil
       end
     end
   end


### PR DESCRIPTION
## Problem

While reviewing https://github.com/Shopify/liquid/pull/1422 I noticed that StandardFilters#test_all_filters_never_raise_non_liquid_exception was doing a lot of redundant work and started to change it to make it more scalable and general.  In the process, I noticed that it also wasn't passing in a default argument, which prevented it from finding some code paths that could result in internal errors.

## Solution

I used Array#repeated_permutation in StandardFilters#test_all_filters_never_raise_non_liquid_exception so it would test permutations in proportion to the arity of the filter.  If the filter method takes optional arguments, then pass in an optional argument in addition to the required arguments.

This uncovered a few errors:
* there were a some `ary.first.respond_to?(:[])` checks which assumed the array had elements of a homogenous type, which could result in an internal error if the first argument responded to `[]` but a following one didn't.  I added a `rescue NoMethodError` to handle these errors.
* Sorting could have an error from comparing incompatible types.  I added a fast path for elements that are comparable and added an extra else case for when neither incomparable items are `nil` to explicitly raise a liquid error.

Note that I haven't actually checked if these internal errors are happening in practice.