### PR TITLE
Fix `BigDecimal` output in `sum` filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -895,6 +895,7 @@ module Liquid
       result = InputIterator.new(values_for_sum, context).sum do |item|
         Utils.to_number(item)
       end
+
       result.is_a?(BigDecimal) ? result.to_f : result
     end
 

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -892,9 +892,10 @@ module Liquid
         raise_property_error(property)
       end
 
-      InputIterator.new(values_for_sum, context).sum do |item|
+      result = InputIterator.new(values_for_sum, context).sum do |item|
         Utils.to_number(item)
       end
+      result.is_a?(BigDecimal) ? result.to_f : result
     end
 
     private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -946,6 +946,21 @@ class StandardFiltersTest < Minitest::Test
     end
   end
 
+  def test_sum_with_floats
+    input = [0.1, 0.2, 0.3]
+    assert_equal(0.6, @filters.sum(input))
+  end
+
+  def test_sum_with_negative_float
+    input = [0.1, 0.2, -0.3]
+    assert_equal(0.0, @filters.sum(input))
+  end
+
+  def test_sum_with_float_strings
+    input = [0.1, "0.2", "0.3"]
+    assert_equal(0.6, @filters.sum(input))
+  end
+
   def test_sum_with_nested_arrays
     input = [1, [2, [3, 4]]]
 
@@ -992,6 +1007,22 @@ class StandardFiltersTest < Minitest::Test
     t = TestThing.new
     Liquid::Template.parse('{{ foo | sum: "quantity" }}').render("foo" => [{ "quantity" => t }])
     assert(t.foo > 0)
+  end
+
+  def test_render_sum_of_floats
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, 0.3]), "0.6")
+  end
+
+  def test_render_sum_of_negative_floats
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, 0.3]), "0.2")
+  end
+
+  def test_render_sum_negative_float_result
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, -0.3]), "-0.4")
+  end
+
+  def test_render_sum_float_zero_result
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, -0.3]), "0.0")
   end
 
   private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -1025,6 +1025,22 @@ class StandardFiltersTest < Minitest::Test
     assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, -0.3]), "0.0")
   end
 
+  def test_render_sum_with_floats_and_indexable_map_values
+    input = [{ "quantity" => 1 }, { "quantity" => 0.2, "weight" => -0.3 }, { "weight" => 0.4 }]
+    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => input), "0")
+    assert_equal(Liquid::Template.parse('{{ foo | sum: "quantity" }}').render("foo" => input), "1.2")
+    assert_equal(Liquid::Template.parse('{{ foo | sum: "weight" }}').render("foo" => input), "0.1")
+    assert_equal(Liquid::Template.parse('{{ foo | sum: "subtotal" }}').render("foo" => input), "0")
+  end
+
+  def test_sum_with_floats_and_indexable_map_values
+    input = [{ "quantity" => 1 }, { "quantity" => 0.2, "weight" => -0.3 }, { "weight" => 0.4 }]
+    assert_equal(0, @filters.sum(input))
+    assert_equal(1.2, @filters.sum(input, "quantity"))
+    assert_equal(0.1, @filters.sum(input, "weight"))
+    assert_equal(0, @filters.sum(input, "subtotal"))
+  end
+
   private
 
   def with_timezone(tz)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -946,21 +946,6 @@ class StandardFiltersTest < Minitest::Test
     end
   end
 
-  def test_sum_with_floats
-    input = [0.1, 0.2, 0.3]
-    assert_equal(0.6, @filters.sum(input))
-  end
-
-  def test_sum_with_negative_float
-    input = [0.1, 0.2, -0.3]
-    assert_equal(0.0, @filters.sum(input))
-  end
-
-  def test_sum_with_float_strings
-    input = [0.1, "0.2", "0.3"]
-    assert_equal(0.6, @filters.sum(input))
-  end
-
   def test_sum_with_nested_arrays
     input = [1, [2, [3, 4]]]
 
@@ -1009,36 +994,40 @@ class StandardFiltersTest < Minitest::Test
     assert(t.foo > 0)
   end
 
-  def test_render_sum_of_floats
-    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, 0.3]), "0.6")
+  def test_sum_of_floats
+    input = [0.1, 0.2, 0.3]
+    assert_equal(0.6, @filters.sum(input))
+    assert_template_result("0.6", "{{ input | sum }}", { "input" => input })
   end
 
-  def test_render_sum_of_negative_floats
-    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, 0.3]), "0.2")
+  def test_sum_of_negative_floats
+    input = [0.1, 0.2, -0.3]
+    assert_equal(0.0, @filters.sum(input))
+    assert_template_result("0.0", "{{ input | sum }}", { "input" => input })
   end
 
-  def test_render_sum_negative_float_result
-    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, -0.2, -0.3]), "-0.4")
+  def test_sum_with_float_strings
+    input = [0.1, "0.2", "0.3"]
+    assert_equal(0.6, @filters.sum(input))
+    assert_template_result("0.6", "{{ input | sum }}", { "input" => input })
   end
 
-  def test_render_sum_float_zero_result
-    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => [0.1, 0.2, -0.3]), "0.0")
-  end
-
-  def test_render_sum_with_floats_and_indexable_map_values
-    input = [{ "quantity" => 1 }, { "quantity" => 0.2, "weight" => -0.3 }, { "weight" => 0.4 }]
-    assert_equal(Liquid::Template.parse('{{ foo | sum }}').render("foo" => input), "0")
-    assert_equal(Liquid::Template.parse('{{ foo | sum: "quantity" }}').render("foo" => input), "1.2")
-    assert_equal(Liquid::Template.parse('{{ foo | sum: "weight" }}').render("foo" => input), "0.1")
-    assert_equal(Liquid::Template.parse('{{ foo | sum: "subtotal" }}').render("foo" => input), "0")
+  def test_sum_resulting_in_negative_float
+    input = [0.1, -0.2, -0.3]
+    assert_equal(-0.4, @filters.sum(input))
+    assert_template_result("-0.4", "{{ input | sum }}", { "input" => input })
   end
 
   def test_sum_with_floats_and_indexable_map_values
     input = [{ "quantity" => 1 }, { "quantity" => 0.2, "weight" => -0.3 }, { "weight" => 0.4 }]
-    assert_equal(0, @filters.sum(input))
+    assert_equal(0.0, @filters.sum(input))
     assert_equal(1.2, @filters.sum(input, "quantity"))
     assert_equal(0.1, @filters.sum(input, "weight"))
-    assert_equal(0, @filters.sum(input, "subtotal"))
+    assert_equal(0.0, @filters.sum(input, "subtotal"))
+    assert_template_result("0", "{{ input | sum }}", { "input" => input })
+    assert_template_result("1.2", "{{ input | sum: 'quantity' }}", { "input" => input })
+    assert_template_result("0.1", "{{ input | sum: 'weight' }}", { "input" => input })
+    assert_template_result("0", "{{ input | sum: 'subtotal' }}", { "input" => input })
   end
 
   private


### PR DESCRIPTION
- Closes #1725 
- Replaces #1728 

---

Thank you, @jg-rp, for identifying this bug and helping to implement the fix.

## Summary

This PR addresses a bug in the `sum` filter when handling arrays containing floats and thus yield a result that is a float.

Previously, the `sum` filter would return a `BigDecimal`, which would render in scientific notation, when summing floats. This behaviour was inconsistent with other math filters.

The change in this PR ensures that the `sum` filter returns a float instead of a `BigDecimal` when summing floats, aligning its behaviour with other math filters.

For example:

https://github.com/Shopify/liquid/blob/0b9318222bcc09681e52fd5b8e70262274e673bf/lib/liquid/standardfilters.rb#L908-L911

## Changes

- Updated the `sum` filter in `lib/liquid/standardfilters.rb` to convert BigDecimal results to floats when summing floats.
- Added tests in `test/integration/standard_filter_test.rb` to verify the correct behaviour of the `sum` filter when handling floats.
