### PR TITLE
Add partials, error_mode and render_errors options to assert_template_result

### DIFF
--- a/test/integration/assign_test.rb
+++ b/test/integration/assign_test.rb
@@ -34,14 +34,9 @@ class AssignTest < Minitest::Test
   end
 
   def test_assign_uses_error_mode
-    with_error_mode(:strict) do
-      assert_raises(SyntaxError) do
-        Template.parse("{% assign foo = ('X' | downcase) %}")
-      end
-    end
-    with_error_mode(:lax) do
-      assert(Template.parse("{% assign foo = ('X' | downcase) %}"))
-    end
+    assert_match_syntax_error("Expected dotdot but found pipe in ",
+      "{% assign foo = ('X' | downcase) %}", error_mode: :strict)
+    assert_template_result("", "{% assign foo = ('X' | downcase) %}", error_mode: :lax)
   end
 
   def test_expression_with_whitespace_in_square_brackets

--- a/test/integration/blank_test.rb
+++ b/test/integration/blank_test.rb
@@ -9,12 +9,6 @@ class FoobarTag < Liquid::Tag
   end
 end
 
-class BlankTestFileSystem
-  def read_template_file(template_path)
-    template_path
-  end
-end
-
 class BlankTest < Minitest::Test
   include Liquid
   N = 10
@@ -95,10 +89,12 @@ class BlankTest < Minitest::Test
   end
 
   def test_include_is_blank
-    Liquid::Template.file_system = BlankTestFileSystem.new
-    assert_template_result("foobar" * (N + 1), wrap("{% include 'foobar' %}"))
-    assert_template_result(" foobar " * (N + 1), wrap("{% include ' foobar ' %}"))
-    assert_template_result("   " * (N + 1), wrap(" {% include ' ' %} "))
+    assert_template_result("foobar" * (N + 1), wrap("{% include 'foobar' %}"),
+      partials: { 'foobar' => 'foobar' })
+    assert_template_result(" foobar " * (N + 1), wrap("{% include ' foobar ' %}"),
+      partials: { ' foobar ' => ' foobar ' })
+    assert_template_result("   " * (N + 1), wrap(" {% include ' ' %} "),
+      partials: { ' ' => ' ' })
   end
 
   def test_case_is_blank

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -134,14 +134,17 @@ class RenderTagTest < Minitest::Test
   end
 
   def test_includes_will_not_render_inside_nested_sibling_tags
-    Liquid::Template.file_system = StubFileSystem.new(
-      'foo' => 'bar',
-      'nested_render_with_sibling_include' => '{% render "test_include" %}{% include "foo" %}',
-      'test_include' => '{% include "foo" %}'
+    assert_template_result(
+      "Liquid error (test_include line 1): include usage is not allowed in this context" \
+        "Liquid error (nested_render_with_sibling_include line 1): include usage is not allowed in this context",
+      '{% render "nested_render_with_sibling_include" %}',
+      partials: {
+        'foo' => 'bar',
+        'nested_render_with_sibling_include' => '{% render "test_include" %}{% include "foo" %}',
+        'test_include' => '{% include "foo" %}',
+      },
+      render_errors: true
     )
-
-    output = Liquid::Template.parse('{% render "nested_render_with_sibling_include" %}').render
-    assert_equal('Liquid error: include usage is not allowed in this contextLiquid error: include usage is not allowed in this context', output)
   end
 
   def test_render_tag_with

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,9 +49,9 @@ module Minitest
       assert_equal(expected, output, message)
     end
 
-    def assert_match_syntax_error(match, template)
+    def assert_match_syntax_error(match, template, error_mode: nil)
       exception = assert_raises(Liquid::SyntaxError) do
-        Template.parse(template, line_numbers: true).render
+        Template.parse(template, line_numbers: true, error_mode: error_mode&.to_sym).render
       end
       assert_match(match, exception.message)
     end


### PR DESCRIPTION
Follow-up to #1611

> There were tests that couldn't be converted with the current assert_template_result & assert_match_syntax_error interface, since they require additional options to be supported. For instance, there is a need to specify the file system, error mode and to render liquid errors. Once that is done, more integration tests can be decoupled from the library API.

The partials, error_mode and render_errors options added by this PR correspond that stated need.  I've also changed a few tests to actually use those options to exercise the code paths for the new options.