### PR TITLE
render error message with actual template path

### DIFF
--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -16,12 +16,7 @@ module Liquid
       template = template_factory.for(template_name)
 
       partial = template.parse(source, parse_context)
-
-      partial.name ||= if context.registers[:file_system]&.respond_to?(:actual_template_name)
-        context.registers[:file_system].actual_template_name(template_name)
-      else
-        template_name
-      end
+      partial.name ||= template_name
 
       cached_partials[template_name] = partial
     ensure

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -16,6 +16,13 @@ module Liquid
       template = template_factory.for(template_name)
 
       partial = template.parse(source, parse_context)
+
+      partial.name ||= if context.registers[:file_system]&.respond_to?(:actual_template_name)
+        context.registers[:file_system].actual_template_name(template_name)
+      else
+        template_name
+      end
+
       cached_partials[template_name] = partial
     ensure
       parse_context.partial = false

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -72,9 +72,9 @@ module Liquid
       old_partial       = context.partial
 
       begin
-        context.template_name = partial.name if partial.name
-
+        context.template_name = partial.name
         context.partial = true
+
         context.stack do
           @attributes.each do |key, value|
             context[key] = context.evaluate(value)

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -70,9 +70,15 @@ module Liquid
 
       old_template_name = context.template_name
       old_partial       = context.partial
+
       begin
-        context.template_name = template_name
-        context.partial       = true
+        context.template_name = if Template.file_system.respond_to?(:actual_template_name)
+          Template.file_system.actual_template_name(template_name).delete_suffix('.liquid')
+        else
+          template_name
+        end
+
+        context.partial = true
         context.stack do
           @attributes.each do |key, value|
             context[key] = context.evaluate(value)

--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -72,11 +72,7 @@ module Liquid
       old_partial       = context.partial
 
       begin
-        context.template_name = if Template.file_system.respond_to?(:actual_template_name)
-          Template.file_system.actual_template_name(template_name).delete_suffix('.liquid')
-        else
-          template_name
-        end
+        context.template_name = partial.name if partial.name
 
         context.partial = true
         context.stack do

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -77,11 +77,7 @@ module Liquid
       render_partial_func = ->(var, forloop) {
         inner_context               = context.new_isolated_subcontext
 
-        inner_context.template_name = if Template.file_system.respond_to?(:actual_template_name)
-          Template.file_system.actual_template_name(template_name).delete_suffix('.liquid')
-        else
-          template_name
-        end
+        inner_context.template_name = partial.name if partial.name
 
         inner_context.partial       = true
         inner_context['forloop']    = forloop if forloop

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -76,7 +76,13 @@ module Liquid
 
       render_partial_func = ->(var, forloop) {
         inner_context               = context.new_isolated_subcontext
-        inner_context.template_name = template_name
+
+        inner_context.template_name = if Template.file_system.respond_to?(:actual_template_name)
+          Template.file_system.actual_template_name(template_name).delete_suffix('.liquid')
+        else
+          template_name
+        end
+
         inner_context.partial       = true
         inner_context['forloop']    = forloop if forloop
 

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -76,9 +76,7 @@ module Liquid
 
       render_partial_func = ->(var, forloop) {
         inner_context               = context.new_isolated_subcontext
-
-        inner_context.template_name = partial.name if partial.name
-
+        inner_context.template_name = partial.name
         inner_context.partial       = true
         inner_context['forloop']    = forloop if forloop
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -15,7 +15,7 @@ module Liquid
   #   template.render('user_name' => 'bob')
   #
   class Template
-    attr_accessor :root
+    attr_accessor :root, :name
     attr_reader :resource_limits, :warnings
 
     class TagRegistry

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -357,16 +357,24 @@ class IncludeTagTest < Minitest::Test
     )
   end
 
-  def test_include_tag_renders_actual_template_name_for_error
-    original_file_system = Liquid::Template.file_system
-
-    Liquid::Template.file_system = MemoryFileSystem.new(
-      '/some/path/snippets/foo.liquid' => "{{ foo.standard_error }}",
+  def test_render_tag_renders_error_with_template_name
+    assert_template_result(
+      'Liquid error (foo line 1): standard error',
+      "{% include 'foo' with errors %}",
+      { 'errors' => ErrorDrop.new },
+      partials: { 'foo' => '{{ foo.standard_error }}' },
+      render_errors: true,
     )
+  end
 
-    template = Liquid::Template.parse("{% include 'foo' with errors %}", line_numbers: true)
-    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render('errors' => ErrorDrop.new))
-  ensure
-    Liquid::Template.file_system = original_file_system
+  def test_render_tag_renders_error_with_template_name_from_template_factory
+    assert_template_result(
+      'Liquid error (some/path/foo line 1): standard error',
+      "{% include 'foo' with errors %}",
+      { 'errors' => ErrorDrop.new },
+      partials: { 'foo' => '{{ foo.standard_error }}' },
+      template_factory: StubTemplateFactory.new,
+      render_errors: true,
+    )
   end
 end # IncludeTagTest

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -356,4 +356,17 @@ class IncludeTagTest < Minitest::Test
       partials: { 'break' => "{% break %}" },
     )
   end
+
+  def test_include_tag_renders_actual_template_name_for_error
+    original_file_system = Liquid::Template.file_system
+
+    Liquid::Template.file_system = MemoryFileSystem.new(
+      '/some/path/snippets/foo.liquid' => "{{ foo.standard_error }}",
+    )
+
+    template = Liquid::Template.parse("{% include 'foo' with errors %}", line_numbers: true)
+    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render('errors' => ErrorDrop.new))
+  ensure
+    Liquid::Template.file_system = original_file_system
+  end
 end # IncludeTagTest

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -265,18 +265,24 @@ class RenderTagTest < Minitest::Test
     )
   end
 
-  def test_render_tag_renders_actual_template_name_for_error
-    original_file_system = Liquid::Template.file_system
-
-    context = Liquid::Context.new('errors' => ErrorDrop.new)
-
-    context.registers[:file_system] = MemoryFileSystem.new(
-      '/some/path/snippets/foo.liquid' => "{{ foo.standard_error }}",
+  def test_render_tag_renders_error_with_template_name
+    assert_template_result(
+      'Liquid error (foo line 1): standard error',
+      "{% render 'foo' with errors %}",
+      { 'errors' => ErrorDrop.new },
+      partials: { 'foo' => '{{ foo.standard_error }}' },
+      render_errors: true,
     )
+  end
 
-    template = Liquid::Template.parse("{% render 'foo' with errors %}", line_numbers: true)
-    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render(context))
-  ensure
-    Liquid::Template.file_system = original_file_system
+  def test_render_tag_renders_error_with_template_name_from_template_factory
+    assert_template_result(
+      'Liquid error (some/path/foo line 1): standard error',
+      "{% render 'foo' with errors %}",
+      { 'errors' => ErrorDrop.new },
+      partials: { 'foo' => '{{ foo.standard_error }}' },
+      template_factory: StubTemplateFactory.new,
+      render_errors: true,
+    )
   end
 end

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -268,12 +268,14 @@ class RenderTagTest < Minitest::Test
   def test_render_tag_renders_actual_template_name_for_error
     original_file_system = Liquid::Template.file_system
 
-    Liquid::Template.file_system = MemoryFileSystem.new(
+    context = Liquid::Context.new('errors' => ErrorDrop.new)
+
+    context.registers[:file_system] = MemoryFileSystem.new(
       '/some/path/snippets/foo.liquid' => "{{ foo.standard_error }}",
     )
 
     template = Liquid::Template.parse("{% render 'foo' with errors %}", line_numbers: true)
-    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render('errors' => ErrorDrop.new))
+    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render(context))
   ensure
     Liquid::Template.file_system = original_file_system
   end

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -264,4 +264,17 @@ class RenderTagTest < Minitest::Test
       },
     )
   end
+
+  def test_render_tag_renders_actual_template_name_for_error
+    original_file_system = Liquid::Template.file_system
+
+    Liquid::Template.file_system = MemoryFileSystem.new(
+      '/some/path/snippets/foo.liquid' => "{{ foo.standard_error }}",
+    )
+
+    template = Liquid::Template.parse("{% render 'foo' with errors %}", line_numbers: true)
+    assert_equal('Liquid error (/some/path/snippets/foo line 1): standard error', template.render('errors' => ErrorDrop.new))
+  ensure
+    Liquid::Template.file_system = original_file_system
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -214,3 +214,25 @@ class StubTemplateFactory
     Liquid::Template.new
   end
 end
+
+class MemoryFileSystem
+  def initialize(values)
+    # values is a hash of template_path => template_source
+    @snippets = {}
+    values.each do |file_path, source|
+      key = file_path.split('/').last.delete_suffix(".liquid")
+      @snippets[key] = {
+        source: source,
+        actual_template_name: file_path,
+      }
+    end
+  end
+
+  def read_template_file(template_name)
+    @snippets[template_name][:source]
+  end
+
+  def actual_template_name(template_name)
+    @snippets[template_name][:actual_template_name]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -233,6 +233,6 @@ class MemoryFileSystem
   end
 
   def actual_template_name(template_name)
-    @snippets[template_name][:actual_template_name]
+    @snippets[template_name][:actual_template_name].delete_suffix(".liquid")
   end
 end

--- a/test/unit/partial_cache_unit_test.rb
+++ b/test/unit/partial_cache_unit_test.rb
@@ -156,4 +156,22 @@ class PartialCacheUnitTest < Minitest::Test
 
     assert_equal(1, shared_file_system.file_read_count)
   end
+
+  def test_uses_template_name_from_template_factory
+    template_factory = StubTemplateFactory.new
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new('my_partial' => 'my partial body'),
+        template_factory: template_factory,
+      },
+    )
+
+    partial = Liquid::PartialCache.load(
+      'my_partial',
+      context: context,
+      parse_context: Liquid::ParseContext.new,
+    )
+
+    assert_equal('some/path/my_partial', partial.name)
+  end
 end


### PR DESCRIPTION
### Problem

When Liquid is used with a `FileSystem` that allows `render` and `include` tags to render a file just by its filename, the error message does not show its actual file path.

setup:
```
# index.liquid
{% render 'foo' with errors %}

# /some/path/snippets/foo.liquid
{{ foo.standard_error }}
```
output:
```
Liquid error (foo line 1): standard error
```

This becomes an issue when Liquid developers have duplicate filenames in multiple folders, which creates confusion where the error is actually coming from.

### Solution

In `render` and `include` tag, it will set the `context.template` with `template.name`.
The Liquid users can use `TemplateFactory` to create a `Template` with a name:
```ruby
class TemplateFactory
  def for(template_name)
    template = Liquid::Template.new
    template.name = "snippets/" + template_name
    template
  end
end

context = Liquid::Context.build(
  registers: { template_factory: StubTemplateFactory.new }
)

template = Liquid::Template.parse("....", line_numbers: true)
template.render(context)

# renders error message in a format of `Liquid error ({folder}/{filename} line #): error message`
Liquid error (snippets/foo line 1): standard error
```