### PR TITLE
Provide another assertion for to_liquid_value unless tag test

### DIFF
--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -35,6 +35,7 @@ class VariableTest < Minitest::Test
 
   def test_unless_tag_calls_to_liquid_value
     assert_template_result('', '{% unless foo %}true{% endunless %}', { 'foo' => BooleanDrop.new(true) })
+    assert_template_result('true', '{% unless foo %}true{% endunless %}', { 'foo' => BooleanDrop.new(false) })
   end
 
   def test_case_tag_calls_to_liquid_value


### PR DESCRIPTION
Since the existing assertion would pass even if to_liquid_value isn't called on the BooleanDrop object, since it would be treated as truthy.