### PR TITLE
fix tablerow drop's last attribute with missing cols param

### DIFF
--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -51,7 +51,7 @@ module Liquid
       collection = Utils.slice_collection(collection, from, to)
       length     = collection.length
 
-      cols = context.evaluate(@attributes['cols']).to_i
+      cols = @attributes['cols'].nil? ? length : context.evaluate(@attributes['cols']).to_i
 
       output << "<tr class=\"row1\">\n"
       context.stack do

--- a/test/integration/tags/table_row_test.rb
+++ b/test/integration/tags/table_row_test.rb
@@ -65,4 +65,56 @@ class TableRowTest < Minitest::Test
       "{% tablerow char in characters cols:3 %}I WILL NOT BE OUTPUT{% endtablerow %}",
       { 'characters' => '' })
   end
+
+  def test_tablerow_loop_drop_attributes
+    template = <<~LIQUID.chomp
+      {% tablerow i in (1...2) %}
+      col: {{ tablerowloop.col }}
+      col0: {{ tablerowloop.col0 }}
+      col_first: {{ tablerowloop.col_first }}
+      col_last: {{ tablerowloop.col_last }}
+      first: {{ tablerowloop.first }}
+      index: {{ tablerowloop.index }}
+      index0: {{ tablerowloop.index0 }}
+      last: {{ tablerowloop.last }}
+      length: {{ tablerowloop.length }}
+      rindex: {{ tablerowloop.rindex }}
+      rindex0: {{ tablerowloop.rindex0 }}
+      row: {{ tablerowloop.row }}
+      {% endtablerow %}
+    LIQUID
+
+    expected_output = <<~OUTPUT
+      <tr class="row1">
+      <td class="col1">
+      col: 1
+      col0: 0
+      col_first: true
+      col_last: false
+      first: true
+      index: 1
+      index0: 0
+      last: false
+      length: 2
+      rindex: 2
+      rindex0: 1
+      row: 1
+      </td><td class="col2">
+      col: 2
+      col0: 1
+      col_first: false
+      col_last: true
+      first: false
+      index: 2
+      index0: 1
+      last: true
+      length: 2
+      rindex: 1
+      rindex0: 0
+      row: 1
+      </td></tr>
+    OUTPUT
+
+    assert_template_result(expected_output, template)
+  end
 end


### PR DESCRIPTION
When `cols` param is missing from the `tablerow` tag, `tablerowloop#col_last` always returns `false`.

Liquid template:
```liquid
{% tablerow i in (1..2) %}
  {{ tablerowloop.col_last }}
{% endtablerow %}
```

Expected output:
```
<tr class="row1">
<td class="col1">
false
</td><td class="col2">
true
</td></tr>
```

Current output:
```
<tr class="row1">
<td class="col1">
false
</td><td class="col2">
false
</td></tr>
```