### PR TITLE
Stop using Liquid::Expression.parse for integration testing

### DIFF
--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -4,48 +4,46 @@ require 'test_helper'
 
 class ExpressionTest < Minitest::Test
   def test_keyword_literals
-    assert_equal(true, parse_and_eval("true"))
-    assert_equal(true, parse_and_eval(" true "))
+    assert_template_result("true", "{{ true }}")
+    assert_expression_result(true, "true")
   end
 
   def test_string
-    assert_equal("single quoted", parse_and_eval("'single quoted'"))
-    assert_equal("double quoted", parse_and_eval('"double quoted"'))
-    assert_equal("spaced", parse_and_eval(" 'spaced' "))
-    assert_equal("spaced2", parse_and_eval(' "spaced2" '))
+    assert_template_result("single quoted", "{{'single quoted'}}")
+    assert_template_result("double quoted", '{{"double quoted"}}')
+    assert_template_result("spaced", "{{ 'spaced' }}")
+    assert_template_result("spaced2", "{{ 'spaced2' }}")
   end
 
   def test_int
-    assert_equal(123, parse_and_eval("123"))
-    assert_equal(456, parse_and_eval(" 456 "))
-    assert_equal(12, parse_and_eval("012"))
+    assert_template_result("456", "{{ 456 }}")
+    assert_expression_result(123, "123")
+    assert_expression_result(12, "012")
   end
 
   def test_float
-    assert_equal(1.5, parse_and_eval("1.5"))
-    assert_equal(2.5, parse_and_eval(" 2.5 "))
+    assert_template_result("2.5", "{{ 2.5 }}")
+    assert_expression_result(1.5, "1.5")
   end
 
   def test_range
-    assert_equal(1..2, parse_and_eval("(1..2)"))
-    assert_equal(3..4, parse_and_eval(" ( 3 .. 4 ) "))
+    assert_template_result("3..4", "{{ ( 3 .. 4 ) }}")
+    assert_expression_result(1..2, "(1..2)")
 
-    exc = assert_raises(Liquid::SyntaxError) { Liquid::Expression.parse("(false..true)") }
-    assert_equal("Liquid syntax error: Invalid expression type 'false' in range expression", exc.message)
-    exc = assert_raises(Liquid::SyntaxError) { Liquid::Expression.parse("((1..2)..3)") }
-    assert_equal("Liquid syntax error: Invalid expression type '(1..2)' in range expression", exc.message)
+    assert_match_syntax_error(
+      "Liquid syntax error (line 1): Invalid expression type 'false' in range expression",
+      "{{ (false..true) }}"
+    )
+    assert_match_syntax_error(
+      "Liquid syntax error (line 1): Invalid expression type '(1..2)' in range expression",
+      "{{ ((1..2)..3) }}"
+    )
   end
 
   private
 
-  def parse_and_eval(markup, **assigns)
-    if Liquid::Template.error_mode == :strict
-      p = Liquid::Parser.new(markup)
-      markup = p.expression
-      p.consume(:end_of_string)
-    end
-    expression = Liquid::Expression.parse(markup)
-    context = Liquid::Context.new(assigns)
-    context.evaluate(expression)
+  def assert_expression_result(expect, markup, **assigns)
+    liquid = "{% if expect == #{markup} %}pass{% else %}got {{ #{markup} }}{% endif %}"
+    assert_template_result("pass", liquid, { "expect" => expect, **assigns })
   end
 end


### PR DESCRIPTION
~~Depends on https://github.com/Shopify/liquid-c/pull/179 to fix the test error~~

## Problem

liquid-c stopped patching Liquid::Expression.parse in https://github.com/Shopify/liquid-c/pull/178 since it was too implicit, so integration tests using Liquid::Expression.parse weren't actually being shared across implementations.

## Solution

Use assert_template_result and assert_match_syntax_error for integration testing, which will better enable us to share tests using it across liquid implementations.