### PR TITLE
Revert "Instrument usage of bug with iteration of String with offset or 0 limit"

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -16,11 +16,7 @@ module Liquid
 
       # Maintains Ruby 1.8.7 String#each behaviour on 1.9
       if collection.is_a?(String)
-        return [] if collection.empty?
-        if from > 0 || to == 0
-          Usage.increment("string_slice_bug")
-        end
-        return [collection]
+        return collection.empty? ? [] : [collection]
       end
       return [] unless collection.respond_to?(:each)
 

--- a/test/unit/tags/for_tag_unit_test.rb
+++ b/test/unit/tags/for_tag_unit_test.rb
@@ -12,34 +12,4 @@ class ForTagUnitTest < Minitest::Test
     template = Liquid::Template.parse('{% for item in items %}FOR{% else %}ELSE{% endfor %}')
     assert_equal(['FOR', 'ELSE'], template.root.nodelist[0].nodelist.map(&:nodelist).flatten)
   end
-
-  def test_for_string_slice_bug_usage
-    template = Liquid::Template.parse("{% for x in str, offset: 1 %}{{ x }},{% endfor %}")
-    assert_usage("string_slice_bug") do
-      assert_equal("abc,", template.render({ "str" => "abc" }))
-    end
-  end
-
-  def test_for_string_0_limit_usage
-    template = Liquid::Template.parse("{% for x in str, limit: 0 %}{{ x }},{% endfor %}")
-    assert_usage("string_slice_bug") do
-      assert_equal("abc,", template.render({ "str" => "abc" }))
-    end
-  end
-
-  def test_for_string_no_slice_usage
-    template = Liquid::Template.parse("{% for x in str, offset: 0, limit: 1 %}{{ x }},{% endfor %}")
-    assert_usage("string_slice_bug", times: 0) do
-      assert_equal("abc,", template.render({ "str" => "abc" }))
-    end
-  end
-
-  private
-
-  def assert_usage(name, times: 1, &block)
-    count = 0
-    result = Liquid::Usage.stub(:increment, ->(n) { count += 1 if n == name }, &block)
-    assert_equal(times, count)
-    result
-  end
 end


### PR DESCRIPTION
Reverts Shopify/liquid#1667

> The instrumentation shows there are a couple hundred uses of per-hour, so it looks like existing code already depends on this bug.

May as well revert this.  We can always revisit this if we want to improve usage instrumentation to dig into the usage of bugs like this more.