### PR TITLE
History.md: Remove non-fix from fixes section of recent release.

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 * StandardFilter: Fix missing @context on iterations (#1525) [Thierry Joyal]
-* Test under Ruby 3.1 (#1533) [petergoldstein]
 * Fix warning about block and default value in `static_registers.rb` (#1531) [Peter Zhu]
 
 ### Deprecation


### PR DESCRIPTION
As I mentioned in https://github.com/Shopify/liquid/pull/1554#discussion_r832623610 after the PR got merged

> This isn't really a change from the user's perspective. The code already worked in ruby 3.1, so this isn't really a fix. Users of the library generally don't care about tests being added.