### PR TITLE
Add a test and improve one for testing break

### DIFF
--- a/test/integration/tags/break_tag_test.rb
+++ b/test/integration/tags/break_tag_test.rb
@@ -9,8 +9,8 @@ class BreakTagTest < Minitest::Test
   # block
   def test_break_with_no_block
     assigns  = { 'i' => 1 }
-    markup   = '{% break %}'
-    expected = ''
+    markup   = 'before{% break %}after'
+    expected = 'before'
 
     assert_template_result(expected, markup, assigns)
   end

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -263,6 +263,19 @@ HERE
     assert_template_result(expected, markup, assigns)
   end
 
+  def test_for_with_break_after_nested_loop
+    source = <<~LIQUID.chomp
+      {% for i in (1..2) -%}
+        {% for j in (1..2) -%}
+          {{ i }}-{{ j }},
+        {%- endfor -%}
+        {% break -%}
+      {% endfor -%}
+      after
+    LIQUID
+    assert_template_result("1-1,1-2,after", source)
+  end
+
   def test_for_with_continue
     assigns = { 'array' => { 'items' => [1, 2, 3, 4, 5] } }
 


### PR DESCRIPTION
The existing test `test_break_with_no_block` didn't actually test what happened after the top-level break tag, so didn't actually make sure it interrupted the rest of the rendering.

The new test makes sure the break tag works properly after a nested loop while still in the outer loop, which I noticed being a missing edge case.