### PR TITLE
[StandardFilter] Fix missing @context on iterations

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,9 @@
 
 ## 5.3.0 (unreleased)
 
+### Fixes
+* StandardFilter: Fix missing @context on iterations (#1525) [Thierry Joyal]
+
 ### Deprecation
 * Condition#evaluate to require mandatory context argument in Liquid 6.0.0 (#1527) [Thierry Joyal]
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -582,8 +582,9 @@ module Liquid
 
       def each
         @input.each do |e|
+          e = e.respond_to?(:to_liquid) ? e.to_liquid : e
           e.context = @context if e.respond_to?(:context=)
-          yield(e.respond_to?(:to_liquid) ? e.to_liquid : e)
+          yield(e)
         end
       end
     end


### PR DESCRIPTION
The existing code was trying to assign `@context` via `context=` before the input being converted to a Liquid aware representation.

As the previous code reads, this leads to “liquid aware objects” without the notion of “`@context`” resulting in unexpected behaviours.

I think this proposed change is safe to add in.

## Extra thinking

I see this proposed change as a temporary patch over a larger issue. 

I am not at ease with the idea of offloading the responsibility of sanitization of liquid conversion 
and context assignment to filters. Standard filter we own in this repository, but I do not think it is safe for all the filters in the wild to do this properly.

I started looking at how we could do this layer of logic upstream via a mix of lib/liquid/context.rb and potentially lib/liquid/extensions.rb so that filters do not need to worry about it.

In this snippet of code you will also see a `e.respond_to?(:to_liquid)` and this worries me. Shouldn’t all user objects exposed to the liquid runtime answer to `to_liquid`? `Context#invoke` and `Context#find_variable` make that assumption. This could either be considered a breaking change or a bugfix. I would love to also see `e.respond_to?(:context=)` to be required, but I’m fine for now ignoring it.

Finally, I’ve started looking at this issue for cases where `@context` is empty (not `nil` as in this bugfix). I do see some places in the code where we potentially create a new `@context` when missing. I’m not sure this issue is strictly rooted in the Liquid codebase, but I’ll see what can be cleaned up as I continue investigating for reproduction steps.

There is also a `return nil unless @context&.strict_variables` in the code which most likely also stem from the same line of issues.

Related to https://github.com/Shopify/liquid/issues/1205 (Execution paths missing @context)
