### PR TITLE
Remove Usage.increment calls that have been shown to in fact be used

### DIFF
--- a/lib/liquid/forloop_drop.rb
+++ b/lib/liquid/forloop_drop.rb
@@ -30,10 +30,7 @@ module Liquid
     # @liquid_return [forloop]
     attr_reader :parentloop
 
-    def name
-      Usage.increment('forloop_drop_name')
-      @name
-    end
+    attr_reader :name
 
     # @liquid_public_docs
     # @liquid_summary

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -177,7 +177,6 @@ module Liquid
       case key
       when 'offset'
         @from = if expr == 'continue'
-          Usage.increment('for_offset_continue')
           :continue
         else
           parse_expression(expr)

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -450,30 +450,4 @@ HERE
 
     assert(context.registers[:for_stack].empty?)
   end
-
-  def test_instrument_for_offset_continue
-    assert_usage_increment('for_offset_continue') do
-      Template.parse('{% for item in items offset:continue %}{{item}}{% endfor %}')
-    end
-
-    assert_usage_increment('for_offset_continue', times: 0) do
-      Template.parse('{% for item in items offset:2 %}{{item}}{% endfor %}')
-    end
-  end
-
-  def test_instrument_forloop_drop_name
-    assigns = { 'items' => [1, 2, 3, 4, 5] }
-
-    assert_usage_increment('forloop_drop_name', times: 5) do
-      Template.parse('{% for item in items %}{{forloop.name}}{% endfor %}').render!(assigns)
-    end
-
-    assert_usage_increment('forloop_drop_name', times: 0) do
-      Template.parse('{% for item in items %}{{forloop.index}}{% endfor %}').render!(assigns)
-    end
-
-    assert_usage_increment('forloop_drop_name', times: 0) do
-      Template.parse('{% for item in items %}{{item}}{% endfor %}').render!(assigns)
-    end
-  end
 end


### PR DESCRIPTION
I think I had added for undocumented features to see if they were actually used and they were being used.  So I figured I would remove them now.