### PR TITLE
Use static environment assert_template_result input values 

### DIFF
--- a/test/integration/tags/increment_tag_test.rb
+++ b/test/integration/tags/increment_tag_test.rb
@@ -6,20 +6,21 @@ class IncrementTagTest < Minitest::Test
   include Liquid
 
   def test_inc
-    assert_template_result('0', '{%increment port %}', {})
-    assert_template_result('0 1', '{%increment port %} {%increment port%}', {})
+    assert_template_result('0 1', '{%increment port %} {{ port }}')
+    assert_template_result(' 0 1 2', '{{port}} {%increment port %} {%increment port%} {{port}}')
     assert_template_result('0 0 1 2 1',
       '{%increment port %} {%increment starboard%} ' \
       '{%increment port %} {%increment port%} ' \
-      '{%increment starboard %}', {})
+      '{%increment starboard %}')
   end
 
   def test_dec
-    assert_template_result('9', '{%decrement port %}', { 'port' => 10 })
-    assert_template_result('-1 -2', '{%decrement port %} {%decrement port%}', {})
-    assert_template_result('1 5 2 2 5',
+    assert_template_result('-1 -1', '{%decrement port %} {{ port }}', { 'port' => 10 })
+    assert_template_result(' -1 -2 -2', '{{port}} {%decrement port %} {%decrement port%} {{port}}')
+    assert_template_result('0 1 2 0 3 1 1 3',
+      '{%increment starboard %} {%increment starboard%} {%increment starboard%} ' \
       '{%increment port %} {%increment starboard%} ' \
       '{%increment port %} {%decrement port%} ' \
-      '{%decrement starboard %}', { 'port' => 1, 'starboard' => 5 })
+      '{%decrement starboard %}')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,7 +44,7 @@ module Minitest
       template = Liquid::Template.parse(template, line_numbers: true, error_mode: error_mode&.to_sym)
       file_system = StubFileSystem.new(partials) if partials
       registers = Liquid::Registers.new(file_system: file_system)
-      context = Liquid::Context.build(environments: assigns, rethrow_errors: !render_errors, registers: registers)
+      context = Liquid::Context.build(static_environments: assigns, rethrow_errors: !render_errors, registers: registers)
       output = template.render(context)
       assert_equal(expected, output, message)
     end


### PR DESCRIPTION
As part of https://github.com/Shopify/liquid/issues/1621, we want tests for the liquid language itself, things that aren't liquid implementation specific.  However, in practice we use the static environment for input even though `assert_template_result` is using the non-static environment that is shared with the counters.  As such, this is neither testing behaviour which we see in practice, nor behaviour that we should need to preserve in a reimplementation of liquid, so I've changed `assert_template_result` to pass input values in the static environment.

Similarly, I've updated the increment/decrement tests to not depend on the ability to pass in initial values for these counters.  I've also updated them to actually test the reading of the variables, which is observable behaviour.