### PR TITLE
[Liquid reference docs] Adding more content to divided_by filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -757,7 +757,7 @@ module Liquid
     # @liquid_type filter
     # @liquid_category math
     # @liquid_summary
-    #   Divides a number by a given number. The `divided_by` filter produces a result of the same type as the divisor. This means if you divide by an integer, the result will be an integer, and if you divide by a float, the result will be a float. 
+    #   Divides a number by a given number. The `divided_by` filter produces a result of the same type as the divisor. This means if you divide by an integer, the result will be an integer, and if you divide by a float, the result will be a float.
     # @liquid_syntax number | divided_by: number
     # @liquid_return [number]
     def divided_by(input, operand)


### PR DESCRIPTION
Addressing feedback from https://github.com/Shopify/shopify-dev/issues/25953

This PR is adding more content to the `divided_by` filter description [(on this page of shopify.dev)](https://shopify.dev/api/liquid/filters/divided_by) by detailing the behaviour of how different results are generated by different types of divisors.

Before: 

![](https://screenshot.click/06-33-hj05w-0vnxt.png)

After:

![](https://screenshot.click/06-32-b0hnc-lfvsf.png)
