### PR TITLE
Allow liquid tag inside liquid tag

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -45,9 +45,12 @@ module Liquid
           end
           tag_name = Regexp.last_match(1)
           markup   = Regexp.last_match(2)
-          if tag_name == "liquid"
-            next
+
+          if tag_name == 'liquid'
+            parse_context.line_number -= 1
+            next parse_liquid_tag(markup, parse_context)
           end
+
           unless (tag = registered_tags[tag_name])
             # end parsing if we reach an unknown tag and let the caller decide
             # determine how to proceed

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -45,6 +45,9 @@ module Liquid
           end
           tag_name = Regexp.last_match(1)
           markup   = Regexp.last_match(2)
+          if tag_name == "liquid"
+            next
+          end
           unless (tag = registered_tags[tag_name])
             # end parsing if we reach an unknown tag and let the caller decide
             # determine how to proceed

--- a/test/integration/tags/liquid_tag_test.rb
+++ b/test/integration/tags/liquid_tag_test.rb
@@ -124,4 +124,26 @@ class LiquidTagTest < Minitest::Test
       -%}
     LIQUID
   end
+
+  def test_nested_liquid_tags_on_same_line
+    assert_template_result('good', <<~LIQUID)
+      {%- liquid liquid liquid echo "good" -%}
+    LIQUID
+  end
+
+  def test_nested_liquid_liquid_is_not_skipped_if_used_in_non_tag_position
+    assert_template_result('liquid', <<~LIQUID, { 'liquid' => 'liquid' })
+      {%- liquid liquid liquid echo liquid -%}
+    LIQUID
+  end
+
+  def test_next_liquid_with_unclosed_if_tag
+    assert_match_syntax_error("Liquid syntax error (line 2): 'if' tag was never closed", <<~LIQUID)
+      {%- liquid
+        liquid if true
+          echo "good"
+        endif
+      -%}
+    LIQUID
+  end
 end

--- a/test/integration/tags/liquid_tag_test.rb
+++ b/test/integration/tags/liquid_tag_test.rb
@@ -113,4 +113,15 @@ class LiquidTagTest < Minitest::Test
       {% raw %}{% liquid echo 'test' %}{% endraw %}
     LIQUID
   end
+
+  def test_nested_liquid_tags
+    assert_template_result('good', <<~LIQUID)
+      {%- liquid
+        liquid
+          if true
+            echo "good"
+          endif
+      -%}
+    LIQUID
+  end
 end


### PR DESCRIPTION
# why? 

matches liquid-c behaviour

# how?

~just skip the liquid tag if it's inside a liquid tag, it essentially does not change any behaviour as far as I can see.~

EDIT: matching the actual liquid-c behaviour we now recursively parse the markup for liquid tags inside liquid tags. I have to decrease the line number by 1 because when tokenizing in liquid tag mode we always up line number by one, but really in this case we are staying in the same line.