### PR TITLE
Use cache built into `ruby/setup-ruby` action

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         entry:
           - { ruby: 2.7, allowed-failure: false } # minimum supported
-          - { ruby: 3.1, allowed-failure: false } # latest
+          - { ruby: 3.2, allowed-failure: false } # latest
           - { ruby: ruby-head, allowed-failure: true }
     name: Test Ruby ${{ matrix.entry.ruby }}
     steps:

--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -1,5 +1,11 @@
 name: Liquid
 on: [push, pull_request]
+
+env:
+  BUNDLE_PATH: "vendor/bundle"
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,20 +15,16 @@ jobs:
           - { ruby: 2.7, allowed-failure: false } # minimum supported
           - { ruby: 3.1, allowed-failure: false } # latest
           - { ruby: ruby-head, allowed-failure: true }
-    name: test (${{ matrix.entry.ruby }})
+    name: Test Ruby ${{ matrix.entry.ruby }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.entry.ruby }}
-      - uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
-          restore-keys: ${{ runner.os }}-gems-
-      - run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
+          bundler-cache: true
       - run: bundle exec rake
         continue-on-error: ${{ matrix.entry.allowed-failure }}
+
   memory_profile:
     runs-on: ubuntu-latest
     steps:
@@ -30,10 +32,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile') }}
-          restore-keys: ${{ runner.os }}-gems-
-      - run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
+          bundler-cache: true
       - run: bundle exec rake memory_profile:run

--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -2,7 +2,6 @@ name: Liquid
 on: [push, pull_request]
 
 env:
-  BUNDLE_PATH: "vendor/bundle"
   BUNDLE_JOBS: 4
   BUNDLE_RETRY: 3
 


### PR DESCRIPTION
The `ruby/setup-ruby` GitHub Action has a provision for caching installed bundle. Using that cache is better than handling it locally.