### PR TITLE
Call to_liquid_value when short circuiting conditions

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -69,9 +69,9 @@ module Liquid
 
         case condition.child_relation
         when :or
-          break if result
+          break if Liquid::Utils.to_liquid_value(result)
         when :and
-          break unless result
+          break unless Liquid::Utils.to_liquid_value(result)
         else
           break
         end

--- a/test/integration/variable_test.rb
+++ b/test/integration/variable_test.rb
@@ -34,6 +34,7 @@ class VariableTest < Minitest::Test
 
     assert_template_result('', '{% if foo %}true{% endif %}', { 'foo' => BooleanDrop.new(false) })
     assert_template_result('', '{% if foo == true %}True{% endif %}', { 'foo' => BooleanDrop.new(false) })
+    assert_template_result('', '{% if foo and true %}SHOULD NOT HAPPEN{% endif %}', { 'foo' => BooleanDrop.new(false) })
 
     assert_template_result('one', '{% if a contains x %}one{% endif %}', { 'a' => [1], 'x' => IntegerDrop.new(1) })
   end


### PR DESCRIPTION
# why?

we were not calling `to_liquid_value` which would result in evaluating `and` conditions if when the first operand was false

# how? 

call `to_liquid_value` when checking if we should short-circuit