### PR TITLE
Update escape filter reference summary

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -73,7 +73,7 @@ module Liquid
     # @liquid_type filter
     # @liquid_category string
     # @liquid_summary
-    #   Escapes a string.
+    #   Escapes special characters in HTML, such as `<>`, `'`, and `&`, and converts characters into escape sequences. The filter doesn't effect characters within the string that don’t have a corresponding escape sequence.".
     # @liquid_syntax string | escape
     # @liquid_return [string]
     def escape(input)


### PR DESCRIPTION
Added a more complete description of what the `escape` Liquid filter achieves, and how it behaves on `/api/liquid/filters` I was [advised in the Liquid slack channel](https://shopify.slack.com/archives/C07F3LRPF/p1664195876822159) to borrow some context from the [description of `CGI.escapeHTML` in Ruby](https://ruby-doc.org/stdlib-2.4.3/libdoc/cgi/rdoc/CGI/Util.html#method-i-escapeHTML), as it has the same behaviour. 

Fixes issue in dev docs https://github.com/Shopify/shopify-dev/pull/26494

Before:

![](https://screenshot.click/28-26-75h4x-vd9n8.png)

After:

![](https://screenshot.click/28-27-38e3j-08vvj.png)

CC: @shainaraskas 