### PR TITLE
Fix resource limit scores resetting on include

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -184,7 +184,7 @@ module Liquid
       end
 
       # Retrying a render resets resource usage
-      context.resource_limits.reset
+      context.resource_limits.reset unless context.partial
 
       if @profiling && context.profiler.nil?
         @profiler = context.profiler = Liquid::Profiler.new

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -129,6 +129,13 @@ class IncludeTagTest < Minitest::Test
       'echo1' => 'test123', 'more_echos' => { "echo2" => 'test321' })
   end
 
+  def test_include_tag_does_not_reset_resource_limits
+    t = Template.parse("{% for a in (0..10) %}x{% assign foo = 1 %} {% endfor %}{% include 'product' with products[0] %}")
+    t.render!({ "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+    assert(t.resource_limits.assign_score > 10)
+    assert(t.resource_limits.render_score > 10)
+  end
+
   def test_included_templates_assigns_variables
     assert_template_result("bar", "{% include 'assignments' %}{{ foo }}")
   end


### PR DESCRIPTION
When `include` is used in a template, it'll go through `Liquid::Template#render`, which is called on a new template instance but with the same context. Meaning the "partial" that was included will keep using & updating the same `Liquid::ResourceLimits` instance. Among those updates though, there is an initial, unconditional reset of the scores done inside `Liquid::Template#render`.

After this fix, the reset will only be applied if the method was not called inside a partial context.