### PR TITLE
Don't render `sum` filter results in scientific notation.

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -892,9 +892,10 @@ module Liquid
         raise_property_error(property)
       end
 
-      InputIterator.new(values_for_sum, context).sum do |item|
+      result = InputIterator.new(values_for_sum, context).sum do |item|
         Utils.to_number(item)
       end
+      result.is_a?(BigDecimal) ? result.to_f : result
     end
 
     private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -946,6 +946,21 @@ class StandardFiltersTest < Minitest::Test
     end
   end
 
+  def test_sum_with_floats
+    input = [0.1, 0.2, 0.3]
+    assert_equal(0.6, @filters.sum(input))
+  end
+
+  def test_sum_with_negative_float
+    input = [0.1, 0.2, -0.3]
+    assert_equal(0.0, @filters.sum(input))
+  end
+
+  def test_sum_with_float_strings
+    input = [0.1, "0.2", "0.3"]
+    assert_equal(0.6, @filters.sum(input))
+  end
+
   def test_sum_with_nested_arrays
     input = [1, [2, [3, 4]]]
 
@@ -992,6 +1007,22 @@ class StandardFiltersTest < Minitest::Test
     t = TestThing.new
     Liquid::Template.parse('{{ foo | sum: "quantity" }}').render("foo" => [{ "quantity" => t }])
     assert(t.foo > 0)
+  end
+
+  def test_render_sum_of_floats
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, 0.3]), "0.6")
+  end
+
+  def test_render_sum_of_negative_floats
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, 0.3]), "0.2")
+  end
+
+  def test_render_sum_negative_float_result
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, -0.3]), "-0.4")
+  end
+
+  def test_render_sum_float_zero_result
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, -0.3]), "0.0")
   end
 
   private


### PR DESCRIPTION
This pull request changes the standard `sum` filter to return a float instead of a `BigDecimal` when given one or more floats as input.

This is necessary to prevent the result being displayed in scientific notation, as all other standard math filters do.

Closes #1725. 