### PR TITLE
Fix CI (as it installs RuboCop 1.45.1 and fails)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :benchmark, :test do
 end
 
 group :test do
+  gem 'rubocop', '~> 1.44.0'
   gem 'rubocop-shopify', '~> 2.7.0', require: false
   gem 'rubocop-performance', require: false
 

--- a/performance/shopify/database.rb
+++ b/performance/shopify/database.rb
@@ -49,8 +49,3 @@ module Database
     end
   end
 end
-
-if __FILE__ == $PROGRAM_NAME
-  p(Database.tables['collections']['frontpage'].keys)
-  # p Database.tables['blog']['articles']
-end


### PR DESCRIPTION
The CI no longer uses RuboCop 1.44.1 (instead it uses 1.45.1). So, it's failing with this error now:

```
Inspecting 136 files
.....................................................................W..................................................................

Offenses:

performance/shopify/database.rb:54:3: W: Lint/Debugger: Remove debugger entry point p(Database.tables['collections']['frontpage'].keys).
  p(Database.tables['collections']['frontpage'].keys)
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

136 files inspected, 1 offense detected
```

Also, I can open a following PR to remove `rubocop` from the `Gemfile` and update `rubocop-shopify` to `2.12.0' (still, it will require broader changes).