### PR TITLE
Remove redundant regexp

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -37,7 +37,7 @@ module Liquid
 
     private def parse_for_liquid_tag(tokenizer, parse_context)
       while (token = tokenizer.shift)
-        unless token.empty? || token =~ WhitespaceOrNothing
+        unless token.empty? || token.match?(WhitespaceOrNothing)
           unless token =~ LiquidTagToken
             # line isn't empty but didn't match tag syntax, yield and let the
             # caller raise a syntax error
@@ -150,7 +150,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= !!(token =~ WhitespaceOrNothing)
+          @blank &&= token.match?(WhitespaceOrNothing)
         end
         parse_context.line_number = tokenizer.line_number
       end

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -7,7 +7,6 @@ module Liquid
     LiquidTagToken      = /\A\s*(\w+)\s*(.*?)\z/o
     FullToken           = /\A#{TagStart}#{WhitespaceControl}?(\s*)(\w+)(\s*)(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable   = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
-    WhitespaceOrNothing = /\A\s*\z/
     TAGSTART            = "{%"
     VARSTART            = "{{"
 
@@ -37,7 +36,7 @@ module Liquid
 
     private def parse_for_liquid_tag(tokenizer, parse_context)
       while (token = tokenizer.shift)
-        unless token.empty? || token =~ WhitespaceOrNothing
+        unless token.strip.empty?
           unless token =~ LiquidTagToken
             # line isn't empty but didn't match tag syntax, yield and let the
             # caller raise a syntax error
@@ -150,7 +149,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= !!(token =~ WhitespaceOrNothing)
+          @blank &&= token.strip.empty?
         end
         parse_context.line_number = tokenizer.line_number
       end

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -7,6 +7,7 @@ module Liquid
     LiquidTagToken      = /\A\s*(\w+)\s*(.*?)\z/o
     FullToken           = /\A#{TagStart}#{WhitespaceControl}?(\s*)(\w+)(\s*)(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable   = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
+    WhitespaceOrNothing = /\A\s*\z/
     TAGSTART            = "{%"
     VARSTART            = "{{"
 
@@ -36,7 +37,7 @@ module Liquid
 
     private def parse_for_liquid_tag(tokenizer, parse_context)
       while (token = tokenizer.shift)
-        unless token.strip.empty?
+        unless token.empty? || token =~ WhitespaceOrNothing
           unless token =~ LiquidTagToken
             # line isn't empty but didn't match tag syntax, yield and let the
             # caller raise a syntax error
@@ -149,7 +150,7 @@ module Liquid
           end
           parse_context.trim_whitespace = false
           @nodelist << token
-          @blank &&= token.strip.empty?
+          @blank &&= !!(token =~ WhitespaceOrNothing)
         end
         parse_context.line_number = tokenizer.line_number
       end

--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -2,8 +2,7 @@
 
 module Liquid
   class VariableLookup
-    SQUARE_BRACKETED = /\A\[(.*)\]\z/m
-    COMMAND_METHODS  = ['size', 'first', 'last'].freeze
+    COMMAND_METHODS = ['size', 'first', 'last'].freeze
 
     attr_reader :name, :lookups
 
@@ -15,8 +14,8 @@ module Liquid
       lookups = markup.scan(VariableParser)
 
       name = lookups.shift
-      if name =~ SQUARE_BRACKETED
-        name = Expression.parse(Regexp.last_match(1))
+      if name&.start_with?('[') && name&.end_with?(']')
+        name = Expression.parse(name[1..-2])
       end
       @name = name
 
@@ -25,8 +24,8 @@ module Liquid
 
       @lookups.each_index do |i|
         lookup = lookups[i]
-        if lookup =~ SQUARE_BRACKETED
-          lookups[i] = Expression.parse(Regexp.last_match(1))
+        if lookup&.start_with?('[') && lookup&.end_with?(']')
+          lookups[i] = Expression.parse(lookup[1..-2])
         elsif COMMAND_METHODS.include?(lookup)
           @command_flags |= 1 << i
         end


### PR DESCRIPTION
The same processing is possible without using regular expressions.

−               | before   | after   | result
--               | --       | --      | --
parse            | 61.006   | 61.975  | 1.016x
render           | 197.095  | 197.103 | -
parse & render   | 44.846   | 45.180  | 1.008x

### Environment
- MacBook Pro (14 inch, 2021)
- macOS 12.3 beta
- Apple M1 Max
- Ruby 3.0.3

### Before
```
$ ruby benchmark.rb

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     6.000  i/100ms
             render:    19.000  i/100ms
     parse & render:     4.000  i/100ms
Calculating -------------------------------------
              parse:     61.006  (± 0.0%) i/s -    612.000  in  10.032337s
             render:    197.095  (± 1.5%) i/s -      1.976k in  10.027538s
     parse & render:     44.846  (± 2.2%) i/s -    452.000  in  10.080806s
```

### After
```
$ ruby benchmark.rb

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     6.000  i/100ms
             render:    19.000  i/100ms
     parse & render:     4.000  i/100ms
Calculating -------------------------------------
              parse:     61.975  (± 0.0%) i/s -    624.000  in  10.069036s
             render:    197.103  (± 1.0%) i/s -      1.976k in  10.026615s
     parse & render:     45.180  (± 0.0%) i/s -    452.000  in  10.005335s
```
