### PR TITLE
Rename and alias Liquid::StaticRegisters to Liquid::Registers

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,7 +10,7 @@
 * Hash registers no longer leak into subcontexts as static registers (#1564) [Chris AtLee]
 
 ### Changed
-* Liquid::Context#registers now always returns a Liquid::StaticRegisters object, though supports the most used Hash functions for compatibility (#1553)
+* Liquid::Context#registers now always returns a Liquid::Registers object, though supports the most used Hash functions for compatibility (#1553)
 
 ## 5.3.0 2022-03-22
 

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -84,7 +84,6 @@ require 'liquid/tokenizer'
 require 'liquid/parse_context'
 require 'liquid/partial_cache'
 require 'liquid/usage'
-require 'liquid/register'
 require 'liquid/registers'
 require 'liquid/template_factory'
 

--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -85,7 +85,7 @@ require 'liquid/parse_context'
 require 'liquid/partial_cache'
 require 'liquid/usage'
 require 'liquid/register'
-require 'liquid/static_registers'
+require 'liquid/registers'
 require 'liquid/template_factory'
 
 # Load all the tags of the standard library

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -28,7 +28,7 @@ module Liquid
 
       @static_environments = [static_environments].flat_map(&:freeze).freeze
       @scopes              = [(outer_scope || {})]
-      @registers           = registers.is_a?(StaticRegisters) ? registers : StaticRegisters.new(registers)
+      @registers           = registers.is_a?(Registers) ? registers : Registers.new(registers)
       @errors              = []
       @partial             = false
       @strict_variables    = false
@@ -144,7 +144,7 @@ module Liquid
       self.class.build(
         resource_limits: resource_limits,
         static_environments: static_environments,
-        registers: StaticRegisters.new(registers)
+        registers: Registers.new(registers)
       ).tap do |subcontext|
         subcontext.base_scope_depth   = base_scope_depth + 1
         subcontext.exception_renderer = exception_renderer

--- a/lib/liquid/register.rb
+++ b/lib/liquid/register.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Liquid
-  class Register
-  end
-end

--- a/lib/liquid/registers.rb
+++ b/lib/liquid/registers.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Liquid
-  class StaticRegisters
+  class Registers
     attr_reader :static
 
     def initialize(registers = {})
-      @static    = registers.is_a?(StaticRegisters) ? registers.static : registers
+      @static    = registers.is_a?(Registers) ? registers.static : registers
       @registers = {}
     end
 
@@ -45,4 +45,7 @@ module Liquid
       @registers.key?(key) || @static.key?(key)
     end
   end
+
+  # Alias for backwards compatibility
+  StaticRegisters = Registers
 end

--- a/lib/liquid/registers.rb
+++ b/lib/liquid/registers.rb
@@ -5,31 +5,31 @@ module Liquid
     attr_reader :static
 
     def initialize(registers = {})
-      @static    = registers.is_a?(Registers) ? registers.static : registers
-      @registers = {}
+      @static = registers.is_a?(Registers) ? registers.static : registers
+      @changes = {}
     end
 
     def []=(key, value)
-      @registers[key] = value
+      @changes[key] = value
     end
 
     def [](key)
-      if @registers.key?(key)
-        @registers[key]
+      if @changes.key?(key)
+        @changes[key]
       else
         @static[key]
       end
     end
 
     def delete(key)
-      @registers.delete(key)
+      @changes.delete(key)
     end
 
     UNDEFINED = Object.new
 
     def fetch(key, default = UNDEFINED, &block)
-      if @registers.key?(key)
-        @registers.fetch(key)
+      if @changes.key?(key)
+        @changes.fetch(key)
       elsif default != UNDEFINED
         if block_given?
           @static.fetch(key, &block)
@@ -42,7 +42,7 @@ module Liquid
     end
 
     def key?(key)
-      @registers.key?(key) || @static.key?(key)
+      @changes.key?(key) || @static.key?(key)
     end
   end
 

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -529,7 +529,7 @@ class ContextTest < Minitest::Test
     registers = {
       my_register: :my_value,
     }
-    super_context = Context.new({}, {}, StaticRegisters.new(registers))
+    super_context = Context.new({}, {}, Registers.new(registers))
     super_context.registers[:my_register] = :my_alt_value
     subcontext                            = super_context.new_isolated_subcontext
     assert_equal(:my_value, subcontext.registers[:my_register])
@@ -623,12 +623,12 @@ class ContextTest < Minitest::Test
       my_register: :my_value,
     }
     c = Context.new({}, {}, registers)
-    assert_instance_of(StaticRegisters, c.registers)
+    assert_instance_of(Registers, c.registers)
     assert_equal(:my_value, c.registers[:my_register])
 
-    r = StaticRegisters.new(registers)
+    r = Registers.new(registers)
     c = Context.new({}, {}, r)
-    assert_instance_of(StaticRegisters, c.registers)
+    assert_instance_of(Registers, c.registers)
     assert_equal(:my_value, c.registers[:my_register])
   end
 

--- a/test/unit/partial_cache_unit_test.rb
+++ b/test/unit/partial_cache_unit_test.rb
@@ -132,7 +132,7 @@ class PartialCacheUnitTest < Minitest::Test
       'my_partial' => 'my shared value'
     )
     context = Liquid::Context.build(
-      registers: Liquid::StaticRegisters.new(
+      registers: Liquid::Registers.new(
         file_system: shared_file_system,
       )
     )

--- a/test/unit/registers_unit_test.rb
+++ b/test/unit/registers_unit_test.rb
@@ -2,11 +2,11 @@
 
 require 'test_helper'
 
-class StaticRegistersUnitTest < Minitest::Test
+class RegistersUnitTest < Minitest::Test
   include Liquid
 
   def test_set
-    static_register = StaticRegisters.new(a: 1, b: 2)
+    static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22
     static_register[:c] = 33
 
@@ -16,13 +16,13 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_get_missing_key
-    static_register = StaticRegisters.new
+    static_register = Registers.new
 
     assert_nil(static_register[:missing])
   end
 
   def test_delete
-    static_register = StaticRegisters.new(a: 1, b: 2)
+    static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22
     static_register[:c] = 33
 
@@ -37,7 +37,7 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_fetch
-    static_register = StaticRegisters.new(a: 1, b: 2)
+    static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22
     static_register[:c] = 33
 
@@ -61,7 +61,7 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_key
-    static_register = StaticRegisters.new(a: 1, b: 2)
+    static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22
     static_register[:c] = 33
 
@@ -72,7 +72,7 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_static_register_can_be_frozen
-    static_register = StaticRegisters.new(a: 1)
+    static_register = Registers.new(a: 1)
 
     static_register.static.freeze
 
@@ -94,14 +94,14 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_new_static_retains_static
-    static_register = StaticRegisters.new(a: 1, b: 2)
+    static_register = Registers.new(a: 1, b: 2)
     static_register[:b] = 22
     static_register[:c] = 33
 
-    new_static_register = StaticRegisters.new(static_register)
+    new_static_register = Registers.new(static_register)
     new_static_register[:b] = 222
 
-    newest_static_register = StaticRegisters.new(new_static_register)
+    newest_static_register = Registers.new(new_static_register)
     newest_static_register[:c] = 333
 
     assert_equal(1, static_register[:a])
@@ -118,11 +118,11 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_multiple_instances_are_unique
-    static_register_1 = StaticRegisters.new(a: 1, b: 2)
+    static_register_1 = Registers.new(a: 1, b: 2)
     static_register_1[:b] = 22
     static_register_1[:c] = 33
 
-    static_register_2 = StaticRegisters.new(a: 10, b: 20)
+    static_register_2 = Registers.new(a: 10, b: 20)
     static_register_2[:b] = 220
     static_register_2[:c] = 330
 
@@ -138,11 +138,11 @@ class StaticRegistersUnitTest < Minitest::Test
   end
 
   def test_initialization_reused_static_same_memory_object
-    static_register_1 = StaticRegisters.new(a: 1, b: 2)
+    static_register_1 = Registers.new(a: 1, b: 2)
     static_register_1[:b] = 22
     static_register_1[:c] = 33
 
-    static_register_2 = StaticRegisters.new(static_register_1)
+    static_register_2 = Registers.new(static_register_1)
 
     assert_equal(1, static_register_2[:a])
     assert_equal(2, static_register_2[:b])


### PR DESCRIPTION
## Problem

Liquid::StaticRegisters is a container around all the registers, not just the static ones, which seems confusing.  Similarly, that object has a `@registers` instance variable that doesn't refer to all registers, just the non-static ones.

## Solution

Rename Liquid::StaticRegisters to Liquid::Registers, which better reflects what it is.  To keep backwards compatibility, I added a Liquid::StaticRegisters to the renamed class.  I also changed the `@registers` instance variable to `@changes`.

In the process, I noticed an empty unused Liquid::Register class, which I removed to avoid confusion, especially given its similarity in name to `Liquid::Registers`.