### PR TITLE
Expose list of filter methods

### DIFF
--- a/lib/liquid/strainer_factory.rb
+++ b/lib/liquid/strainer_factory.rb
@@ -14,6 +14,10 @@ module Liquid
       strainer_from_cache(filters).new(context)
     end
 
+    def filters
+      GlobalCache.filter_methods
+    end
+
     GlobalCache = Class.new(StrainerTemplate)
 
     private

--- a/lib/liquid/strainer_template.rb
+++ b/lib/liquid/strainer_template.rb
@@ -36,8 +36,6 @@ module Liquid
         subclass.instance_variable_set(:@filter_methods, @filter_methods.dup)
       end
 
-      private
-
       def filter_methods
         @filter_methods ||= Set.new
       end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -86,6 +86,10 @@ module Liquid
         StrainerFactory.add_global_filter(mod)
       end
 
+      def filters
+        StrainerFactory.filters
+      end
+
       attr_accessor :default_resource_limits
       Template.default_resource_limits = {}
       private :default_resource_limits=


### PR DESCRIPTION
We currently don't have a way to retrieve a list of filter methods. 
Tags could be retrieved from `Liquid::Template.tags`, exposing filter_methods so we could retrieve the set of filters from `Liquid::Template.filters`