### PR TITLE
Clarify sort_natural and fix unless syntax

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -358,7 +358,11 @@ module Liquid
     # @liquid_type filter
     # @liquid_category array
     # @liquid_summary
-    #   Sorts the items in an array in case-insensitive alphabetical, or numerical, order.
+    #   Sorts the items in an array in case-insensitive alphabetical order.
+    # @liquid_description
+    #   > Caution:
+    #   > You shouldn't use the `sort_natural` filter to sort numerical values. When comparing items an array, each item is converted to a
+    #   > string, so sorting on numerical values can lead to unexpected results.
     # @liquid_syntax array | sort_natural
     # @liquid_return [array[untyped]]
     def sort_natural(input, property = nil)

--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -15,7 +15,7 @@ module Liquid
   # @liquid_syntax
   #   {% unless condition %}
   #     expression
-  #   {% endif %}
+  #   {% endunless %}
   # @liquid_syntax_keyword condition The condition to evaluate.
   # @liquid_syntax_keyword expression The expression to render unless the condition is met.
   class Unless < If


### PR DESCRIPTION
## This PR:

  - Updates the `sort_natural` filter to note that it should only be used on strings as all items are converted to strings, which leads to unexpected numerical sorting.
  - Fixes a typo with the syntax for `unless`.