### PR TITLE
[trim] Fix trimming at end of raw block when specified in the opening tag

### DIFF
--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -26,6 +26,7 @@ module Liquid
       @body = +''
       while (token = tokens.shift)
         if token =~ FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
+          parse_context.trim_whitespace = (token[-3] == WhitespaceControl)
           @body << Regexp.last_match(1) if Regexp.last_match(1) != ""
           return
         end

--- a/test/integration/tags/raw_tag_test.rb
+++ b/test/integration/tags/raw_tag_test.rb
@@ -13,8 +13,9 @@ class RawTagTest < Minitest::Test
   end
 
   def test_output_in_raw
-    # assert_template_result('{{ test }}', '{% raw %}{{ test }}{% endraw %}')
     assert_template_result('>{{ test }}<', '> {%- raw -%}{{ test }}{%- endraw -%} <')
+    assert_template_result("> inner  <", "> {%- raw -%} inner {%- endraw %} <")
+    assert_template_result("> inner <", "> {%- raw -%} inner {%- endraw -%} <")
   end
 
   def test_open_tag_in_raw


### PR DESCRIPTION
The `raw` tag doesn't use `BlockBody` to parse its body. As a result, it currently doesn't respect nor reset the parsing context's `trim_whitespace` value.

This PR makes it reset it at the end of the block, respecting either non-trimming (`endraw %}`) or trimming (`endraw -%}`).

This change is in line with Liquid::C's implementation.

It __does not__ respect inner whitespace control, and `{% raw -%}   inner   {%- endraw %}` will preserve the spaces. This is also in line with Liquid::C.