### PR TITLE
recursively parse brackets on variable lookup

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -41,7 +41,7 @@ module Liquid
   AnyStartingTag              = /#{TagStart}|#{VariableStart}/o
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
-  VariableParser              = /\[[^\]]+\]|#{VariableSegment}+\??/o
+  VariableParser              = /\[(?:[^\[\]]+|\g<0>)*\]|#{VariableSegment}+\??/o
 
   RAISE_EXCEPTION_LAMBDA = ->(_e) { raise }
 

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -157,4 +157,16 @@ class VariableTest < Minitest::Test
       }
     )
   end
+
+  def test_double_nested_variable_lookup
+    assert_template_result(
+      'bar',
+      '{{ list[list[settings.zero]]["foo"] }}',
+      {
+        'list' => [1, { 'foo' => 'bar' }],
+        'settings' => SettingsDrop.new("zero" => 0),
+        'bar' => 'foo',
+      }
+    )
+  end
 end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -135,4 +135,26 @@ class VariableTest < Minitest::Test
   def test_raw_value_variable
     assert_template_result('bar', '{{ [key] }}', { 'key' => 'foo', 'foo' => 'bar' })
   end
+
+  def test_dynamic_find_var_with_drop
+    assert_template_result(
+      'bar',
+      '{{ [list[settings.zero]] }}',
+      {
+        'list' => ['foo'],
+        'settings' => SettingsDrop.new("zero" => 0),
+        'foo' => 'bar',
+      }
+    )
+
+    assert_template_result(
+      'foo',
+      '{{ [list[settings.zero]["foo"]] }}',
+      {
+        'list' => [{ 'foo' => 'bar' }],
+        'settings' => SettingsDrop.new("zero" => 0),
+        'bar' => 'foo',
+      }
+    )
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -125,6 +125,17 @@ class ThingWithToLiquid
   end
 end
 
+class SettingsDrop < Liquid::Drop
+  def initialize(settings)
+    super()
+    @settings = settings
+  end
+
+  def liquid_method_missing(key)
+    @settings[key]
+  end
+end
+
 class IntegerDrop < Liquid::Drop
   def initialize(value)
     super()


### PR DESCRIPTION
### Problem

With dynamic variable lookup, Liquid is not properly parsing the expression.
With this template: 
```liquid
{{ [list[settings.zero]] }}
```
`VariableLookup` matches `[list[settings.zero]` for the `name` without the extra closing bracket.
This causes an issue because `VariableLookup` parses the expression with `Expression.parse(name[1..-2])` which is `list[settings.zero` and Liquid creates a `VariableLookup` where the name is `list` and lookups are `["settings", "zero"]`.

This problem also exists for the double-nested variable lookups such as this template: `list[llist[setting.value]]`

### Solution

We can solve this issue by recursively parsing the dynamic lookups:
```regex
\[(?:[^\[\]]+|\g<0>)*\]

\[          # match open bracket
(?:         # start non-capturing group
  [^\[\]]+  # match non-square brackets
  |         # OR
  \g<0>     # go back to the beginning of the regex
)*          # end of non-capturing group
\]          # match closing bracket
```
