### PR TITLE
Allow commas to separate `for` tag attributes

### DIFF
--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -98,11 +98,12 @@ module Liquid
       @name     = "#{@variable_name}-#{collection_name}"
       @reversed = p.id?('reversed')
 
-      while p.look(:id) && p.look(:colon, 1)
+      while p.look(:comma) || p.look(:id)
+        p.consume?(:comma)
         unless (attribute = p.id?('limit') || p.id?('offset'))
           raise SyntaxError, options[:locale].t("errors.syntax.for_invalid_attribute")
         end
-        p.consume
+        p.consume(:colon)
         set_attribute(attribute, p.expression)
       end
       p.consume(:end_of_string)

--- a/test/integration/tags/for_tag_test.rb
+++ b/test/integration/tags/for_tag_test.rb
@@ -103,6 +103,7 @@ HERE
     assert_template_result('1234', '{%for i in array limit:4 %}{{ i }}{%endfor%}', assigns)
     assert_template_result('3456', '{%for i in array limit:4 offset:2 %}{{ i }}{%endfor%}', assigns)
     assert_template_result('3456', '{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}', assigns)
+    assert_template_result('3456', '{%for i in array, limit: 4, offset: 2 %}{{ i }}{%endfor%}', assigns)
   end
 
   def test_limiting_with_invalid_limit


### PR DESCRIPTION
## Problem

There are multiple tags that use Liquid::TagAttributes to scan for attributes, but the only one that has strict parsing is the `for` tag and that strict parsing doesn't allow commas as separators as we typically use in other tags for tag attributes.

For example, the [`render` tag documentation for passing variables to a snippet](https://shopify.dev/api/liquid/tags/render#render-passing-variables-to-a-snippet) demonstrates this with `{% render 'filename', variable: value %}`.  Based on what I see in the dawn theme, it looks like this is our preferred style (e.g. we have [`{% render 'card-collection', card_collection: block.settings.collection , media_aspect_ratio: section.settings.image_ratio, columns: columns %}`](https://github.com/Shopify/dawn/blob/9361f8c65332efb67ea9a4ad2cba82eec1c22fa9/sections/collection-list.liquid#L54))

In contrast, trying to use the same style in the `for` tag (e.g. `{% for i in array, limit: 4, offset: 2 %}...{% endfor %}`) would be a syntax error in strict parsing mode, requiring only a space to be used as a separate (e.g. `{% for i in array  limit: 4  offset: 2 %}...{% endfor %}`).

## Solution

Update Liquid::For#strict_parse to optionally allow commas to separate tag attributes.

Note that the `for` tag also allows a `reversed` option to be specified, but it is different from a tag attribute in that it isn't given a value and is expected to precede any tag attributes.  Given this, I decided it didn't need to also allow a comma to precede it.