### PR TITLE
Fix missing inheritance of disabled tags

### DIFF
--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -14,12 +14,18 @@ module Liquid
       end
 
       def disable_tags(*tag_names)
-        @disabled_tags ||= []
-        @disabled_tags.concat(tag_names)
+        tag_names += disabled_tags
+        define_singleton_method(:disabled_tags) { tag_names }
         prepend(Disabler)
       end
 
       private :new
+
+      protected
+
+      def disabled_tags
+        []
+      end
     end
 
     def initialize(tag_name, markup, parse_context)

--- a/lib/liquid/tag/disabler.rb
+++ b/lib/liquid/tag/disabler.rb
@@ -3,14 +3,6 @@
 module Liquid
   class Tag
     module Disabler
-      module ClassMethods
-        attr_reader :disabled_tags
-      end
-
-      def self.prepended(base)
-        base.extend(ClassMethods)
-      end
-
       def render_to_output_buffer(context, output)
         context.with_disabled_tags(self.class.disabled_tags) do
           super


### PR DESCRIPTION
## Problem

I noticed that when we subclass the Liquid::Render tag, it doesn't inherit the disabled tags or set the `@disabled_tags` instance variable on the class.  This results in an internal error when the tag subclassing the Liquid::Render tag is used without the subclass also calling `disable_tags "include"`.  Also, if the subclass tried to disable another tag, it could easily re-enable the tag disabled in the subclass.

## Solution

Use the same approach as rails' `class_attribute` of defining a method when `disable_tags` is called to override the parent's `disabled_tags`, without the method needing to be called to inherit the parent class' method.