### PR TITLE
clarify inline_comment

### DIFF
--- a/lib/liquid/tags/inline_comment.rb
+++ b/lib/liquid/tags/inline_comment.rb
@@ -4,13 +4,16 @@ module Liquid
   # @liquid_public_docs
   # @liquid_type tag
   # @liquid_category syntax
-  # @liquid_name inline comment
+  # @liquid_name inline comments
   # @liquid_summary
   #   Prevents an expression inside of a tag `{% %}` from being rendered or output.
   # @liquid_description
+  #   You can use inline comment tags to annotate your code, or to temporarily prevent logic in your code from executing.
+  #
+  #   You can create multi-line inline comments. However, each line in the tag must begin with a `#`, or a syntax error will occur.
   # @liquid_syntax
   #   {% # content %}
-  # @liquid_syntax_keyword content The content of the comment.
+  # @liquid_syntax_keyword content The content of the tag.
   class InlineComment < Tag
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/inline_comment.rb
+++ b/lib/liquid/tags/inline_comment.rb
@@ -1,19 +1,6 @@
 # frozen_string_literal: true
 
 module Liquid
-  # @liquid_public_docs
-  # @liquid_type tag
-  # @liquid_category syntax
-  # @liquid_name inline comments
-  # @liquid_summary
-  #   Prevents an expression inside of a tag `{% %}` from being rendered or output.
-  # @liquid_description
-  #   You can use inline comment tags to annotate your code, or to temporarily prevent logic in your code from executing.
-  #
-  #   You can create multi-line inline comments. However, each line in the tag must begin with a `#`, or a syntax error will occur.
-  # @liquid_syntax
-  #   {% # content %}
-  # @liquid_syntax_keyword content The content of the tag.
   class InlineComment < Tag
     def initialize(tag_name, markup, options)
       super

--- a/lib/liquid/tags/inline_comment.rb
+++ b/lib/liquid/tags/inline_comment.rb
@@ -4,13 +4,10 @@ module Liquid
   # @liquid_public_docs
   # @liquid_type tag
   # @liquid_category syntax
-  # @liquid_name inline_comment
+  # @liquid_name inline comment
   # @liquid_summary
-  #   Prevents an expression from being rendered or output.
+  #   Prevents an expression inside of a tag `{% %}` from being rendered or output.
   # @liquid_description
-  #   Any text inside an `inline_comment` tag won't be rendered or output.
-  #
-  #   You can create multi-line inline comments. However, each line must begin with a `#`.
   # @liquid_syntax
   #   {% # content %}
   # @liquid_syntax_keyword content The content of the comment.


### PR DESCRIPTION
Remove inline comment YARD tags, with the intent of moving the documentation into the `comment` tag docs as examples in shopify.dev