### PR TITLE
Increase parsing performance

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -231,8 +231,8 @@ module Liquid
     end
 
     def create_variable(token, parse_context)
-      token.scan(ContentOfVariable) do |content|
-        markup = content.first
+      if token =~ ContentOfVariable
+        markup = Regexp.last_match(1)
         return Variable.new(markup, parse_context)
       end
       BlockBody.raise_missing_variable_terminator(token, parse_context)

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -10,21 +10,23 @@ module Liquid
       'empty' => ''
     }.freeze
 
-    SINGLE_QUOTED_STRING = /\A\s*'(.*)'\s*\z/m
-    DOUBLE_QUOTED_STRING = /\A\s*"(.*)"\s*\z/m
-    INTEGERS_REGEX       = /\A\s*(-?\d+)\s*\z/
-    FLOATS_REGEX         = /\A\s*(-?\d[\d\.]+)\s*\z/
+    INTEGERS_REGEX       = /\A(-?\d+)\z/
+    FLOATS_REGEX         = /\A(-?\d[\d\.]+)\z/
 
     # Use an atomic group (?>...) to avoid pathological backtracing from
     # malicious input as described in https://github.com/Shopify/liquid/issues/1357
-    RANGES_REGEX         = /\A\s*\(\s*(?>(\S+)\s*\.\.)\s*(\S+)\s*\)\s*\z/
+    RANGES_REGEX         = /\A\(\s*(?>(\S+)\s*\.\.)\s*(\S+)\s*\)\z/
 
     def self.parse(markup)
+      return nil unless markup
+
+      markup = markup.strip
+      if (markup.start_with?('"') && markup.end_with?('"')) ||
+         (markup.start_with?("'") && markup.end_with?("'"))
+        return markup[1..-2]
+      end
+
       case markup
-      when nil
-        nil
-      when SINGLE_QUOTED_STRING, DOUBLE_QUOTED_STRING
-        Regexp.last_match(1)
       when INTEGERS_REGEX
         Regexp.last_match(1).to_i
       when RANGES_REGEX
@@ -32,7 +34,6 @@ module Liquid
       when FLOATS_REGEX
         Regexp.last_match(1).to_f
       else
-        markup = markup.strip
         if LITERALS.key?(markup)
           LITERALS[markup]
         else


### PR DESCRIPTION
This PR will increase parsing performance slightly.

−               | before   | after   | result
--               | --       | --      | --
parse            | 66.675   | 70.205  | 1.053x
render           | 225.502  | 225.397 | -
parse & render   | 48.816   | 50.937  | 1.043x


### Environment
- MacBook Air (M1, 2020)
- macOS 12.0 beta 7
- Apple M1
- Ruby 3.0.2

### Before
```
$ rake benchmark:run
/Users/watson/.rbenv/versions/3.0.2/bin/ruby ./performance/benchmark.rb lax

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     6.000  i/100ms
             render:    22.000  i/100ms
     parse & render:     4.000  i/100ms
Calculating -------------------------------------
              parse:     66.675  (± 0.0%) i/s -    672.000  in  10.078787s
             render:    225.502  (± 0.9%) i/s -      2.266k in  10.049823s
     parse & render:     48.816  (± 0.0%) i/s -    492.000  in  10.078850s
```

### After
```
$ rake benchmark:run
/Users/watson/.rbenv/versions/3.0.2/bin/ruby ./performance/benchmark.rb lax

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     6.000  i/100ms
             render:    21.000  i/100ms
     parse & render:     5.000  i/100ms
Calculating -------------------------------------
              parse:     70.205  (± 0.0%) i/s -    708.000  in  10.084957s
             render:    225.397  (± 0.9%) i/s -      2.268k in  10.063268s
     parse & render:     50.937  (± 0.0%) i/s -    510.000  in  10.012423s
```