### PR TITLE
Add sum filter documentation

### DIFF
--- a/_filters/sum.md
+++ b/_filters/sum.md
@@ -1,0 +1,42 @@
+---
+title: sum
+description: Liquid filter that sums all items in an array.
+---
+
+Sums all items in an array.
+
+If a string is passed as an argument, it sums the property values.
+
+In this example, assume the object `collection.products` contains a list of products, and each `product` object has a `quantity` property. Using `assign` with the `sum` filter creates a variable that contains the total quantity for all products in the collection.
+
+<p class="code-label">Input</p>
+```liquid
+{%- raw -%}
+{% assign total_quantity = collection.products | sum: "quantity" %}
+
+{{ total_quantity }}
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```text
+6
+```
+
+The `sum` filter also works without any argument.
+
+In this example, assume the object `article.ratings` is an array of integers. Using `assign` with the `sum` filter creates a variable that contains the total ratings for the article.
+
+<p class="code-label">Input</p>
+```liquid
+{%- raw -%}
+{% assign total_rating = article.ratings | sum %}
+
+{{ total_rating }}
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```text
+6
+```


### PR DESCRIPTION
Adding liquid documentation for the recently introduced [`sum` standard filter](https://github.com/Shopify/liquid/pull/1722)


🎩 
<img width="1507" alt="Screenshot 2023-07-07 at 10 06 18 AM" src="https://github.com/Shopify/liquid/assets/44833/4a5c8d64-3bab-4769-b903-d56cdccd5276">
<img width="1510" alt="Screenshot 2023-07-07 at 10 06 25 AM" src="https://github.com/Shopify/liquid/assets/44833/8a52f71f-6cdf-4d4e-a3ce-aad4aa7964cd">
