### PR TITLE
Fix broken documentantion link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * [Contributing guidelines](CONTRIBUTING.md)
 * [Version history](History.md)
-* [Liquid documentation from Shopify](https://shopify.dev/docs/docs/api/liquid)
+* [Liquid documentation from Shopify](https://shopify.dev/docs/api/liquid)
 * [Liquid Wiki at GitHub](https://github.com/Shopify/liquid/wiki)
 * [Website](http://liquidmarkup.org/)
 


### PR DESCRIPTION
The reference to https://shopify.dev/docs/api/liquid points to a URL that 404s at the moment.

This fixes the reference.