### PR TITLE
tablerow: Avoid accidental special case for constant nil cols

### DIFF
--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -51,7 +51,7 @@ module Liquid
       collection = Utils.slice_collection(collection, from, to)
       length     = collection.length
 
-      cols = @attributes['cols'].nil? ? length : context.evaluate(@attributes['cols']).to_i
+      cols = @attributes.key?('cols') ? context.evaluate(@attributes['cols']).to_i : length
 
       output << "<tr class=\"row1\">\n"
       context.stack do

--- a/test/integration/tags/table_row_test.rb
+++ b/test/integration/tags/table_row_test.rb
@@ -66,6 +66,20 @@ class TableRowTest < Minitest::Test
       { 'characters' => '' })
   end
 
+  def test_cols_nil_constant_same_as_evaluated_nil_expression
+    expect = "<tr class=\"row1\">\n" \
+      "<td class=\"col1\">false</td>" \
+      "<td class=\"col2\">false</td>" \
+      "</tr>\n"
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) cols:nil %}{{ tablerowloop.col_last }}{% endtablerow %}")
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) cols:var %}{{ tablerowloop.col_last }}{% endtablerow %}",
+      { "var" => nil })
+  end
+
   def test_tablerow_loop_drop_attributes
     template = <<~LIQUID.chomp
       {% tablerow i in (1...2) %}


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid/pull/1633 recently introduced a weird special case behaviour for a nil literal for the tablerow columns, which differs from an expression that evaluates to `nil`.  This is because `@attributes['cols'].nil?` would match a `nil` literal expression, but wouldn't match an expression that dynamically evaluates to `nil`.

The included regression test demonstrates the problem, where `{% tablerow i in (1..2) cols:nil %}{{ tablerowloop.col_last }}{% endtablerow %}` doesn't produces the same output as `{% tablerow i in (1..2) cols:var %}{{ tablerowloop.col_last }}{% endtablerow %}` when `var` is `nil`.

## Solution

It seems like the intended behaviour is to default 'cols' to the length of the slice being iterated over, as `@attributes.key?` does for the 'offset' and 'limit' attributes.  So I updated the expression to default 'cols' to also use `@attributes.key?`.