### PR TITLE
Update link paths in docs markup

### DIFF
--- a/lib/liquid/forloop_drop.rb
+++ b/lib/liquid/forloop_drop.rb
@@ -5,7 +5,7 @@ module Liquid
   # @liquid_type object
   # @liquid_name forloop
   # @liquid_summary
-  #   Information about a parent [`for` loop](/api/liquid/tags#for).
+  #   Information about a parent [`for` loop](/api/liquid/tags/for).
   class ForloopDrop < Drop
     def initialize(name, length, parentloop)
       @name       = name

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -599,7 +599,7 @@ module Liquid
     # @liquid_description
     #   > Note:
     #   > The `concat` filter won't filter out duplicates. If you want to remove duplicates, then you need to use the
-    #   > [`uniq` filter](/api/liquid/filters#uniq).
+    #   > [`uniq` filter](/api/liquid/filters/uniq).
     # @liquid_syntax array | concat: array
     # @liquid_return [array[untyped]]
     def concat(input, array)

--- a/lib/liquid/tablerowloop_drop.rb
+++ b/lib/liquid/tablerowloop_drop.rb
@@ -5,7 +5,7 @@ module Liquid
   # @liquid_type object
   # @liquid_name tablerowloop
   # @liquid_summary
-  #   Information about a parent [`tablerow` loop](/api/liquid/tags#tablerow).
+  #   Information about a parent [`tablerow` loop](/api/liquid/tags/tablerow).
   class TablerowloopDrop < Drop
     def initialize(length, cols)
       @length = length

--- a/lib/liquid/tags/break.rb
+++ b/lib/liquid/tags/break.rb
@@ -15,7 +15,7 @@ module Liquid
   # @liquid_category iteration
   # @liquid_name break
   # @liquid_summary
-  #   Stops a [`for` loop](/api/liquid/tags#for) from iterating.
+  #   Stops a [`for` loop](/api/liquid/tags/for) from iterating.
   # @liquid_syntax
   #   {% break %}
   class Break < Tag

--- a/lib/liquid/tags/continue.rb
+++ b/lib/liquid/tags/continue.rb
@@ -6,7 +6,7 @@ module Liquid
   # @liquid_category iteration
   # @liquid_name continue
   # @liquid_summary
-  #   Causes a [`for` loop](/api/liquid/tags#for) to skip to the next iteration.
+  #   Causes a [`for` loop](/api/liquid/tags/for) to skip to the next iteration.
   # @liquid_syntax
   #   {% continue %}
   class Continue < Tag

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -6,7 +6,7 @@ module Liquid
   # @liquid_category iteration
   # @liquid_name cycle
   # @liquid_summary
-  #   Loops through a group of strings and outputs them one at a time for each iteration of a [`for` loop](/api/liquid/tags#for).
+  #   Loops through a group of strings and outputs them one at a time for each iteration of a [`for` loop](/api/liquid/tags/for).
   # @liquid_description
   #   The `cycle` tag must be used inside a `for` loop.
   #

--- a/lib/liquid/tags/decrement.rb
+++ b/lib/liquid/tags/decrement.rb
@@ -12,8 +12,8 @@ module Liquid
   #   or [section](/themes/architecture/sections) file that they're created in. However, the variable is shared across
   #   [snippets](/themes/architecture#snippets) included in the file.
   #
-  #   Similarly, variables that are created with `decrement` are independent from those created with [`assign`](/api/liquid/tags#assign)
-  #   and [`capture`](/api/liquid/tags#capture). However, `decrement` and [`increment`](/api/liquid/tags#increment) share
+  #   Similarly, variables that are created with `decrement` are independent from those created with [`assign`](/api/liquid/tags/assign)
+  #   and [`capture`](/api/liquid/tags/capture). However, `decrement` and [`increment`](/api/liquid/tags/increment) share
   #   variables.
   # @liquid_syntax
   #   {% decrement variable_name %}

--- a/lib/liquid/tags/echo.rb
+++ b/lib/liquid/tags/echo.rb
@@ -9,7 +9,7 @@ module Liquid
   #   Outputs an expression.
   # @liquid_description
   #   Using the `echo` tag is the same as wrapping an expression in curly brackets (`{{` and `}}`). However, unlike the curly
-  #   bracket method, you can use the `echo` tag inside [`liquid` tags](/api/liquid/tags#liquid).
+  #   bracket method, you can use the `echo` tag inside [`liquid` tags](/api/liquid/tags/liquid).
   #
   #   > Tip:
   #   > You can use [filters](/api/liquid/filters) on expressions inside `echo` tags.

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -9,10 +9,10 @@ module Liquid
   #   Renders an expression for every item in an array.
   # @liquid_description
   #   You can do a maximum of 50 iterations with a `for` loop. If you need to iterate over more than 50 items, then use the
-  #   [`paginate` tag](/api/liquid/tags#paginate) to split the items over multiple pages.
+  #   [`paginate` tag](/api/liquid/tags/paginate) to split the items over multiple pages.
   #
   #   > Tip:
-  #   > Every `for` loop has an associated [`forloop` object](/api/liquid/objects#forloop) with information about the loop.
+  #   > Every `for` loop has an associated [`forloop` object](/api/liquid/objects/forloop) with information about the loop.
   # @liquid_syntax
   #   {% for variable in array %}
   #     expression

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -8,7 +8,7 @@ module Liquid
   # @liquid_summary
   #   Renders a [snippet](/themes/architecture#snippets).
   # @liquid_description
-  #   Inside the snippet, you can access and alter variables that are [created](/api/liquid/tags#variable-tags) outside of the
+  #   Inside the snippet, you can access and alter variables that are [created](/api/liquid/tags/variable-tags) outside of the
   #   snippet.
   # @liquid_syntax
   #   {% include 'filename' %}
@@ -16,7 +16,7 @@ module Liquid
   # @liquid_deprecated
   #   Deprecated because the way that variables are handled reduces performance and makes code harder to both read and maintain.
   #
-  #   The `include` tag has been replaced by [`render`](/api/liquid/tags#render).
+  #   The `include` tag has been replaced by [`render`](/api/liquid/tags/render).
   class Include < Tag
     prepend Tag::Disableable
 

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -12,8 +12,8 @@ module Liquid
   #   or [section](/themes/architecture/sections) file that they're created in. However, the variable is shared across
   #   [snippets](/themes/architecture#snippets) included in the file.
   #
-  #   Similarly, variables that are created with `increment` are independent from those created with [`assign`](/api/liquid/tags#assign)
-  #   and [`capture`](/api/liquid/tags#capture). However, `increment` and [`decrement`](/api/liquid/tags#decrement) share
+  #   Similarly, variables that are created with `increment` are independent from those created with [`assign`](/api/liquid/tags/assign)
+  #   and [`capture`](/api/liquid/tags/capture). However, `increment` and [`decrement`](/api/liquid/tags/decrement) share
   #   variables.
   # @liquid_syntax
   #   {% increment variable_name %}

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -8,19 +8,19 @@ module Liquid
   # @liquid_summary
   #   Renders a [snippet](/themes/architecture#snippets) or [app block](/themes/architecture/sections/section-schema#render-app-blocks).
   # @liquid_description
-  #   Inside snippets and app blocks, you can't directly access variables that are [created](/api/liquid/tags#variable-tags) outside
-  #   of the snippet or app block. However, you can [specify variables as parameters](/api/liquid/tags#render-passing-variables-to-snippets)
+  #   Inside snippets and app blocks, you can't directly access variables that are [created](/api/liquid/tags/variable-tags) outside
+  #   of the snippet or app block. However, you can [specify variables as parameters](/api/liquid/tags/render#render-passing-variables-to-a-snippet)
   #   to pass outside variables to snippets.
   #
   #   While you can't directly access created variables, you can access global objects, as well as any objects that are
   #   directly accessible outside the snippet or app block. For example, a snippet or app block inside the [product template](/themes/architecture/templates/product)
-  #   can access the [`product` object](/api/liquid/objects#product), and a snippet or app block inside a [section](/themes/architecture/sections)
-  #   can access the [`section` object](/api/liquid/objects#section).
+  #   can access the [`product` object](/api/liquid/objects/product), and a snippet or app block inside a [section](/themes/architecture/sections)
+  #   can access the [`section` object](/api/liquid/objects/section).
   #
   #   Outside a snippet or app block, you can't access variables created inside the snippet or app block.
   #
   #   > Note:
-  #   > When you render a snippet using the `render` tag, you can't use the [`include` tag](/api/liquid/tags#include)
+  #   > When you render a snippet using the `render` tag, you can't use the [`include` tag](/api/liquid/tags/include)
   #   > inside the snippet.
   # @liquid_syntax
   #   {% render 'filename' %}

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -11,7 +11,7 @@ module Liquid
   #   The `tablerow` tag must be wrapped in HTML `<table>` and `</table>` tags.
   #
   #   > Tip:
-  #   > Every `tablerow` loop has an associated [`tablerowloop` object](/api/liquid/objects#tablerowloop) with information about the loop.
+  #   > Every `tablerow` loop has an associated [`tablerowloop` object](/api/liquid/objects/tablerowloop) with information about the loop.
   # @liquid_syntax
   #   {% tablerow variable in array %}
   #     expression

--- a/lib/liquid/tags/unless.rb
+++ b/lib/liquid/tags/unless.rb
@@ -11,7 +11,7 @@ module Liquid
   #   Renders an expression unless a specific condition is `true`.
   # @liquid_description
   #   > Tip:
-  #   > Similar to the [`if` tag](/api/liquid/tags#if), you can use `elsif` to add more conditions to an `unless` tag.
+  #   > Similar to the [`if` tag](/api/liquid/tags/if), you can use `elsif` to add more conditions to an `unless` tag.
   # @liquid_syntax
   #   {% unless condition %}
   #     expression


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify-dev/issues/25372

This PR updates links used in the Liquid docs to reflect a new routing schema being implemented for SEO reasons. While a tag/filter/object previously lived at `/api/liquid/tags#tagname`, it will now live at `/api/liquid/tags/tagname`, so all of the hard-coded links used in the docs content need to be updated to the new schema.