### PR TITLE
Stop using assert_template_result in some tests depending on language extension

### DIFF
--- a/test/integration/blank_test.rb
+++ b/test/integration/blank_test.rb
@@ -27,7 +27,7 @@ class BlankTest < Minitest::Test
 
   def test_new_tags_are_not_blank_by_default
     with_custom_tag('foobar', FoobarTag) do
-      assert_template_result(" " * N, wrap_in_for("{% foobar %}"))
+      assert_equal(" " * N, Liquid::Template.parse(wrap_in_for("{% foobar %}")).render!)
     end
   end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -469,8 +469,8 @@ class StandardFiltersTest < Minitest::Test
   def test_map_over_proc
     drop  = TestDrop.new(value: "testfoo")
     p     = proc { drop }
-    templ = '{{ procs | map: "value" }}'
-    assert_template_result("testfoo", templ, { "procs" => [p] })
+    output = Liquid::Template.parse('{{ procs | map: "value" }}').render!({ "procs" => [p] })
+    assert_equal("testfoo", output)
   end
 
   def test_map_over_drops_returning_procs
@@ -482,12 +482,13 @@ class StandardFiltersTest < Minitest::Test
         "proc" => -> { "bar" },
       },
     ]
-    templ = '{{ drops | map: "proc" }}'
-    assert_template_result("foobar", templ, { "drops" => drops })
+    output = Liquid::Template.parse('{{ drops | map: "proc" }}').render!({ "drops" => drops })
+    assert_equal("foobar", output)
   end
 
   def test_map_works_on_enumerables
-    assert_template_result("123", '{{ foo | map: "foo" }}', { "foo" => TestEnumerable.new })
+    output = Liquid::Template.parse('{{ foo | map: "foo" }}').render!({ "foo" => TestEnumerable.new })
+    assert_equal("123", output)
   end
 
   def test_map_returns_empty_on_2d_input_array


### PR DESCRIPTION
For #1621 

> Tests for liquid extensions (e.g. custom drops, tags or filters) would depend on the library API and should probably be distinguished from language tests so they don't get converted to YAML tests. Perhaps they shouldn't use those decoupled test helpers like `assert_template_result` or `assert_match_syntax_error` to make it easier to separate those tests when we are ready to rewrite them in YAML.

As such, I've written a PR as a sample of this sort of change, before make this change more broadly.

The `assert_template_result` test helper is a pretty thin abstraction, so using the library API can actually make the test a bit clearer to those familiar with that API, even though it is a bit more verbose.

An alternative would be to move all these tests to different test files, perhaps in a different directory.  However, I think it does make sense for these tests to stay in the test/integration/ folder (since they are integration tests for this library) and it seems like these changes would be easier to review than moving tests between files.