### PR TITLE
StandardFiltersTest: Initialize following production code paths with context

### DIFF
--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -3,10 +3,6 @@
 
 require 'test_helper'
 
-class Filters
-  include Liquid::StandardFilters
-end
-
 class TestThing
   attr_reader :foo
 
@@ -53,10 +49,13 @@ class NumberLikeThing < Liquid::Drop
 end
 
 class StandardFiltersTest < Minitest::Test
+  Filters = Class.new(Liquid::StrainerTemplate)
+  Filters.add_filter(Liquid::StandardFilters)
+
   include Liquid
 
   def setup
-    @filters = Filters.new
+    @filters = Filters.new(Context.new)
   end
 
   def test_size


### PR DESCRIPTION
Tests only.

Extraction from https://github.com/Shopify/liquid/pull/1528 which I'm not yet confident to ship.

Rely on the `Liquid::StrainerTemplate` as opposed to an arbitrary module to test filters behaviors.

This change breaks the local encapsulation of the test, but better reflects production code paths.

Concrete impact: `@context` is now being set as it would be during runtime.
