### PR TITLE
refactor: Advance tokenizer array offset instead of using Array#shift

### DIFF
--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -8,11 +8,15 @@ module Liquid
       @source         = source.to_s.to_str
       @line_number    = line_number || (line_numbers ? 1 : nil)
       @for_liquid_tag = for_liquid_tag
+      @offset         = 0
       @tokens         = tokenize
     end
 
     def shift
-      (token = @tokens.shift) || return
+      token = @tokens[@offset]
+      return nil unless token
+
+      @offset += 1
 
       if @line_number
         @line_number += @for_liquid_tag ? 1 : token.count("\n")
@@ -31,7 +35,9 @@ module Liquid
       tokens = @source.split(TemplateParser)
 
       # removes the rogue empty element at the beginning of the array
-      tokens.shift if tokens[0]&.empty?
+      if tokens[0]&.empty?
+        @offset += 1
+      end
 
       tokens
     end


### PR DESCRIPTION
Array#shift would move all the remaining elements of the array, which is slower for larger arrays, such as from larger templates.