### PR TITLE
Initialize context to nil on the Drop class

### DIFF
--- a/lib/liquid/drop.rb
+++ b/lib/liquid/drop.rb
@@ -25,6 +25,10 @@ module Liquid
   class Drop
     attr_writer :context
 
+    def initialize
+      @context = nil
+    end
+
     # Catch all for the method
     def liquid_method_missing(method)
       return nil unless @context&.strict_variables


### PR DESCRIPTION
We believe this will reduce megamorphic exits in YJIT. There are currently 241 separate shapes generated with edge_name "@context" in SFR. Initializing it to nil will significantly reduce this number.