### PR TITLE
Instrument usage of bug with iteration of String with offset or 0 limit

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -16,7 +16,11 @@ module Liquid
 
       # Maintains Ruby 1.8.7 String#each behaviour on 1.9
       if collection.is_a?(String)
-        return collection.empty? ? [] : [collection]
+        return [] if collection.empty?
+        if from > 0 || to == 0
+          Usage.increment("string_slice_bug")
+        end
+        return [collection]
       end
       return [] unless collection.respond_to?(:each)
 

--- a/test/unit/tags/for_tag_unit_test.rb
+++ b/test/unit/tags/for_tag_unit_test.rb
@@ -12,4 +12,34 @@ class ForTagUnitTest < Minitest::Test
     template = Liquid::Template.parse('{% for item in items %}FOR{% else %}ELSE{% endfor %}')
     assert_equal(['FOR', 'ELSE'], template.root.nodelist[0].nodelist.map(&:nodelist).flatten)
   end
+
+  def test_for_string_slice_bug_usage
+    template = Liquid::Template.parse("{% for x in str, offset: 1 %}{{ x }},{% endfor %}")
+    assert_usage("string_slice_bug") do
+      assert_equal("abc,", template.render({ "str" => "abc" }))
+    end
+  end
+
+  def test_for_string_0_limit_usage
+    template = Liquid::Template.parse("{% for x in str, limit: 0 %}{{ x }},{% endfor %}")
+    assert_usage("string_slice_bug") do
+      assert_equal("abc,", template.render({ "str" => "abc" }))
+    end
+  end
+
+  def test_for_string_no_slice_usage
+    template = Liquid::Template.parse("{% for x in str, offset: 0, limit: 1 %}{{ x }},{% endfor %}")
+    assert_usage("string_slice_bug", times: 0) do
+      assert_equal("abc,", template.render({ "str" => "abc" }))
+    end
+  end
+
+  private
+
+  def assert_usage(name, times: 1, &block)
+    count = 0
+    result = Liquid::Usage.stub(:increment, ->(n) { count += 1 if n == name }, &block)
+    assert_equal(times, count)
+    result
+  end
 end


### PR DESCRIPTION
## Problem

Looks like https://github.com/Shopify/liquid/commit/01dea9467122bf84b0ad9d8249b85aa36d050fef introduced a bugs from trying to preserve ruby 1.8.7 behaviour.  One that I think seems worth trying to fix is the special case of the limit and offset not applying to a String, which seems like enough of an edge case that it may not be used in practice.

The other regression from that commit demonstrates how little usage there was of String iteration at the time, since in ruby 1.8.7 liquid/ruby would iterate over lines of a String (i.e. String#each would split on the default separator `$/`).

## Solution

Use Liquid::Usage.instrument to see if any code iterates of a String with a positive offset or 0 limit.  That way we can decide whether we can fix this buggy behaviour or need to preserve it for backwards compatibility.