### PR TITLE
Update Liquid Documentation from Shopify URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * [Contributing guidelines](CONTRIBUTING.md)
 * [Version history](History.md)
-* [Liquid documentation from Shopify](https://shopify.dev/docs/docs/api/liquid)
+* [Liquid documentation from Shopify](https://shopify.dev/docs/api/liquid)
 * [Liquid Wiki at GitHub](https://github.com/Shopify/liquid/wiki)
 * [Website](http://liquidmarkup.org/)
 


### PR DESCRIPTION
Current url https://shopify.dev/docs/docs/api/liquid 404s. 

<img width="1458" alt="image" src="https://github.com/Shopify/liquid/assets/1620641/57bfdcdb-4cca-4205-9c86-78c65d9a810c">

Updated to https://shopify.dev/docs/api/liquid

<img width="1422" alt="image" src="https://github.com/Shopify/liquid/assets/1620641/6e18d1da-0ecb-4658-bb5d-451326914a3c">
