### PR TITLE
fix variable lookup parse timing out with missing closing bracket

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -41,7 +41,7 @@ module Liquid
   AnyStartingTag              = /#{TagStart}|#{VariableStart}/o
   PartialTemplateParser       = /#{TagStart}.*?#{TagEnd}|#{VariableStart}.*?#{VariableIncompleteEnd}/om
   TemplateParser              = /(#{PartialTemplateParser}|#{AnyStartingTag})/om
-  VariableParser              = /\[(?:[^\[\]]+|\g<0>)*\]|#{VariableSegment}+\??/o
+  VariableParser              = /\[(?>[^\[\]]+|\g<0>)*\]|#{VariableSegment}+\??/o
 
   RAISE_EXCEPTION_LAMBDA = ->(_e) { raise }
 

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -185,15 +185,23 @@ class VariableTest < Minitest::Test
 
     very_long_key = "1234567890" * 100
 
-    Timeout.timeout(1) do
-      assert_template_result(
-        'bar',
-        "{{['#{very_long_key}'}}",
-        {
-          very_long_key => 'bar',
-        },
-        error_mode: :lax,
-      )
+    template_list = [
+      "{{['#{very_long_key}']}}", # valid
+      "{{['#{very_long_key}'}}", # missing closing bracket
+      "{{[['#{very_long_key}']}}", # extra open bracket
+    ]
+
+    template_list.each do |template|
+      Timeout.timeout(1) do
+        assert_template_result(
+          'bar',
+          template,
+          {
+            very_long_key => 'bar',
+          },
+          error_mode: :lax,
+        )
+      end
     end
   end
 end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'timeout'
 
 class VariableTest < Minitest::Test
   include Liquid
@@ -168,5 +169,31 @@ class VariableTest < Minitest::Test
         'bar' => 'foo',
       }
     )
+  end
+
+  def test_variable_lookup_should_not_hang_with_invalid_syntax
+    Timeout.timeout(1) do
+      assert_template_result(
+        'bar',
+        "{{['foo'}}",
+        {
+          'foo' => 'bar',
+        },
+        error_mode: :lax,
+      )
+    end
+
+    very_long_key = "1234567890" * 100
+
+    Timeout.timeout(1) do
+      assert_template_result(
+        'bar',
+        "{{['#{very_long_key}'}}",
+        {
+          very_long_key => 'bar',
+        },
+        error_mode: :lax,
+      )
+    end
   end
 end


### PR DESCRIPTION
### Problem

This PR https://github.com/Shopify/liquid/pull/1680 has introduced a bug that causes `VariableLookup#initialize` to time out.
This happened when the `VariableLookup`'s markup had a missing closing bracket and a very long string. 

```ruby
# this will execute within 50ms
"[12345678901234567890".scan /\[(?:[^\]\[]+|\g<0>)*\]/

# this will take a second to execute
"[123456789012345678901234".scan /\[(?:[^\]\[]+|\g<0>)*\]/
```

The regex is taking a long time to execute because the non-capturing group `(?:[^\[^]+...` recursively re-searches/backtraces the input with different lengths.
The non-capturing group match will look like this throughout the search:
1. [123456789012345678901234
2. [12345678901234567890123
3. [1234567890123456789012
4. [123456789012345678901
5. [12345678901234567890
6. and so on...

### Solution
We can use the atomic group feature in regex to prevent regex from dividing the non-bracket characters, and early end the search.

```regex
\[(?:[^\[\]]+|\g<0>)*\]

\[          # match open bracket
(?>         # start an atomic capturing group (prevent backtracking)
  [^\[\]]+  # match non-square brackets
  |         # OR
  \g<0>     # go back to the beginning of the regex
)*          # end of non-capturing group
\]          # match closing bracket
```
