### PR TITLE
Use assert_template_result & assert_match_syntax_error in more places

### DIFF
--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -6,13 +6,11 @@ class AssignTest < Minitest::Test
   include Liquid
 
   def test_assign_with_hyphen_in_variable_name
-    template_source = <<-END_TEMPLATE
-    {% assign this-thing = 'Print this-thing' %}
-    {{ this-thing }}
+    template_source = <<~END_TEMPLATE
+      {% assign this-thing = 'Print this-thing' -%}
+      {{ this-thing -}}
     END_TEMPLATE
-    template        = Template.parse(template_source)
-    rendered        = template.render!
-    assert_equal("Print this-thing", rendered.strip)
+    assert_template_result("Print this-thing", template_source)
   end
 
   def test_assigned_variable

--- a/test/integration/block_test.rb
+++ b/test/integration/block_test.rb
@@ -6,10 +6,8 @@ class BlockTest < Minitest::Test
   include Liquid
 
   def test_unexpected_end_tag
-    exc = assert_raises(SyntaxError) do
-      Template.parse("{% if true %}{% endunless %}")
-    end
-    assert_equal(exc.message, "Liquid syntax error: 'endunless' is not a valid delimiter for if tags. use endif")
+    source = '{% if true %}{% endunless %}'
+    assert_match_syntax_error("Liquid syntax error (line 1): 'endunless' is not a valid delimiter for if tags. use endif", source)
   end
 
   def test_with_custom_tag

--- a/test/integration/capture_test.rb
+++ b/test/integration/capture_test.rb
@@ -10,44 +10,38 @@ class CaptureTest < Minitest::Test
   end
 
   def test_capture_with_hyphen_in_variable_name
-    template_source = <<-END_TEMPLATE
-    {% capture this-thing %}Print this-thing{% endcapture %}
-    {{ this-thing }}
+    template_source = <<~END_TEMPLATE
+      {% capture this-thing %}Print this-thing{% endcapture -%}
+      {{ this-thing -}}
     END_TEMPLATE
-    template        = Template.parse(template_source)
-    rendered        = template.render!
-    assert_equal("Print this-thing", rendered.strip)
+    assert_template_result("Print this-thing", template_source)
   end
 
   def test_capture_to_variable_from_outer_scope_if_existing
-    template_source = <<-END_TEMPLATE
-    {% assign var = '' %}
-    {% if true %}
-    {% capture var %}first-block-string{% endcapture %}
-    {% endif %}
-    {% if true %}
-    {% capture var %}test-string{% endcapture %}
-    {% endif %}
-    {{var}}
+    template_source = <<~END_TEMPLATE
+      {% assign var = '' -%}
+      {% if true -%}
+        {% capture var %}first-block-string{% endcapture -%}
+      {% endif -%}
+      {% if true -%}
+        {% capture var %}test-string{% endcapture -%}
+      {% endif -%}
+      {{var-}}
     END_TEMPLATE
-    template        = Template.parse(template_source)
-    rendered        = template.render!
-    assert_equal("test-string", rendered.gsub(/\s/, ''))
+    assert_template_result("test-string", template_source)
   end
 
   def test_assigning_from_capture
-    template_source = <<-END_TEMPLATE
-    {% assign first = '' %}
-    {% assign second = '' %}
-    {% for number in (1..3) %}
-    {% capture first %}{{number}}{% endcapture %}
-    {% assign second = first %}
-    {% endfor %}
-    {{ first }}-{{ second }}
+    template_source = <<~END_TEMPLATE
+      {% assign first = '' -%}
+      {% assign second = '' -%}
+      {% for number in (1..3) -%}
+        {% capture first %}{{number}}{% endcapture -%}
+        {% assign second = first -%}
+      {% endfor -%}
+      {{ first }}-{{ second -}}
     END_TEMPLATE
-    template        = Template.parse(template_source)
-    rendered        = template.render!
-    assert_equal("3-3", rendered.gsub(/\s/, ''))
+    assert_template_result("3-3", template_source)
   end
 
   def test_increment_assign_score_by_bytes_not_characters

--- a/test/integration/document_test.rb
+++ b/test/integration/document_test.rb
@@ -6,16 +6,12 @@ class DocumentTest < Minitest::Test
   include Liquid
 
   def test_unexpected_outer_tag
-    exc = assert_raises(SyntaxError) do
-      Template.parse("{% else %}")
-    end
-    assert_equal(exc.message, "Liquid syntax error: Unexpected outer 'else' tag")
+    source = "{% else %}"
+    assert_match_syntax_error("Liquid syntax error (line 1): Unexpected outer 'else' tag", source)
   end
 
   def test_unknown_tag
-    exc = assert_raises(SyntaxError) do
-      Template.parse("{% foo %}")
-    end
-    assert_equal(exc.message, "Liquid syntax error: Unknown tag 'foo'")
+    source = "{% foo %}"
+    assert_match_syntax_error("Liquid syntax error (line 1): Unknown tag 'foo'", source)
   end
 end

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -63,9 +63,7 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   def test_missing_endtag_parse_time_error
-    assert_raises(Liquid::SyntaxError) do
-      Liquid::Template.parse(' {% for a in b %} ... ')
-    end
+    assert_match_syntax_error(/: 'for' tag was never closed\z/, ' {% for a in b %} ... ')
   end
 
   def test_unrecognized_operator
@@ -84,33 +82,26 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   def test_with_line_numbers_adds_numbers_to_parser_errors
-    err = assert_raises(SyntaxError) do
-      Liquid::Template.parse('
-          foobar
+    source = <<~LIQUID
+      foobar
 
-          {% "cat" | foobar %}
+      {% "cat" | foobar %}
 
-          bla
-        ',
-        line_numbers: true)
-    end
-
-    assert_match(/Liquid syntax error \(line 4\)/, err.message)
+      bla
+    LIQUID
+    assert_match_syntax_error(/Liquid syntax error \(line 3\)/, source)
   end
 
   def test_with_line_numbers_adds_numbers_to_parser_errors_with_whitespace_trim
-    err = assert_raises(SyntaxError) do
-      Liquid::Template.parse('
-          foobar
+    source = <<~LIQUID
+      foobar
 
-          {%- "cat" | foobar -%}
+      {%- "cat" | foobar -%}
 
-          bla
-        ',
-        line_numbers: true)
-    end
+      bla
+    LIQUID
 
-    assert_match(/Liquid syntax error \(line 4\)/, err.message)
+    assert_match_syntax_error(/Liquid syntax error \(line 3\)/, source)
   end
 
   def test_parsing_warn_with_line_numbers_adds_numbers_to_lexer_errors
@@ -145,20 +136,17 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   def test_syntax_errors_in_nested_blocks_have_correct_line_number
-    err = assert_raises(SyntaxError) do
-      Liquid::Template.parse('
-          foobar
+    source = <<~LIQUID
+      foobar
 
-          {% if 1 != 2 %}
-            {% foo %}
-          {% endif %}
+      {% if 1 != 2 %}
+        {% foo %}
+      {% endif %}
 
-          bla
-                ',
-        line_numbers: true)
-    end
+      bla
+    LIQUID
 
-    assert_equal("Liquid syntax error (line 5): Unknown tag 'foo'", err.message)
+    assert_match_syntax_error("Liquid syntax error (line 4): Unknown tag 'foo'", source)
   end
 
   def test_strict_error_messages

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -59,84 +59,66 @@ class FiltersTest < Minitest::Test
   end
 
   def test_size
-    @context['var'] = 'abcd'
-    @context.add_filters(MoneyFilter)
-
-    assert_equal('4', Template.parse("{{var | size}}").render(@context))
+    assert_template_result("4", "{{var | size}}", { "var" => 'abcd' })
   end
 
   def test_join
-    @context['var'] = [1, 2, 3, 4]
-
-    assert_equal("1 2 3 4", Template.parse("{{var | join}}").render(@context))
+    assert_template_result("1 2 3 4", "{{var | join}}", { "var" => [1, 2, 3, 4] })
   end
 
   def test_sort
-    @context['value']   = 3
-    @context['numbers'] = [2, 1, 4, 3]
-    @context['words']   = ['expected', 'as', 'alphabetic']
-    @context['arrays']  = ['flower', 'are']
-    @context['case_sensitive'] = ['sensitive', 'Expected', 'case']
-
-    assert_equal('1 2 3 4', Template.parse("{{numbers | sort | join}}").render(@context))
-    assert_equal('alphabetic as expected', Template.parse("{{words | sort | join}}").render(@context))
-    assert_equal('3', Template.parse("{{value | sort}}").render(@context))
-    assert_equal('are flower', Template.parse("{{arrays | sort | join}}").render(@context))
-    assert_equal('Expected case sensitive', Template.parse("{{case_sensitive | sort | join}}").render(@context))
+    assert_template_result("1 2 3 4", "{{numbers | sort | join}}", { "numbers" => [2, 1, 4, 3] })
+    assert_template_result("alphabetic as expected", "{{words | sort | join}}",
+      { "words" => ['expected', 'as', 'alphabetic'] })
+    assert_template_result("3", "{{value | sort}}", { "value" => 3 })
+    assert_template_result('are flower', "{{arrays | sort | join}}", { 'arrays' => ['flower', 'are'] })
+    assert_template_result("Expected case sensitive", "{{case_sensitive | sort | join}}",
+      { "case_sensitive" => ["sensitive", "Expected", "case"] })
   end
 
   def test_sort_natural
-    @context['words']   = ['case', 'Assert', 'Insensitive']
-    @context['hashes']  = [{ 'a' => 'A' }, { 'a' => 'b' }, { 'a' => 'C' }]
-    @context['objects'] = [TestObject.new('A'), TestObject.new('b'), TestObject.new('C')]
-
     # Test strings
-    assert_equal('Assert case Insensitive', Template.parse("{{words | sort_natural | join}}").render(@context))
+    assert_template_result("Assert case Insensitive", "{{words | sort_natural | join}}",
+      { "words" => ["case", "Assert", "Insensitive"] })
 
     # Test hashes
-    assert_equal('A b C', Template.parse("{{hashes | sort_natural: 'a' | map: 'a' | join}}").render(@context))
+    assert_template_result("A b C", "{{hashes | sort_natural: 'a' | map: 'a' | join}}",
+      { "hashes" => [{ "a" => "A" }, { "a" => "b" }, { "a" => "C" }] })
 
     # Test objects
+    @context['objects'] = [TestObject.new('A'), TestObject.new('b'), TestObject.new('C')]
     assert_equal('A b C', Template.parse("{{objects | sort_natural: 'a' | map: 'a' | join}}").render(@context))
   end
 
   def test_compact
-    @context['words']   = ['a', nil, 'b', nil, 'c']
-    @context['hashes']  = [{ 'a' => 'A' }, { 'a' => nil }, { 'a' => 'C' }]
-    @context['objects'] = [TestObject.new('A'), TestObject.new(nil), TestObject.new('C')]
-
     # Test strings
-    assert_equal('a b c', Template.parse("{{words | compact | join}}").render(@context))
+    assert_template_result("a b c", "{{words | compact | join}}",
+      { "words" => ['a', nil, 'b', nil, 'c'] })
 
     # Test hashes
-    assert_equal('A C', Template.parse("{{hashes | compact: 'a' | map: 'a' | join}}").render(@context))
+    assert_template_result("A C", "{{hashes | compact: 'a' | map: 'a' | join}}",
+      { "hashes" => [{ "a" => "A" }, { "a" => nil }, { "a" => "C" }] })
 
     # Test objects
+    @context['objects'] = [TestObject.new('A'), TestObject.new(nil), TestObject.new('C')]
     assert_equal('A C', Template.parse("{{objects | compact: 'a' | map: 'a' | join}}").render(@context))
   end
 
   def test_strip_html
-    @context['var'] = "<b>bla blub</a>"
-
-    assert_equal("bla blub", Template.parse("{{ var | strip_html }}").render(@context))
+    assert_template_result("bla blub", "{{ var | strip_html }}", { "var" => "<b>bla blub</a>" })
   end
 
   def test_strip_html_ignore_comments_with_html
-    @context['var'] = "<!-- split and some <ul> tag --><b>bla blub</a>"
-
-    assert_equal("bla blub", Template.parse("{{ var | strip_html }}").render(@context))
+    assert_template_result("bla blub", "{{ var | strip_html }}",
+      { "var" => "<!-- split and some <ul> tag --><b>bla blub</a>" })
   end
 
   def test_capitalize
-    @context['var'] = "blub"
-
-    assert_equal("Blub", Template.parse("{{ var | capitalize }}").render(@context))
+    assert_template_result("Blub", "{{ var | capitalize }}", { "var" => "blub" })
   end
 
   def test_nonexistent_filter_is_ignored
-    @context['var'] = 1000
-
-    assert_equal('1000', Template.parse("{{ var | xyzzy }}").render(@context))
+    assert_template_result("1000", "{{ var | xyzzy }}", { "var" => 1000 })
   end
 
   def test_filter_with_keyword_arguments

--- a/test/integration/output_test.rb
+++ b/test/integration/output_test.rb
@@ -33,31 +33,25 @@ class OutputTest < Minitest::Test
 
   def setup
     @assigns = {
-      'best_cars' => 'bmw',
       'car' => { 'bmw' => 'good', 'gm' => 'bad' },
     }
   end
 
   def test_variable
-    text = %( {{best_cars}} )
-
-    expected = %( bmw )
-    assert_equal(expected, Template.parse(text).render!(@assigns))
+    assert_template_result(" bmw ", " {{best_cars}} ", { "best_cars" => "bmw" })
   end
 
   def test_variable_traversing_with_two_brackets
-    text = %({{ site.data.menu[include.menu][include.locale] }})
-    assert_equal("it works!", Template.parse(text).render!(
+    source = "{{ site.data.menu[include.menu][include.locale] }}"
+    assert_template_result("it works!", source, {
       "site" => { "data" => { "menu" => { "foo" => { "bar" => "it works!" } } } },
-      "include" => { "menu" => "foo", "locale" => "bar" }
-    ))
+      "include" => { "menu" => "foo", "locale" => "bar" },
+    })
   end
 
   def test_variable_traversing
-    text = %( {{car.bmw}} {{car.gm}} {{car.bmw}} )
-
-    expected = %( good bad good )
-    assert_equal(expected, Template.parse(text).render!(@assigns))
+    source = " {{car.bmw}} {{car.gm}} {{car.bmw}} "
+    assert_template_result(" good bad good ", source, @assigns)
   end
 
   def test_variable_piping
@@ -110,10 +104,11 @@ class OutputTest < Minitest::Test
   end
 
   def test_multiple_pipings
+    assigns = { 'best_cars' => 'bmw' }
     text     = %( {{ best_cars | cite_funny | paragraph }} )
     expected = %( <p>LOL: bmw</p> )
 
-    assert_equal(expected, Template.parse(text).render!(@assigns, filters: [FunnyFilter]))
+    assert_equal(expected, Template.parse(text).render!(assigns, filters: [FunnyFilter]))
   end
 
   def test_link_to

--- a/test/integration/tags/standard_tag_test.rb
+++ b/test/integration/tags/standard_tag_test.rb
@@ -174,13 +174,12 @@ class StandardTagTest < Minitest::Test
 
   def test_assign_from_case
     # Example from the shopify forums
-    code     = "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{% else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
-    template = Liquid::Template.parse(code)
-    assert_equal("menswear",   template.render!("collection" => { 'handle' => 'menswear-jackets' }))
-    assert_equal("menswear",   template.render!("collection" => { 'handle' => 'menswear-t-shirts' }))
-    assert_equal("womenswear", template.render!("collection" => { 'handle' => 'x' }))
-    assert_equal("womenswear", template.render!("collection" => { 'handle' => 'y' }))
-    assert_equal("womenswear", template.render!("collection" => { 'handle' => 'z' }))
+    code = "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{% else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
+    assert_template_result("menswear",   code, { "collection" => { 'handle' => 'menswear-jackets' } })
+    assert_template_result("menswear",   code, { "collection" => { 'handle' => 'menswear-t-shirts' } })
+    assert_template_result("womenswear", code, { "collection" => { 'handle' => 'x' } })
+    assert_template_result("womenswear", code, { "collection" => { 'handle' => 'y' } })
+    assert_template_result("womenswear", code, { "collection" => { 'handle' => 'z' } })
   end
 
   def test_case_when_or

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -315,13 +315,11 @@ class TemplateTest < Minitest::Test
   end
 
   def test_using_range_literal_works_as_expected
-    t = Template.parse("{% assign foo = (x..y) %}{{ foo }}")
-    result = t.render('x' => 1, 'y' => 5)
-    assert_equal('1..5', result)
+    source = "{% assign foo = (x..y) %}{{ foo }}"
+    assert_template_result("1..5", source, { "x" => 1, "y" => 5 })
 
-    t = Template.parse("{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}")
-    result = t.render('x' => 1, 'y' => 5)
-    assert_equal('12345', result)
+    source = "{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}"
+    assert_template_result("12345", source, { "x" => 1, "y" => 5 })
   end
 
   def test_source_string_subclass

--- a/test/integration/trim_mode_test.rb
+++ b/test/integration/trim_mode_test.rb
@@ -530,14 +530,9 @@ class TrimModeTest < Minitest::Test
   end
 
   def test_pre_trim_blank_preceding_text
-    template = Liquid::Template.parse("\n{%- raw %}{% endraw %}")
-    assert_equal("", template.render)
-
-    template = Liquid::Template.parse("\n{%- if true %}{% endif %}")
-    assert_equal("", template.render)
-
-    template = Liquid::Template.parse("{{ 'B' }} \n{%- if true %}C{% endif %}")
-    assert_equal("BC", template.render)
+    assert_template_result("", "\n{%- raw %}{% endraw %}")
+    assert_template_result("", "\n{%- if true %}{% endif %}")
+    assert_template_result("BC", "{{ 'B' }} \n{%- if true %}C{% endif %}")
   end
 
   def test_bug_compatible_pre_trim

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -6,9 +6,8 @@ class VariableTest < Minitest::Test
   include Liquid
 
   def test_simple_variable
-    template = Template.parse(%({{test}}))
-    assert_equal('worked', template.render!('test' => 'worked'))
-    assert_equal('worked wonderfully', template.render!('test' => 'worked wonderfully'))
+    assert_template_result('worked', "{{test}}", { 'test' => 'worked' })
+    assert_template_result('worked wonderfully', "{{test}}", { 'test' => 'worked wonderfully' })
   end
 
   def test_variable_render_calls_to_liquid
@@ -43,9 +42,8 @@ class VariableTest < Minitest::Test
   end
 
   def test_simple_with_whitespaces
-    template = Template.parse(%(  {{ test }}  ))
-    assert_equal('  worked  ', template.render!('test' => 'worked'))
-    assert_equal('  worked wonderfully  ', template.render!('test' => 'worked wonderfully'))
+    assert_template_result("  worked  ", "  {{ test }}  ", { "test" => "worked" })
+    assert_template_result("  worked wonderfully  ", "  {{ test }}  ", { "test" => "worked wonderfully" })
   end
 
   def test_expression_with_whitespace_in_square_brackets
@@ -54,18 +52,15 @@ class VariableTest < Minitest::Test
   end
 
   def test_ignore_unknown
-    template = Template.parse(%({{ test }}))
-    assert_equal('', template.render!)
+    assert_template_result("", "{{ test }}")
   end
 
   def test_using_blank_as_variable_name
-    template = Template.parse("{% assign foo = blank %}{{ foo }}")
-    assert_equal('', template.render!)
+    assert_template_result("", "{% assign foo = blank %}{{ foo }}")
   end
 
   def test_using_empty_as_variable_name
-    template = Template.parse("{% assign foo = empty %}{{ foo }}")
-    assert_equal('', template.render!)
+    assert_template_result("", "{% assign foo = empty %}{{ foo }}")
   end
 
   def test_hash_scoping
@@ -74,13 +69,13 @@ class VariableTest < Minitest::Test
   end
 
   def test_false_renders_as_false
-    assert_equal('false', Template.parse("{{ foo }}").render!('foo' => false))
-    assert_equal('false', Template.parse("{{ false }}").render!)
+    assert_template_result("false", "{{ foo }}", { 'foo' => false })
+    assert_template_result("false", "{{ false }}")
   end
 
   def test_nil_renders_as_empty_string
-    assert_equal('', Template.parse("{{ nil }}").render!)
-    assert_equal('cat', Template.parse("{{ nil | append: 'cat' }}").render!)
+    assert_template_result("", "{{ nil }}")
+    assert_template_result("cat", "{{ nil | append: 'cat' }}")
   end
 
   def test_preset_assigns
@@ -121,7 +116,7 @@ class VariableTest < Minitest::Test
   end
 
   def test_multiline_variable
-    assert_equal('worked', Template.parse("{{\ntest\n}}").render!('test' => 'worked'))
+    assert_template_result("worked", "{{\ntest\n}}", { "test" => "worked" })
   end
 
   def test_render_symbol


### PR DESCRIPTION
## Problem

The test/integration folder is meant to be a set of tests that can be shared with other liquid implementations, initially used with liquid-c.  However, it still has coupling to the liquid library API, which could be further reduced.

## Solution

Use assert_template_result & assert_match_syntax_error in more places, since they are more decoupled from the liquid library API.

## Follow-up Work

There were tests that couldn't be converted with the current assert_template_result & assert_match_syntax_error interface, since they require additional options to be supported.  For instance, there is a need to specify the file system, error mode and to render liquid errors.  Once that is done, more integration tests can be decoupled from the library API.

I've also deferred the conversion of the standard library tests, which could use another help method to properly test the filter results, taking into account the type of the result.

I also noticed there were tests that are coupled to the liquid library API, which still need to be moved out of the test/integration folder to keep them separate.