### PR TITLE
render template name with Liquid Syntax errors

### DIFF
--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -15,7 +15,13 @@ module Liquid
       template_factory = context.registers[:template_factory]
       template = template_factory.for(template_name)
 
-      partial = template.parse(source, parse_context)
+      begin
+        partial = template.parse(source, parse_context)
+      rescue Liquid::Error => e
+        e.template_name = template&.name || template_name
+        raise e
+      end
+
       partial.name ||= template_name
 
       cached_partials[template_name] = partial

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -189,6 +189,8 @@ module Liquid
         @profiler = context.profiler = Liquid::Profiler.new
       end
 
+      context.template_name ||= name
+
       begin
         # render the nodelist.
         @root.render_to_output_buffer(context, output || +'')

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -263,4 +263,81 @@ class ErrorHandlingTest < Minitest::Test
     output = Liquid::Template.parse("{% assign x = 0 %}{% if 1 < '2' %}{% assign x = 3 %}{% endif %}{{ x }}").render
     assert_equal("0", output)
   end
+
+  def test_syntax_error_is_raised_with_template_name
+    file_system = StubFileSystem.new("snippet" => "1\n2\n{{ 1")
+
+    context = Liquid::Context.build(
+      registers: { file_system: file_system },
+    )
+
+    template = Template.parse(
+      '{% render "snippet" %}',
+      line_numbers: true,
+    )
+    template.name = "template/index"
+
+    assert_equal(
+      "Liquid syntax error (snippet line 3): Variable '{{' was not properly terminated with regexp: /\\}\\}/",
+      template.render(context),
+    )
+  end
+
+  def test_syntax_error_is_raised_with_template_name_from_template_factory
+    file_system = StubFileSystem.new("snippet" => "1\n2\n{{ 1")
+
+    context = Liquid::Context.build(
+      registers: {
+        file_system: file_system,
+        template_factory: StubTemplateFactory.new,
+      },
+    )
+
+    template = Template.parse(
+      '{% render "snippet" %}',
+      line_numbers: true,
+    )
+    template.name = "template/index"
+
+    assert_equal(
+      "Liquid syntax error (some/path/snippet line 3): Variable '{{' was not properly terminated with regexp: /\\}\\}/",
+      template.render(context),
+    )
+  end
+
+  def test_error_is_raised_during_parse_with_template_name
+    depth = Liquid::Block::MAX_DEPTH + 1
+    code = "{% if true %}" * depth + "rendered" + "{% endif %}" * depth
+
+    template = Template.parse("{% render 'snippet' %}", line_numbers: true)
+
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new("snippet" => code),
+        template_factory: StubTemplateFactory.new,
+      },
+    )
+
+    assert_equal("Liquid error (some/path/snippet line 1): Nesting too deep", template.render(context))
+  end
+
+  def test_internal_error_is_raised_with_template_name
+    template = Template.new
+    template.parse(
+      "{% render 'snippet' %}",
+      line_numbers: true,
+    )
+    template.name = "template/index"
+
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new({}),
+      },
+    )
+
+    assert_equal(
+      "Liquid error (template/index line 1): internal",
+      template.render(context),
+    )
+  end
 end


### PR DESCRIPTION
### What are you trying to solve?

When there is a syntax error from a template, the Liquid error message would have a wrong filename:
Liquid:
```liquid
# index
{% render 'snippet' %}

# snippet
1
2
{{ "hello world!" 
```

Error
```
Liquid syntax error (index line 3): Variable '{{' was not properly terminated with regexp: /\\}\\}/
```

### How are you solving this?

In `PartialCache`, rescue Liquid errors from a `Liquid#parse` and assign `template_name` to it.

After:
```
Liquid syntax error (snippet line 3): Variable '{{' was not properly terminated with regexp: /\\}\\}/
```