### PR TITLE
Deterministic cycle keys

### DIFF
--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -26,8 +26,8 @@ module Liquid
         @variables = variables_from_string(Regexp.last_match(2))
         @name      = parse_expression(Regexp.last_match(1))
       when SimpleSyntax
-        @variables = variables_from_string(markup)
-        @name      = @variables.to_s
+        @variables, names = variables_and_names_from_string(markup)
+        @name             = names.to_s
       else
         raise SyntaxError, options[:locale].t("errors.syntax.cycle")
       end
@@ -63,6 +63,18 @@ module Liquid
         var =~ /\s*(#{QuotedFragment})\s*/o
         Regexp.last_match(1) ? parse_expression(Regexp.last_match(1)) : nil
       end.compact
+    end
+
+    def variables_and_names_from_string(markup)
+      markup.split(',').collect do |var|
+        next unless var =~ /\s*(#{QuotedFragment})\s*/o
+        object = parse_expression(Regexp.last_match(1))
+        if object.respond_to?(:evaluate)
+          [object, "#{object.class}-#{Regexp.last_match(1)}"]
+        else
+          [object, object]
+        end
+      end.transpose
     end
 
     class ParseTreeVisitor < Liquid::ParseTreeVisitor

--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -272,6 +272,62 @@ class StandardTagTest < Minitest::Test
       '{%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %}', assigns)
   end
 
+  def test_cycle_variables_from_context
+    assigns = { "a" => 1, "b" => 2, "c" => 3 }
+    assert_template_result('1 2 3', '{%cycle a,b,c%} {%cycle a,b,c%} {%cycle a,b,c%}', assigns)
+  end
+
+  def test_cycle_undefined_variables
+    assert_template_result('  ', '{%cycle a,b,c%} {%cycle a,b,c%} {%cycle a,b,c%}')
+  end
+
+  def test_cycle_string_and_integer_keys
+    assert_template_result('1 1 2 2', '{%cycle 1,2,3%} {%cycle "1","2","3"%} {%cycle 1,2,3%} {%cycle "1","2","3"%}')
+  end
+
+  def test_cycle_mixed_context_variables_and_literals
+    assigns = { "a" => 1, "b" => 2 }
+    assert_template_result(
+      '1 2 three 1',
+      '{%cycle a,b,"three"%} {%cycle a,b,"three"%} {%cycle a,b,"three"%} {%cycle a,b,"three"%}',
+      assigns
+    )
+  end
+
+  def test_cycle_boolean_literals
+    assert_template_result(
+      'true true false true',
+      '{%cycle true, true, false%} {%cycle true, true, false%} {%cycle true, true, false%} {%cycle true, true, false%}',
+    )
+  end
+
+  def test_cycle_variable_keys_dont_conflict_with_literals
+    assigns = { "a" => 1, "b" => 2, "c" => 3 }
+    assert_template_result(
+      '1 1 2 c',
+      '{%cycle a,b,"c"%} {%cycle a,b,c%} {%cycle a,b,"c"%} {%cycle a,b,"c"%}',
+      assigns
+    )
+  end
+
+  def test_cycle_over_changing_context_variables
+    assigns = { "a" => 1, "b" => 2, "c" => 3 }
+    assert_template_result(
+      '1 2 z x',
+      '{%cycle a,b,c%} {%assign a="x"%}{%assign c="z"%}{%cycle a,b,c%} {%cycle a,b,c%} {%cycle a,b,c%}',
+      assigns
+    )
+  end
+
+  def test_cycle_with_a_changing_variable_name
+    assigns = { "x" => "var1" }
+    assert_template_result(
+      'a a b',
+      '{%cycle x: "a","b","c"%} {%assign x="var2" %}{%cycle x: "a","b","c"%} {%cycle x: "a","b","c"%}',
+      assigns
+    )
+  end
+
   def test_size_of_array
     assigns = { "array" => [1, 2, 3, 4] }
     assert_template_result('array has 4 elements', "array has {{ array.size }} elements", assigns)


### PR DESCRIPTION
This pull request fixes #1519 by offering an alternative method for generating context keys for the `cycle` tag when using "simple syntax".

Rather than using a string representation of objects returned from `parse_expression()`, we combine the object's class name and input argument, separated by a hyphen.

For example, given a identifier that gets parsed to a `Liquid::VariableLookup`, instead of a key containing something like `"<Liquid::VariableLookup:0x00005632631bc858>"`, which changes with every occurrence of `{% cycle %}`, we would get `"VariableLookup-x"`. Where `x` is the input argument.

Extra care has been take to handle `Liquid::C::Expression` objects. Hence the use of `object.respond_to?(:evaluate)` and the reason for generating key strings at the same time as parsing each expression.
