### PR TITLE
Ensure that partial caches are shared with subcontexts

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 # Liquid Change Log
 
+## 5.3.1 (unreleased)
+
+### Fixes
+* `PartialCache` now shares snippet cache with subcontexts by default (#1553) [Chris AtLee]
+* Hash registers no longer leak into subcontexts as static registers (#1564) [Chris AtLee]
+
+### Changed
+* Liquid::Context#registers now always returns a Liquid::StaticRegisters object, though supports the most used Hash functions for compatibility (#1553)
+
 ## 5.3.0 2022-03-22
 
 ### Fixes

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -28,7 +28,7 @@ module Liquid
 
       @static_environments = [static_environments].flat_map(&:freeze).freeze
       @scopes              = [(outer_scope || {})]
-      @registers           = registers
+      @registers           = registers.is_a?(StaticRegisters) ? registers : StaticRegisters.new(registers)
       @errors              = []
       @partial             = false
       @strict_variables    = false
@@ -38,6 +38,10 @@ module Liquid
       @filters             = []
       @global_filter       = nil
       @disabled_tags       = {}
+
+      @registers.static[:cached_partials] ||= {}
+      @registers.static[:file_system] ||= Liquid::Template.file_system
+      @registers.static[:template_factory] ||= Liquid::TemplateFactory.new
 
       self.exception_renderer = Template.default_exception_renderer
       if rethrow_errors

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -3,16 +3,16 @@
 module Liquid
   class PartialCache
     def self.load(template_name, context:, parse_context:)
-      cached_partials = (context.registers[:cached_partials] ||= {})
+      cached_partials = context.registers[:cached_partials]
       cached = cached_partials[template_name]
       return cached if cached
 
-      file_system = (context.registers[:file_system] ||= Liquid::Template.file_system)
+      file_system = context.registers[:file_system]
       source      = file_system.read_template_file(template_name)
 
       parse_context.partial = true
 
-      template_factory = (context.registers[:template_factory] ||= Liquid::TemplateFactory.new)
+      template_factory = context.registers[:template_factory]
       template = template_factory.for(template_name)
 
       partial = template.parse(source, parse_context)

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -167,15 +167,14 @@ module Liquid
 
       output = nil
 
-      context_register = context.registers.is_a?(StaticRegisters) ? context.registers.static : context.registers
-
       case args.last
       when Hash
         options = args.pop
         output  = options[:output] if options[:output]
+        static_registers = context.registers.static
 
         options[:registers]&.each do |key, register|
-          context_register[key] = register
+          static_registers[key] = register
         end
 
         apply_options_to_context(context, options)

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -618,6 +618,20 @@ class ContextTest < Minitest::Test
     end
   end
 
+  def test_context_always_uses_static_registers
+    registers = {
+      my_register: :my_value,
+    }
+    c = Context.new({}, {}, registers)
+    assert_instance_of(StaticRegisters, c.registers)
+    assert_equal(:my_value, c.registers[:my_register])
+
+    r = StaticRegisters.new(registers)
+    c = Context.new({}, {}, r)
+    assert_instance_of(StaticRegisters, c.registers)
+    assert_equal(:my_value, c.registers[:my_register])
+  end
+
   private
 
   def assert_no_object_allocations

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -32,7 +32,7 @@ class TestDrop < Liquid::Drop
   attr_reader :value
 
   def registers
-    @context.registers
+    { @value => @context.registers[@value] }
   end
 end
 
@@ -440,7 +440,7 @@ class StandardFiltersTest < Minitest::Test
   end
 
   def test_map_calls_context=
-    model = TestModel.new(value: "test")
+    model = TestModel.new(value: :test)
 
     template = Template.parse('{{ foo | map: "registers" }}')
     template.registers[:test] = 1234


### PR DESCRIPTION
`PartialCache.load` currently stores its cache in `context.registers[:cached_partials]`.

By default, this is not a static register and so is set just for the current contexts. When we render another snippet via the `render` tag, a new context is created via `Liquid::Context#new_isolated_subcontext`, which copies only static registers to the subcontext.

The consequence of this is that if you have snippets that render other snippets, the partial cache for the second level of snippets is lost.

This PR explicitly adds `cached_partials` to the static registers when creating a new context so that it is shared with any subcontexts that are created.

This could be considered a breaking change for any applications relying on subcontexts having their own partial cache.