### PR TITLE
Use assert_template_result partials option to specify file system state

### DIFF
--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -6,53 +6,52 @@ class RenderTagTest < Minitest::Test
   include Liquid
 
   def test_render_with_no_arguments
-    Liquid::Template.file_system = StubFileSystem.new('source' => 'rendered content')
-    assert_template_result('rendered content', '{% render "source" %}')
+    assert_template_result('rendered content', '{% render "source" %}',
+      partials: { 'source' => 'rendered content' })
   end
 
   def test_render_tag_looks_for_file_system_in_registers_first
-    file_system = StubFileSystem.new('pick_a_source' => 'from register file system')
-    assert_equal('from register file system',
-      Template.parse('{% render "pick_a_source" %}').render!({}, registers: { file_system: file_system }))
+    assert_template_result('from register file system', '{% render "pick_a_source" %}',
+      partials: { 'pick_a_source' => 'from register file system' })
   end
 
   def test_render_passes_named_arguments_into_inner_scope
-    Liquid::Template.file_system = StubFileSystem.new('product' => '{{ inner_product.title }}')
     assert_template_result('My Product', '{% render "product", inner_product: outer_product %}',
-      { 'outer_product' => { 'title' => 'My Product' } })
+      { 'outer_product' => { 'title' => 'My Product' } },
+      partials: { 'product' => '{{ inner_product.title }}' })
   end
 
   def test_render_accepts_literals_as_arguments
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ price }}')
-    assert_template_result('123', '{% render "snippet", price: 123 %}')
+    assert_template_result('123', '{% render "snippet", price: 123 %}',
+      partials: { 'snippet' => '{{ price }}' })
   end
 
   def test_render_accepts_multiple_named_arguments
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ one }} {{ two }}')
-    assert_template_result('1 2', '{% render "snippet", one: 1, two: 2 %}')
+    assert_template_result('1 2', '{% render "snippet", one: 1, two: 2 %}',
+      partials: { 'snippet' => '{{ one }} {{ two }}' })
   end
 
   def test_render_does_not_inherit_parent_scope_variables
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ outer_variable }}')
-    assert_template_result('', '{% assign outer_variable = "should not be visible" %}{% render "snippet" %}')
+    assert_template_result('', '{% assign outer_variable = "should not be visible" %}{% render "snippet" %}',
+      partials: { 'snippet' => '{{ outer_variable }}' })
   end
 
   def test_render_does_not_inherit_variable_with_same_name_as_snippet
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => '{{ snippet }}')
-    assert_template_result('', "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}")
+    assert_template_result('', "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}",
+      partials: { 'snippet' => '{{ snippet }}' })
   end
 
   def test_render_does_not_mutate_parent_scope
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => '{% assign inner = 1 %}')
-    assert_template_result('', "{% render 'snippet' %}{{ inner }}")
+    assert_template_result('', "{% render 'snippet' %}{{ inner }}",
+      partials: { 'snippet' => '{% assign inner = 1 %}' })
   end
 
   def test_nested_render_tag
-    Liquid::Template.file_system = StubFileSystem.new(
-      'one' => "one {% render 'two' %}",
-      'two' => 'two'
-    )
-    assert_template_result('one two', "{% render 'one' %}")
+    assert_template_result('one two', "{% render 'one' %}",
+      partials: {
+        'one' => "one {% render 'two' %}",
+        'two' => 'two',
+      })
   end
 
   def test_recursively_rendered_template_does_not_produce_endless_loop
@@ -73,11 +72,7 @@ class RenderTagTest < Minitest::Test
   end
 
   def test_dynamically_choosen_templates_are_not_allowed
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => 'should not be rendered')
-
-    assert_raises(Liquid::SyntaxError) do
-      Liquid::Template.parse("{% assign name = 'snippet' %}{% render name %}")
-    end
+    assert_syntax_error("{% assign name = 'snippet' %}{% render name %}")
   end
 
   def test_include_tag_caches_second_read_of_same_partial
@@ -101,36 +96,36 @@ class RenderTagTest < Minitest::Test
   end
 
   def test_render_tag_within_if_statement
-    Liquid::Template.file_system = StubFileSystem.new('snippet' => 'my message')
-    assert_template_result('my message', '{% if true %}{% render "snippet" %}{% endif %}')
+    assert_template_result('my message', '{% if true %}{% render "snippet" %}{% endif %}',
+      partials: { 'snippet' => 'my message' })
   end
 
   def test_break_through_render
-    Liquid::Template.file_system = StubFileSystem.new('break' => '{% break %}')
-    assert_template_result('1', '{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}')
-    assert_template_result('112233', '{% for i in (1..3) %}{{ i }}{% render "break" %}{{ i }}{% endfor %}')
+    options = { partials: { 'break' => '{% break %}' } }
+    assert_template_result('1', '{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}', **options)
+    assert_template_result('112233', '{% for i in (1..3) %}{{ i }}{% render "break" %}{{ i }}{% endfor %}', **options)
   end
 
   def test_increment_is_isolated_between_renders
-    Liquid::Template.file_system = StubFileSystem.new('incr' => '{% increment %}')
-    assert_template_result('010', '{% increment %}{% increment %}{% render "incr" %}')
+    assert_template_result('010', '{% increment %}{% increment %}{% render "incr" %}',
+      partials: { 'incr' => '{% increment %}' })
   end
 
   def test_decrement_is_isolated_between_renders
-    Liquid::Template.file_system = StubFileSystem.new('decr' => '{% decrement %}')
-    assert_template_result('-1-2-1', '{% decrement %}{% decrement %}{% render "decr" %}')
+    assert_template_result('-1-2-1', '{% decrement %}{% decrement %}{% render "decr" %}',
+      partials: { 'decr' => '{% decrement %}' })
   end
 
   def test_includes_will_not_render_inside_render_tag
-    Liquid::Template.file_system = StubFileSystem.new(
-      'foo' => 'bar',
-      'test_include' => '{% include "foo" %}'
+    assert_template_result(
+      'Liquid error (test_include line 1): include usage is not allowed in this context',
+      '{% render "test_include" %}',
+      render_errors: true,
+      partials: {
+        'foo' => 'bar',
+        'test_include' => '{% include "foo" %}',
+      }
     )
-
-    exc = assert_raises(Liquid::DisabledError) do
-      Liquid::Template.parse('{% render "test_include" %}').render!
-    end
-    assert_equal('Liquid error: include usage is not allowed in this context', exc.message)
   end
 
   def test_includes_will_not_render_inside_nested_sibling_tags
@@ -148,74 +143,67 @@ class RenderTagTest < Minitest::Test
   end
 
   def test_render_tag_with
-    Liquid::Template.file_system = StubFileSystem.new(
-      'product' => "Product: {{ product.title }} ",
-      'product_alias' => "Product: {{ product.title }} ",
-    )
-
     assert_template_result("Product: Draft 151cm ",
       "{% render 'product' with products[0] %}",
-      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] },
+      partials: {
+        'product' => "Product: {{ product.title }} ",
+        'product_alias' => "Product: {{ product.title }} ",
+      })
   end
 
   def test_render_tag_with_alias
-    Liquid::Template.file_system = StubFileSystem.new(
-      'product' => "Product: {{ product.title }} ",
-      'product_alias' => "Product: {{ product.title }} ",
-    )
-
     assert_template_result("Product: Draft 151cm ",
       "{% render 'product_alias' with products[0] as product %}",
-      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] },
+      partials: {
+        'product' => "Product: {{ product.title }} ",
+        'product_alias' => "Product: {{ product.title }} ",
+      })
   end
 
   def test_render_tag_for_alias
-    Liquid::Template.file_system = StubFileSystem.new(
-      'product' => "Product: {{ product.title }} ",
-      'product_alias' => "Product: {{ product.title }} ",
-    )
-
     assert_template_result("Product: Draft 151cm Product: Element 155cm ",
       "{% render 'product_alias' for products as product %}",
-      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] },
+      partials: {
+        'product' => "Product: {{ product.title }} ",
+        'product_alias' => "Product: {{ product.title }} ",
+      })
   end
 
   def test_render_tag_for
-    Liquid::Template.file_system = StubFileSystem.new(
-      'product' => "Product: {{ product.title }} ",
-      'product_alias' => "Product: {{ product.title }} ",
-    )
-
     assert_template_result("Product: Draft 151cm Product: Element 155cm ",
       "{% render 'product' for products %}",
-      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] },
+      partials: {
+        'product' => "Product: {{ product.title }} ",
+        'product_alias' => "Product: {{ product.title }} ",
+      })
   end
 
   def test_render_tag_forloop
-    Liquid::Template.file_system = StubFileSystem.new(
-      'product' => "Product: {{ product.title }} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %} index:{{ forloop.index }} ",
-    )
-
     assert_template_result("Product: Draft 151cm first  index:1 Product: Element 155cm  last index:2 ",
       "{% render 'product' for products %}",
-      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] })
+      { "products" => [{ 'title' => 'Draft 151cm' }, { 'title' => 'Element 155cm' }] },
+      partials: {
+        'product' => "Product: {{ product.title }} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %} index:{{ forloop.index }} ",
+      })
   end
 
   def test_render_tag_for_drop
-    Liquid::Template.file_system = StubFileSystem.new(
-      'loop' => "{{ value.foo }}",
-    )
-
     assert_template_result("123",
-      "{% render 'loop' for loop as value %}", { "loop" => TestEnumerable.new })
+      "{% render 'loop' for loop as value %}", { "loop" => TestEnumerable.new },
+      partials: {
+        'loop' => "{{ value.foo }}",
+      })
   end
 
   def test_render_tag_with_drop
-    Liquid::Template.file_system = StubFileSystem.new(
-      'loop' => "{{ value }}",
-    )
-
     assert_template_result("TestEnumerable",
-      "{% render 'loop' with loop as value %}", { "loop" => TestEnumerable.new })
+      "{% render 'loop' with loop as value %}", { "loop" => TestEnumerable.new },
+      partials: {
+        'loop' => "{{ value }}",
+      })
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,10 @@ module Minitest
       assert_match(match, exception.message)
     end
 
+    def assert_syntax_error(template, error_mode: nil)
+      assert_match_syntax_error("", template, error_mode: error_mode)
+    end
+
     def assert_usage_increment(name, times: 1)
       old_method = Liquid::Usage.method(:increment)
       calls = 0


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/1614 added a partials option to assert_template_result along with a sample usage of it.

This PR uses that option more extensively to avoid the use of the `Liquid::Template.file_system = ` global state mutation to test with a given file system state for language tests.  This also makes these tests easier to understand, by keeping the relevant file system state together with the test that uses it.