### PR TITLE
Stop freezing the static environment hashes to allow Proc memoization

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -26,7 +26,7 @@ module Liquid
       @environments = [environments]
       @environments.flatten!
 
-      @static_environments = [static_environments].flat_map(&:freeze).freeze
+      @static_environments = [static_environments].flatten(1).freeze
       @scopes              = [(outer_scope || {})]
       @registers           = registers.is_a?(Registers) ? registers : Registers.new(registers)
       @errors              = []


### PR DESCRIPTION
## Problem

I noticed for Shopify's storefront rendering that we are hacking around the fact that the static environments get frozen by overriding the Liquid::Context#initialize and Liquid::Context#new_isolated_subcontext to mimic the same feature.  I suspect the reason for that hack is that it allows for lazy loading by assigning a Proc in the environment, which doesn't work with Liquid::Context#static_environments due to the freezing of its Hashes in Liquid::Context#initialize.

## Solution

Remove the freezing of the static environments hashes in Liquid::Context#initialize.  Instead, we just treat it as semantically static, so that it supports memoization.  This is similar to how liquid values tend to be immutable, even though they may have internal mutations for memoizing lazy loads.