### PR TITLE
Consolidate contextualization of inputs via the context

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 * StandardFilter: Fix missing @context on iterations (#1525) [Thierry Joyal]
+* Consolidate contextualization of inputs via the context (#XXX) [Thierry Joyal]
 
 ### Deprecation
 * Condition#evaluate to require mandatory context argument in Liquid 6.0.0 (#1527) [Thierry Joyal]

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -582,8 +582,7 @@ module Liquid
 
       def each
         @input.each do |e|
-          e = e.respond_to?(:to_liquid) ? e.to_liquid : e
-          e.context = @context if e.respond_to?(:context=)
+          e = @context.contextualize(e)
           yield(e)
         end
       end

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -49,15 +49,14 @@ module Liquid
             ((object.respond_to?(:key?) && object.key?(key)) ||
              (object.respond_to?(:fetch) && key.is_a?(Integer)))
 
-          # if its a proc we will replace the entry with the proc
-          res    = context.lookup_and_evaluate(object, key)
-          object = res.to_liquid
+          object = context.lookup_and_evaluate(object, key)
 
           # Some special cases. If the part wasn't in square brackets and
           # no key with the same name was found we interpret following calls
           # as commands and call them on the current object
         elsif @command_flags & (1 << i) != 0 && object.respond_to?(key)
-          object = object.send(key).to_liquid
+          object = object.send(key)
+          object = context.contextualize(object)
 
           # No key was present with the desired value and it wasn't one of the directly supported
           # keywords either. The only thing we got left is to return nil or
@@ -66,9 +65,6 @@ module Liquid
           return nil unless context.strict_variables
           raise Liquid::UndefinedVariable, "undefined variable #{key}"
         end
-
-        # If we are dealing with a drop here we have to
-        object.context = context if object.respond_to?(:context=)
       end
 
       object

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -34,6 +34,10 @@ class TestDrop < Liquid::Drop
   def registers
     @context.registers
   end
+
+  def to_s
+    "TestDrop(value:#{@value})"
+  end
 end
 
 class TestModel
@@ -467,10 +471,38 @@ class StandardFiltersTest < Minitest::Test
   end
 
   def test_map_over_proc
-    drop  = TestDrop.new(value: "testfoo")
+    drop  = TestDrop.new(value: "123")
     p     = proc { drop }
     templ = '{{ procs | map: "value" }}'
-    assert_template_result("testfoo", templ, "procs" => [p])
+    assert_template_result("123", templ, "procs" => [p])
+  end
+
+  def test_join_over_proc
+    drop  = TestDrop.new(value: "123")
+    p     = proc { drop }
+    templ = '{{ procs | join }}'
+    assert_template_result('TestDrop(value:123)', templ, "procs" => [p])
+  end
+
+  def test_sort_over_proc
+    drop  = TestDrop.new(value: "123")
+    p     = proc { drop }
+    templ = '{{ procs | sort: "value" }}'
+    assert_template_result("TestDrop(value:123)", templ, "procs" => [p])
+  end
+
+  def test_where_over_proc
+    drop  = TestDrop.new(value: "123")
+    p     = proc { drop }
+    templ = '{{ procs | where: "value", "123" }}'
+    assert_template_result("TestDrop(value:123)", templ, "procs" => [p])
+  end
+
+  def test_uniq_over_proc
+    drop  = TestDrop.new(value: "123")
+    p     = proc { drop }
+    templ = '{{ procs | uniq }}'
+    assert_template_result("TestDrop(value:123)", templ, "procs" => [p])
   end
 
   def test_map_over_drops_returning_procs
@@ -888,7 +920,7 @@ class StandardFiltersTest < Minitest::Test
       { foo: "bar" },
       [{ "foo" => "bar" }, { "foo" => 123 }, { "foo" => nil }, { "foo" => true }, { "foo" => ["foo", "bar"] }],
       { 1 => "bar" },
-      ["foo", 123, nil, true, false, Drop, ["foo"], { foo: "bar" }],
+      ["foo", 123, nil, true, false, ["foo"], { foo: "bar" }],
     ]
     StandardFilters.public_instance_methods(false).each do |method|
       arg_count = @filters.method(method).arity

--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -272,14 +272,36 @@ class StandardTagTest < Minitest::Test
       '{%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %}', assigns)
   end
 
-  def test_size_of_array
-    assigns = { "array" => [1, 2, 3, 4] }
-    assert_template_result('array has 4 elements', "array has {{ array.size }} elements", assigns)
+  def test_command_methods_of_array
+    assigns = { "array" => [11, 22, 33] }
+
+    assert_template_result("3", "{{ array.size }}", assigns)
+
+    assert_template_result("11", "{{ array.first }}", assigns)
+
+    assert_template_result("33", "{{ array.last }}", assigns)
   end
 
-  def test_size_of_hash
-    assigns = { "hash" => { a: 1, b: 2, c: 3, d: 4 } }
-    assert_template_result('hash has 4 elements', "hash has {{ hash.size }} elements", assigns)
+  def test_command_methods_of_hash
+    assigns = { "hash" => { a: 11, b: 22, c: 33 } }
+
+    assert_template_result("3", "{{ hash.size }}", assigns)
+
+    assert_template_result("a11", "{{ hash.first }}", assigns)
+    assert_template_result("a", "{{ hash.first.first }}", assigns)
+    assert_template_result("11", "{{ hash.first.last }}", assigns)
+
+    assert_template_result("", "{{ hash.last }}", assigns)
+  end
+
+  def test_command_methods_with_proc
+    skip("Liquid-C does not properly resolve Procs in with command methods") if ENV['LIQUID_C'] == '1'
+
+    assigns = { "array" => [proc { "test" }] }
+    assert_template_result("test", "{{ array.first }}", assigns)
+
+    assigns = { "hash" => { a: proc { "test" } } }
+    assert_template_result("test", "{{ hash.first.last }}", assigns)
   end
 
   def test_illegal_symbols


### PR DESCRIPTION
This PR is all over the place, I am sorry for that. I found it hard to separate isolated deliverables as there is a lot of inter-dependency at play.

This PR adds `Context#contextualize` which acts as a central hub to handle logic regarding transformation of variable into liquid aware representation. 

This abstraction handles `Proc` resolutions when needed, the call to `to_liquid` and assignment of context via `context=`.


### Changes

**Context:**
- Pushed contextualization from `find_variable` to `lookup_and_evaluate`. No behavior change specific to this class,  this will allow for `VariableLookup#evaluate` to re-use said logic.

**VariableLookup:**
- Main path can delegate the responsibility of contextualization to `Context#lookup_and_evaluate`, allowing some of the logic duplication to be removed.
- The "command methods" have to deal with manual contextualization have been updated to the unified code path. `Context#contextualize` logic properly handles `Proc` which solves for the newly added tests who would have been failing otherwise. We could look at moving this `send` call to `Context` but I opted to limit the changes in the current PR.

**StandardFilters:**
- There is a bug fix and breaking change due to the removal of `respond_to?(:to_liquid)`. The previous code would have left a possibly unexpected object exposed to the template which could have lead to unforeseen privilege given to the template. Procs were notably not being converted. 


### Behavior of unhandled Procs
Cases when `Proc` are not handled sometimes lead to exceptions, but other times they could lead to exposure of internal code structure (eg.: rendered as strings in the template such as`"#<Proc:0xXXXXXX /Users/tjoyal/projects/liquid/test/integration/standard_filter_test.rb:485>"`). 

### North star

The question of supporting `Proc` behavior is to be asked.

I think most of that “lazy evaluation” can be achieved with an implementation over `Liquid::Drop` wrapping the underlying implementation which needs to be delayed.

I’ll need to do some git archeology to learn more as to when it was introduced and if it still have merit to be maintained going forward.
