### PR TITLE
Liquid::Drop: Expect @context to always be set

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,12 @@
 # Liquid Change Log
 
+## 5.2.1 (unreleased)
+
+### Features
+
+### Fixes
+* Liquid::Drop: Expect @context to always be set (#1528) [Thierry Joyal]
+
 ## 5.2.0 2021-03-01
 
 ### Features

--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -27,7 +27,7 @@ module Liquid
 
     # Catch all for the method
     def liquid_method_missing(method)
-      return nil unless @context&.strict_variables
+      return nil unless @context.strict_variables
       raise Liquid::UndefinedDropMethod, "undefined method #{method}"
     end
 


### PR DESCRIPTION
Liquid::Drop to always assume `@context` is set.

While this is the direction I think we need to take, I'm not sure this is a safe change to introduce yet until further exploration of reports regarding issues with `@context` being absent or reset. 

I think I would still go ahead and extract these tests as a pre-PR as they better reflect the production behavior and desired code coverage.

Related to https://github.com/Shopify/liquid/issues/1205 (Execution paths missing @context)
