### PR TITLE
Clarifying description for {% comment %}

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -8,7 +8,7 @@ module Liquid
   # @liquid_summary
   #   Prevents an expression from being rendered or output.
   # @liquid_description
-  #   Any text inside `comment` tags won't be output, and any Liquid code won't be rendered.
+  #   Any text inside `comment` tags won't be output, and any Liquid code will be parsed, but not executed.
   # @liquid_syntax
   #   {% comment %}
   #     content


### PR DESCRIPTION
This PR addresses feedback we have received about why liquid would throw parsing errors even for code in {% comment %} blocks. Hopefully, this clarifies that this code (while not being executed/rendered) is indeed parsed initially.