### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         entry:
           - { ruby: 2.5, allowed-failure: false } # minimum supported
-          - { ruby: '3.0', allowed-failure: false }
           - { ruby: 3.1, allowed-failure: false } # latest
           - { ruby: ruby-head, allowed-failure: true }
     name: test (${{ matrix.entry.ruby }})


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

Also quoted the `3.0` so it is properly interpreted as 3.0 rather than 3.  An unquoted `3.0` is truncated to `3`, loading the latest Ruby 3 - at time of writing Ruby 3.1.1.  Adding quotes ensures that a Ruby 3.0.x version is loaded for this CI matrix entry.