### PR TITLE
Increase performance in VariableLookup

### DIFF
--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -12,7 +12,7 @@ module Liquid
     end
 
     def initialize(markup)
-      lookups = markup.scan(VariableParser)
+      lookups = tokenize(markup)
 
       name = lookups.shift
       if name =~ SQUARE_BRACKETED
@@ -82,6 +82,16 @@ module Liquid
 
     def state
       [@name, @lookups, @command_flags]
+    end
+
+    private
+
+    def tokenize(markup)
+      if markup.match?(SQUARE_BRACKETED)
+        markup.scan(VariableParser)
+      else
+        markup.split('.')
+      end
     end
 
     class ParseTreeVisitor < Liquid::ParseTreeVisitor


### PR DESCRIPTION
It is faster to use String#split when available, rather than using String#scan to tokenize a string for variable.

```
VariableSignature           = /\(?[\w\-\.\[\]]\)?/
```
If the string for variable does not have `SQUARE_BRACKETED`, then it has `'\w'`, `'-'` and `'.'` characters by `VariableSignature`.

```
VariableSegment             = /[\w\-]/
```
Since it is only extracting the characters that match `VariableSegment` rule, so it can simply use `'.'` to split the string.

−               | before   | after   | result
--               | --       | --      | --
parse            | 66.567   | 72.815  | 1.094x
render           | 222.191  | 223.829 | -
parse & render   | 48.295   | 52.275  | 1.082x

### Environment
- MacBook Pro (14 inch, 2021)
- macOS 12.3 beta
- Apple M1 Max
- Ruby 3.0.3

### Before
```
$ ruby -v benchmark.rb
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [arm64-darwin21]

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     6.000  i/100ms
             render:    21.000  i/100ms
     parse & render:     4.000  i/100ms
Calculating -------------------------------------
              parse:     66.567  (± 0.0%) i/s -    666.000  in  10.005345s
             render:    222.191  (± 1.4%) i/s -      2.226k in  10.020448s
     parse & render:     48.295  (± 2.1%) i/s -    484.000  in  10.031455s
```

### After
```
$ ruby -v benchmark.rb
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [arm64-darwin21]

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     7.000  i/100ms
             render:    22.000  i/100ms
     parse & render:     5.000  i/100ms
Calculating -------------------------------------
              parse:     72.815  (± 0.0%) i/s -    735.000  in  10.094441s
             render:    223.829  (± 1.3%) i/s -      2.244k in  10.027316s
     parse & render:     52.275  (± 0.0%) i/s -    525.000  in  10.043554s
```
