### PR TITLE
Add variable_name_expr to render's ParseTreeVisitor

### DIFF
--- a/History.md
+++ b/History.md
@@ -11,6 +11,7 @@
 ### Fixes
 * `PartialCache` now shares snippet cache with subcontexts by default (#1553) [Chris AtLee]
 * Hash registers no longer leak into subcontexts as static registers (#1564) [Chris AtLee]
+* Fix `ParseTreeVisitor` for `with` variable expressions in `Render` tag (#1596) [CP Clermont]
 
 ### Changed
 * Liquid::Context#registers now always returns a Liquid::Registers object, though supports the most used Hash functions for compatibility (#1553)

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -31,7 +31,7 @@ module Liquid
 
     disable_tags "include"
 
-    attr_reader :template_name_expr, :attributes
+    attr_reader :template_name_expr, :variable_name_expr, :attributes
 
     def initialize(tag_name, markup, options)
       super
@@ -99,6 +99,7 @@ module Liquid
       def children
         [
           @node.template_name_expr,
+          @node.variable_name_expr,
         ] + @node.attributes.values
       end
     end

--- a/test/unit/parse_tree_visitor_test.rb
+++ b/test/unit/parse_tree_visitor_test.rb
@@ -236,6 +236,20 @@ class ParseTreeVisitorTest < Minitest::Test
     )
   end
 
+  def test_render_with
+    assert_equal(
+      ["test"],
+      visit(%({% render "hai" with test %}))
+    )
+  end
+
+  def test_render_for
+    assert_equal(
+      ["test"],
+      visit(%({% render "hai" for test %}))
+    )
+  end
+
   def test_preserve_tree_structure
     assert_equal(
       [[nil, [


### PR DESCRIPTION
Solves Shopify/theme-check#582

`icon` should be visited in the render tag for the following snippet:

```liquid
{% assign icon = 'warning' %}
{% render 'icon' with icon %}
```

This allows us to properly see that the `icon` assign was used, and thus not flag an UnusedAssign when it is.
