### PR TITLE
include parse mode to partial cache key

### DIFF
--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -4,7 +4,8 @@ module Liquid
   class PartialCache
     def self.load(template_name, context:, parse_context:)
       cached_partials = context.registers[:cached_partials]
-      cached = cached_partials[template_name]
+      cache_key = "#{template_name}:#{parse_context.error_mode}"
+      cached = cached_partials[cache_key]
       return cached if cached
 
       file_system = context.registers[:file_system]
@@ -24,7 +25,7 @@ module Liquid
 
       partial.name ||= template_name
 
-      cached_partials[template_name] = partial
+      cached_partials[cache_key] = partial
     ensure
       parse_context.partial = false
     end

--- a/test/unit/partial_cache_unit_test.rb
+++ b/test/unit/partial_cache_unit_test.rb
@@ -174,4 +174,27 @@ class PartialCacheUnitTest < Minitest::Test
 
     assert_equal('some/path/my_partial', partial.name)
   end
+
+  def test_includes_error_mode_into_template_cache
+    template_factory = StubTemplateFactory.new
+    context = Liquid::Context.build(
+      registers: {
+        file_system: StubFileSystem.new('my_partial' => 'my partial body'),
+        template_factory: template_factory,
+      },
+    )
+
+    [:lax, :warn, :strict].each do |error_mode|
+      Liquid::PartialCache.load(
+        'my_partial',
+        context: context,
+        parse_context: Liquid::ParseContext.new(error_mode: error_mode),
+      )
+    end
+
+    assert_equal(
+      ["my_partial:lax", "my_partial:warn", "my_partial:strict"],
+      context.registers[:cached_partials].keys,
+    )
+  end
 end


### PR DESCRIPTION
### What are you trying to solve?

When a `PartialCache` gets created, it is caching the `Template` by its name and without the used parse mode.
```liquid
# from templates/index.liquid
{% render "snippet" %}  # parse the template in Lax mode

# from sections/product.liquid
{% render "snippet" %} # loads the previously parsed template that is parsed in Lax mode. (this should be using strict mode)
```

### How are you solving this?

Add the `ParseContext#error_mode` value to the `PartialCache`'s cache key to add more context.