### PR TITLE
Improve test coverage of the to_liquid_value feature.

### DIFF
--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -24,13 +24,17 @@ class VariableTest < Minitest::Test
 
   def test_if_tag_calls_to_liquid_value
     assert_template_result('one', '{% if foo == 1 %}one{% endif %}', { 'foo' => IntegerDrop.new('1') })
+    assert_template_result('one', '{% if foo == eqv %}one{% endif %}', { 'foo' => IntegerDrop.new(1), 'eqv' => IntegerDrop.new(1) })
     assert_template_result('one', '{% if 0 < foo %}one{% endif %}', { 'foo' => IntegerDrop.new('1') })
     assert_template_result('one', '{% if foo > 0 %}one{% endif %}', { 'foo' => IntegerDrop.new('1') })
+    assert_template_result('one', '{% if b > a %}one{% endif %}', { 'b' => IntegerDrop.new(1), 'a' => IntegerDrop.new(0) })
     assert_template_result('true', '{% if foo == true %}true{% endif %}', { 'foo' => BooleanDrop.new(true) })
     assert_template_result('true', '{% if foo %}true{% endif %}', { 'foo' => BooleanDrop.new(true) })
 
     assert_template_result('', '{% if foo %}true{% endif %}', { 'foo' => BooleanDrop.new(false) })
     assert_template_result('', '{% if foo == true %}True{% endif %}', { 'foo' => BooleanDrop.new(false) })
+
+    assert_template_result('one', '{% if a contains x %}one{% endif %}', { 'a' => [1], 'x' => IntegerDrop.new(1) })
   end
 
   def test_unless_tag_calls_to_liquid_value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,10 +131,6 @@ class IntegerDrop < Liquid::Drop
     @value = value.to_i
   end
 
-  def ==(other)
-    @value == other
-  end
-
   def to_s
     @value.to_s
   end
@@ -148,10 +144,6 @@ class BooleanDrop < Liquid::Drop
   def initialize(value)
     super()
     @value = value
-  end
-
-  def ==(other)
-    @value == other
   end
 
   def to_liquid_value


### PR DESCRIPTION
I removed == method from the to_liquid_value test drops IntegerDrop and BooleanDrop, since they could cause tests to pass without to_liquid_value being called on the left side of the equality comparison.

I also added a few more assertions for to_liquid_value.