### PR TITLE
Add missing changelog entry for PR #1518

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 * Fix some internal errors in filters from invalid input (#1476) [Dylan Thacker-Smith]
+* Allow dash in filter kwarg name for consistency with Liquid::C (#1518) [CP Clermont]
 
 ## 5.1.0 / 2021-09-09
 


### PR DESCRIPTION
A changelog entry wasn't added by https://github.com/Shopify/liquid/pull/1518, yet it introduces a fix that would be quite relevant for liquid upgrades