### PR TITLE
raise invalid integer argument error from tablerow

### DIFF
--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -45,24 +45,13 @@ module Liquid
     def render_to_output_buffer(context, output)
       (collection = context.evaluate(@collection_name)) || (return '')
 
-      from = if @attributes.key?('offset')
-        Utils.to_integer(context.evaluate(@attributes['offset']), allow_nil: true)
-      else
-        0
-      end
-
-      to = if @attributes.key?('limit')
-        from + Utils.to_integer(context.evaluate(@attributes['limit']), allow_nil: true)
-      end
+      from = @attributes.key?('offset') ? to_integer(context.evaluate(@attributes['offset'])) : 0
+      to = @attributes.key?('limit') ? from + to_integer(context.evaluate(@attributes['limit'])) : nil
 
       collection = Utils.slice_collection(collection, from, to)
       length     = collection.length
 
-      cols = if @attributes.key?('cols')
-        Utils.to_integer(context.evaluate(@attributes['cols']), allow_nil: true)
-      else
-        length
-      end
+      cols = @attributes.key?('cols') ? to_integer(context.evaluate(@attributes['cols'])) : length
 
       output << "<tr class=\"row1\">\n"
       context.stack do
@@ -92,6 +81,14 @@ module Liquid
       def children
         super + @node.attributes.values + [@node.collection_name]
       end
+    end
+
+    private
+
+    def to_integer(value)
+      value.to_i
+    rescue NoMethodError
+      raise Liquid::ArgumentError, "invalid integer"
     end
   end
 

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -45,13 +45,24 @@ module Liquid
     def render_to_output_buffer(context, output)
       (collection = context.evaluate(@collection_name)) || (return '')
 
-      from = @attributes.key?('offset') ? context.evaluate(@attributes['offset']).to_i : 0
-      to   = @attributes.key?('limit')  ? from + context.evaluate(@attributes['limit']).to_i : nil
+      from = if @attributes.key?('offset')
+        Utils.to_integer(context.evaluate(@attributes['offset']), allow_nil: true)
+      else
+        0
+      end
+
+      to = if @attributes.key?('limit')
+        from + Utils.to_integer(context.evaluate(@attributes['limit']), allow_nil: true)
+      end
 
       collection = Utils.slice_collection(collection, from, to)
       length     = collection.length
 
-      cols = @attributes.key?('cols') ? context.evaluate(@attributes['cols']).to_i : length
+      cols = if @attributes.key?('cols')
+        Utils.to_integer(context.evaluate(@attributes['cols']), allow_nil: true)
+      else
+        length
+      end
 
       output << "<tr class=\"row1\">\n"
       context.stack do

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -39,8 +39,11 @@ module Liquid
       segments
     end
 
-    def self.to_integer(num)
+    def self.to_integer(num, allow_nil: false)
       return num if num.is_a?(Integer)
+      # with allow_nil param, return 0 which is equal to nil.to_i
+      return 0 if num.nil? && allow_nil
+
       num = num.to_s
       begin
         Integer(num)

--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -39,11 +39,8 @@ module Liquid
       segments
     end
 
-    def self.to_integer(num, allow_nil: false)
+    def self.to_integer(num)
       return num if num.is_a?(Integer)
-      # with allow_nil param, return 0 which is equal to nil.to_i
-      return 0 if num.nil? && allow_nil
-
       num = num.to_s
       begin
         Integer(num)

--- a/test/integration/tags/table_row_test.rb
+++ b/test/integration/tags/table_row_test.rb
@@ -80,6 +80,32 @@ class TableRowTest < Minitest::Test
       { "var" => nil })
   end
 
+  def test_nil_limit_is_treated_as_zero
+    expect = "<tr class=\"row1\">\n" \
+      "</tr>\n"
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) limit:nil %}{{ i }}{% endtablerow %}")
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) limit:var %}{{ i }}{% endtablerow %}",
+      { "var" => nil })
+  end
+
+  def test_nil_offset_is_treated_as_zero
+    expect = "<tr class=\"row1\">\n" \
+      "<td class=\"col1\">1:false</td>" \
+      "<td class=\"col2\">2:true</td>" \
+      "</tr>\n"
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) offset:nil %}{{ i }}:{{ tablerowloop.col_last }}{% endtablerow %}")
+
+    assert_template_result(expect,
+      "{% tablerow i in (1..2) offset:var %}{{ i }}:{{ tablerowloop.col_last }}{% endtablerow %}",
+      { "var" => nil })
+  end
+
   def test_tablerow_loop_drop_attributes
     template = <<~LIQUID.chomp
       {% tablerow i in (1...2) %}
@@ -130,5 +156,25 @@ class TableRowTest < Minitest::Test
     OUTPUT
 
     assert_template_result(expected_output, template)
+  end
+
+  def test_table_row_renders_correct_error_message_for_invalid_parameters
+    assert_template_result(
+      "Liquid error (line 1): invalid integer",
+      '{% tablerow n in (1...10) limit:true %} {{n}} {% endtablerow %}',
+      render_errors: true,
+    )
+
+    assert_template_result(
+      "Liquid error (line 1): invalid integer",
+      '{% tablerow n in (1...10) offset:true %} {{n}} {% endtablerow %}',
+      render_errors: true,
+    )
+
+    assert_template_result(
+      "Liquid error (line 1): invalid integer",
+      '{% tablerow n in (1...10) cols:true %} {{n}} {% endtablerow %}',
+      render_errors: true,
+    )
   end
 end


### PR DESCRIPTION
## Problem
When a `tablerow` tag gets an invalid parameter for `cols`, `limit`, or `offset`, Liquid renders an internal error message:
```liquid
{% tablerow a in (1...10) limit: true %}{{ a }}{% endtablerow %}
```

```
Liquid error: internal
```

This is a different behaviour than the `for` tag, and `tablerow` should have the same behaviour with the `for` tag:
```liquid
{% for a in (1..2) limit: true %}{{ a }}{% endfor %}
```
```
Liquid error: invalid integer
```