### PR TITLE
Fix warning about block and default value

### DIFF
--- a/lib/liquid/static_registers.rb
+++ b/lib/liquid/static_registers.rb
@@ -31,7 +31,11 @@ module Liquid
       if @registers.key?(key)
         @registers.fetch(key)
       elsif default != UNDEFINED
-        @static.fetch(key, default, &block)
+        if block_given?
+          @static.fetch(key, &block)
+        else
+          @static.fetch(key, default)
+        end
       else
         @static.fetch(key, &block)
       end


### PR DESCRIPTION
Ruby's Array#fetch accepts either a default value or a block, but not
both. If both are passed in, then it uses the block and outputs this
warning:

```
lib/liquid/static_registers.rb:34: warning: block supersedes default value argument
```