### PR TITLE
Add deep search for filter taking in properties

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -368,10 +368,10 @@ module Liquid
         begin
           ary.sort do |a, b|
             if deep[:enable]
-              return nil_safe_compare(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+              nil_safe_compare(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+            else
+              nil_safe_compare(a[property], b[property])
             end
-
-            nil_safe_compare(a[property], b[property])
           end
         rescue TypeError
           raise_property_error(property)
@@ -406,10 +406,10 @@ module Liquid
         begin
           ary.sort do |a, b|
             if deep[:enable]
-              return nil_safe_casecmp(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+              nil_safe_casecmp(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+            else
+              nil_safe_casecmp(a[property], b[property])
             end
-
-            nil_safe_casecmp(a[property], b[property])
           end
         rescue TypeError
           raise_property_error(property)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -352,7 +352,10 @@ module Liquid
     #   Sorts the items in an array in case-sensitive alphabetical, or numerical, order.
     # @liquid_syntax array | sort
     # @liquid_return [array[untyped]]
-    def sort(input, property = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def sort(input, property = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
       ary = InputIterator.new(input, context)
 
       return [] if ary.empty?
@@ -363,7 +366,13 @@ module Liquid
         end
       elsif ary.all? { |el| el.respond_to?(:[]) }
         begin
-          ary.sort { |a, b| nil_safe_compare(a[property], b[property]) }
+          ary.sort do |a, b|
+            if deep[:enable]
+              return nil_safe_compare(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+            end
+
+            nil_safe_compare(a[property], b[property])
+          end
         rescue TypeError
           raise_property_error(property)
         end
@@ -381,7 +390,10 @@ module Liquid
     #   > string, so sorting on numerical values can lead to unexpected results.
     # @liquid_syntax array | sort_natural
     # @liquid_return [array[untyped]]
-    def sort_natural(input, property = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def sort_natural(input, property = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
       ary = InputIterator.new(input, context)
 
       return [] if ary.empty?
@@ -392,7 +404,13 @@ module Liquid
         end
       elsif ary.all? { |el| el.respond_to?(:[]) }
         begin
-          ary.sort { |a, b| nil_safe_casecmp(a[property], b[property]) }
+          ary.sort do |a, b|
+            if deep[:enable]
+              return nil_safe_casecmp(a.dig(*deep[:properties]), b.dig(*deep[:properties]))
+            end
+
+            nil_safe_casecmp(a[property], b[property])
+          end
         rescue TypeError
           raise_property_error(property)
         end
@@ -408,7 +426,10 @@ module Liquid
     #   This requires you to provide both the property name and the associated value.
     # @liquid_syntax array | where: string, string
     # @liquid_return [array[untyped]]
-    def where(input, property, target_value = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def where(input, property, target_value = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
       ary = InputIterator.new(input, context)
 
       if ary.empty?
@@ -424,7 +445,8 @@ module Liquid
         end
       else
         ary.select do |item|
-          item[property] == target_value
+          item_value = deep[:enable] ? item.dig(*deep[:properties]) : item[property]
+          item_value == target_value
         rescue TypeError
           raise_property_error(property)
         rescue NoMethodError
@@ -441,7 +463,10 @@ module Liquid
     #   Removes any duplicate items in an array.
     # @liquid_syntax array | uniq
     # @liquid_return [array[untyped]]
-    def uniq(input, property = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def uniq(input, property = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
       ary = InputIterator.new(input, context)
 
       if property.nil?
@@ -450,7 +475,7 @@ module Liquid
         []
       else
         ary.uniq do |item|
-          item[property]
+          deep[:enable] ? item.dig(*deep[:properties]) : item[property]
         rescue TypeError
           raise_property_error(property)
         rescue NoMethodError
@@ -479,15 +504,19 @@ module Liquid
     #   Creates an array of values from a specific property of the items in an array.
     # @liquid_syntax array | map: string
     # @liquid_return [array[untyped]]
-    def map(input, property)
-      InputIterator.new(input, context).map do |e|
-        e = e.call if e.is_a?(Proc)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def map(input, property, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
+
+      InputIterator.new(input, context).map do |item|
+        item = item.call if item.is_a?(Proc)
 
         if property == "to_liquid"
-          e
-        elsif e.respond_to?(:[])
-          r = e[property]
-          r.is_a?(Proc) ? r.call : r
+          item
+        elsif item.respond_to?(:[])
+          result = deep[:enable] ? item.dig(*deep[:properties]) : item[property]
+          result.is_a?(Proc) ? result.call : result
         end
       end
     rescue TypeError
@@ -876,7 +905,11 @@ module Liquid
     #   Returns the sum of all elements in an array.
     # @liquid_syntax array | sum
     # @liquid_return [number]
-    def sum(input, property = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def sum(input, property = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
+
       ary = InputIterator.new(input, context)
       return 0 if ary.empty?
 
@@ -884,7 +917,7 @@ module Liquid
         if property.nil?
           item
         elsif item.respond_to?(:[])
-          item[property]
+          deep[:enable] ? item.dig(*deep[:properties]) : item[property]
         else
           0
         end
@@ -930,6 +963,20 @@ module Liquid
       else
         a.nil? ? 1 : -1
       end
+    end
+
+    def deep_search_properties(key, options = {})
+      options = {} unless options.is_a?(Hash)
+
+      enable = options['deep'] ? true : false
+      separator = options['deep'].kind_of?(String) ? options['deep'] : '.' if enable
+      properties = key.to_s.split(separator) if enable
+
+      {
+        :enable => enable,
+        :separator => separator,
+        :properties => properties
+      }
     end
 
     class InputIterator

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -530,7 +530,10 @@ module Liquid
     #   Removes any `nil` items from an array.
     # @liquid_syntax array | compact
     # @liquid_return [array[untyped]]
-    def compact(input, property = nil)
+    # @liquid_optional_param deep [boolean | string] Whether to use dot notation to perform a deep search. A string can be passed to change separator.
+    def compact(input, property = nil, options = {})
+      options = {} unless options.is_a?(Hash)
+      deep = deep_search_properties(property, options)
       ary = InputIterator.new(input, context)
 
       if property.nil?
@@ -539,7 +542,7 @@ module Liquid
         []
       else
         ary.reject do |item|
-          item[property].nil?
+          deep[:enable] ? item.dig(*deep[:properties]).nil? : item[property].nil?
         rescue TypeError
           raise_property_error(property)
         rescue NoMethodError

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -989,13 +989,13 @@ module Liquid
       options = {} unless options.is_a?(Hash)
 
       enable = options['deep'] ? true : false
-      separator = options['deep'].kind_of?(String) ? options['deep'] : '.' if enable
+      separator = options['deep'].is_a?(String) ? options['deep'] : '.' if enable
       properties = key.to_s.split(separator) if enable
 
       {
-        :enable => enable,
-        :separator => separator,
-        :properties => properties
+        enable: enable,
+        separator: separator,
+        properties: properties,
       }
     end
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -605,7 +605,7 @@ class StandardFiltersTest < Minitest::Test
       { "foo" => { "bar" => "baz", "handle" => "alpha" } },
       { "foo" => { "bar" => "qux", "handle" => "charlie" } },
     ]
-    assert_equal(expectation, @filters.where(input, "foo_bar", "baz", { "deep" => "_" }))
+    assert_equal(expectation, @filters.compact(input, "foo_bar", { "deep" => "_" }))
   end
 
   def test_compact_deep_off_by_default
@@ -618,7 +618,7 @@ class StandardFiltersTest < Minitest::Test
       { "foo.bar" => "baz", "handle" => "alpha" },
       { "foo.bar" => "qux", "handle" => "charlie" },
     ]
-    assert_equal(expectation, @filters.where(input, "foo.bar", "baz"))
+    assert_equal(expectation, @filters.compact(input, "foo.bar"))
   end
 
   def test_reverse

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -477,7 +477,7 @@ class StandardFiltersTest < Minitest::Test
       { "foo.key" => "Z" },
       { "foo.fake" => "t" },
     ]
-    assert_equal(expectation, @filters.sort_natural(input, "foo.key" ))
+    assert_equal(expectation, @filters.sort_natural(input, "foo.key"))
   end
 
   def test_sort_empty_array

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -582,6 +582,45 @@ class StandardFiltersTest < Minitest::Test
     end
   end
 
+  def test_compact_deep_default_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    assert_equal(expectation, @filters.compact(input, "foo.bar", { "deep" => true }))
+  end
+
+  def test_compact_deep_custom_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    assert_equal(expectation, @filters.where(input, "foo_bar", "baz", { "deep" => "_" }))
+  end
+
+  def test_compact_deep_off_by_default
+    input = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.handle" => "beta" },
+      { "foo.bar" => "qux", "handle" => "charlie" },
+    ]
+    expectation = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.bar" => "qux", "handle" => "charlie" },
+    ]
+    assert_equal(expectation, @filters.where(input, "foo.bar", "baz"))
+  end
+
   def test_reverse
     assert_equal([4, 3, 2, 1], @filters.reverse([1, 2, 3, 4]))
   end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -265,6 +265,60 @@ class StandardFiltersTest < Minitest::Test
     assert_equal([{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }], @filters.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a"))
   end
 
+  def test_sort_deep_default_separator
+    input = [
+      { "foo" => { "price" => 4, "handle" => "alpha" } } ,
+      { "foo" => { "handle" => "beta" } } ,
+      { "foo" => { "price" => 1, "handle" => "gamma" } } ,
+      { "foo" => { "handle" => "delta" } } ,
+      { "foo" => { "price" => 2, "handle" => "epsilon" } } ,
+    ]
+    expectation = [
+      { "foo" => { "price" => 1, "handle" => "gamma" } },
+      { "foo" => { "price" => 2, "handle" => "epsilon" } },
+      { "foo" => { "price" => 4, "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "handle" => "delta" } },
+    ]
+    assert_equal(expectation, @filters.sort(input, "foo.price", { "deep" => true }))
+  end
+
+  def test_sort_deep_custom_separator
+    input = [
+      { "foo" => { "price" => 4, "handle" => "alpha" } } ,
+      { "foo" => { "handle" => "beta" } } ,
+      { "foo" => { "price" => 1, "handle" => "gamma" } } ,
+      { "foo" => { "handle" => "delta" } } ,
+      { "foo" => { "price" => 2, "handle" => "epsilon" } } ,
+    ]
+    expectation = [
+      { "foo" => { "price" => 1, "handle" => "gamma" } },
+      { "foo" => { "price" => 2, "handle" => "epsilon" } },
+      { "foo" => { "price" => 4, "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "handle" => "delta" } },
+    ]
+    assert_equal(expectation, @filters.sort(input, "foo_price", { "deep" => "_" }))
+  end
+
+  def test_sort_deep_off_by_default
+    input = [
+      { "foo.price" => 4, "handle" => "alpha" },
+      { "handle" => "beta" },
+      { "foo.price" => 1, "handle" => "gamma" },
+      { "handle" => "delta" },
+      { "foo.price" => 2, "handle" => "epsilon" },
+    ]
+    expectation = [
+      { "foo.price" => 1, "handle" => "gamma" },
+      { "foo.price" => 2, "handle" => "epsilon" },
+      { "foo.price" => 4, "handle" => "alpha" },
+      { "handle" => "beta" },
+      { "handle" => "delta" },
+    ]
+    assert_equal(expectation, @filters.sort(input, "foo.price"))
+  end
+
   def test_sort_with_nils
     assert_equal([1, 2, 3, 4, nil], @filters.sort([nil, 4, 3, 2, 1]))
     assert_equal([{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }, {}], @filters.sort([{ "a" => 4 }, { "a" => 3 }, {}, { "a" => 1 }, { "a" => 2 }], "a"))
@@ -337,6 +391,72 @@ class StandardFiltersTest < Minitest::Test
     ]
     assert_equal(expectation, @filters.sort_natural(input, "key"))
     assert_equal(["a", "b", "c", "X", "Y", "Z"], @filters.sort_natural(["X", "Y", "Z", "a", "b", "c"]))
+  end
+
+  def test_sort_natural_deep_default_separator
+    input = [
+      { "foo" => { "key" => "X" } },
+      { "foo" => { "key" => "Y" } },
+      { "foo" => { "key" => "Z" } },
+      { "foo" => { "fake" => "t" } },
+      { "foo" => { "key" => "a" } },
+      { "foo" => { "key" => "b" } },
+      { "foo" => { "key" => "c" } },
+    ]
+    expectation = [
+      { "foo" => { "key" => "a" } },
+      { "foo" => { "key" => "b" } },
+      { "foo" => { "key" => "c" } },
+      { "foo" => { "key" => "X" } },
+      { "foo" => { "key" => "Y" } },
+      { "foo" => { "key" => "Z" } },
+      { "foo" => { "fake" => "t" } },
+    ]
+    assert_equal(expectation, @filters.sort_natural(input, "foo.key", { "deep" => true }))
+  end
+
+  def test_sort_natural_deep_custom_separator
+    input = [
+      { "foo" => { "key" => "X" } },
+      { "foo" => { "key" => "Y" } },
+      { "foo" => { "key" => "Z" } },
+      { "foo" => { "fake" => "t" } },
+      { "foo" => { "key" => "a" } },
+      { "foo" => { "key" => "b" } },
+      { "foo" => { "key" => "c" } },
+    ]
+    expectation = [
+      { "foo" => { "key" => "a" } },
+      { "foo" => { "key" => "b" } },
+      { "foo" => { "key" => "c" } },
+      { "foo" => { "key" => "X" } },
+      { "foo" => { "key" => "Y" } },
+      { "foo" => { "key" => "Z" } },
+      { "foo" => { "fake" => "t" } },
+    ]
+    assert_equal(expectation, @filters.sort_natural(input, "foo_key", { "deep" => "_" }))
+  end
+
+  def test_sort_natural_deep_off_by_default
+    input = [
+      { "foo.key" => "X" },
+      { "foo.key" => "Y" },
+      { "foo.key" => "Z" },
+      { "foo.fake" => "t" },
+      { "foo.key" => "a" },
+      { "foo.key" => "b" },
+      { "foo.key" => "c" },
+    ]
+    expectation = [
+      { "foo.key" => "a" },
+      { "foo.key" => "b" },
+      { "foo.key" => "c" },
+      { "foo.key" => "X" },
+      { "foo.key" => "Y" },
+      { "foo.key" => "Z" },
+      { "foo.fake" => "t" },
+    ]
+    assert_equal(expectation, @filters.sort_natural(input, "foo.key" ))
   end
 
   def test_sort_empty_array
@@ -437,6 +557,30 @@ class StandardFiltersTest < Minitest::Test
       'abc',
       "{{ ary | map:'foo' | map:'bar' }}",
       { 'ary' => [{ 'foo' => { 'bar' => 'a' } }, { 'foo' => { 'bar' => 'b' } }, { 'foo' => { 'bar' => 'c' } }] },
+    )
+  end
+
+  def test_map_deep_default_separator
+    assert_template_result(
+      'abc',
+      "{{ ary | map: 'foo.bar', deep: true }}",
+      { 'ary' => [{ 'foo' => { 'bar' => 'a' } }, { 'foo' => { 'bar' => 'b' } }, { 'foo' => { 'bar' => 'c' } }] },
+    )
+  end
+
+  def test_map_deep_custom_separator
+    assert_template_result(
+      'abc',
+      "{{ ary | map: 'foo_bar', deep: '_' }}",
+      { 'ary' => [{ 'foo' => { 'bar' => 'a' } }, { 'foo' => { 'bar' => 'b' } }, { 'foo' => { 'bar' => 'c' } }] },
+    )
+  end
+
+  def test_map_deep_off_by_default
+    assert_template_result(
+      'abc',
+      "{{ ary | map: 'foo.bar' }}",
+      { 'ary' => [{ 'foo.bar' => 'a' }, { 'foo.bar' => 'b' }, { 'foo.bar' => 'c' }] },
     )
   end
 
@@ -992,6 +1136,36 @@ class StandardFiltersTest < Minitest::Test
     t = TestThing.new
     Liquid::Template.parse('{{ foo | sum: "quantity" }}').render("foo" => [{ "quantity" => t }])
     assert(t.foo > 0)
+  end
+
+  def test_sum_deep_default_separator
+    input = [
+      { "foo" => { "quantity" => 1 } },
+      { "foo" => { "quantity" => 2 } },
+      { "foo" => { "quantity" => 3 } },
+      { "foo" => { "quantity" => 4 } },
+    ]
+    assert_equal(10, @filters.sum(input, "foo.quantity", { "deep" => true }))
+  end
+
+  def test_sum_deep_custom_separator
+    input = [
+      { "foo" => { "quantity" => 1 } },
+      { "foo" => { "quantity" => 2 } },
+      { "foo" => { "quantity" => 3 } },
+      { "foo" => { "quantity" => 4 } },
+    ]
+    assert_equal(10, @filters.sum(input, "foo_quantity", { "deep" => "_" }))
+  end
+
+  def test_sum_deep_off_by_default
+    input = [
+      { "foo.quantity" => 1 },
+      { "foo.quantity" => 2 },
+      { "foo.quantity" => 3 },
+      { "foo.quantity" => 4 },
+    ]
+    assert_equal(10, @filters.sum(input, "foo.quantity"))
   end
 
   private

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -267,11 +267,11 @@ class StandardFiltersTest < Minitest::Test
 
   def test_sort_deep_default_separator
     input = [
-      { "foo" => { "price" => 4, "handle" => "alpha" } } ,
-      { "foo" => { "handle" => "beta" } } ,
-      { "foo" => { "price" => 1, "handle" => "gamma" } } ,
-      { "foo" => { "handle" => "delta" } } ,
-      { "foo" => { "price" => 2, "handle" => "epsilon" } } ,
+      { "foo" => { "price" => 4, "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "price" => 1, "handle" => "gamma" } },
+      { "foo" => { "handle" => "delta" } },
+      { "foo" => { "price" => 2, "handle" => "epsilon" } },
     ]
     expectation = [
       { "foo" => { "price" => 1, "handle" => "gamma" } },
@@ -285,11 +285,11 @@ class StandardFiltersTest < Minitest::Test
 
   def test_sort_deep_custom_separator
     input = [
-      { "foo" => { "price" => 4, "handle" => "alpha" } } ,
-      { "foo" => { "handle" => "beta" } } ,
-      { "foo" => { "price" => 1, "handle" => "gamma" } } ,
-      { "foo" => { "handle" => "delta" } } ,
-      { "foo" => { "price" => 2, "handle" => "epsilon" } } ,
+      { "foo" => { "price" => 4, "handle" => "alpha" } },
+      { "foo" => { "handle" => "beta" } },
+      { "foo" => { "price" => 1, "handle" => "gamma" } },
+      { "foo" => { "handle" => "delta" } },
+      { "foo" => { "price" => 2, "handle" => "epsilon" } },
     ]
     expectation = [
       { "foo" => { "price" => 1, "handle" => "gamma" } },
@@ -529,13 +529,13 @@ class StandardFiltersTest < Minitest::Test
 
   def test_uniq_deep_default_separator
     input = [
-      { "foo" => { "bar" => "baz", "handle" => "alpha" } } ,
-      { "foo" => { "bar" => "baz", "handle" => "beta" } } ,
-      { "foo" => { "bar" => "qux", "handle" => "charlie" } } ,
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
     ]
     expectation = [
-      { "foo" => { "bar" => "baz", "handle" => "alpha" } } ,
-      { "foo" => { "bar" => "qux", "handle" => "charlie" } } ,
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
     ]
     assert_equal(expectation, @filters.uniq(input, "foo.bar", { "deep" => true }))
   end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -527,6 +527,45 @@ class StandardFiltersTest < Minitest::Test
     end
   end
 
+  def test_uniq_deep_default_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } } ,
+      { "foo" => { "bar" => "baz", "handle" => "beta" } } ,
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } } ,
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } } ,
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } } ,
+    ]
+    assert_equal(expectation, @filters.uniq(input, "foo.bar", { "deep" => true }))
+  end
+
+  def test_uniq_deep_custom_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    assert_equal(expectation, @filters.uniq(input, "foo_bar", { "deep" => "_" }))
+  end
+
+  def test_uniq_deep_off_by_default
+    input = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.bar" => "baz", "handle" => "beta" },
+      { "foo.bar" => "qux", "handle" => "charlie" },
+    ]
+    expectation = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.bar" => "qux", "handle" => "charlie" },
+    ]
+    assert_equal(expectation, @filters.uniq(input, "foo.bar"))
+  end
+
   def test_compact_empty_array
     assert_equal([], @filters.compact([], "a"))
   end
@@ -1021,6 +1060,45 @@ class StandardFiltersTest < Minitest::Test
   def test_where_array_of_only_unindexable_values
     assert_nil(@filters.where([nil], "ok", true))
     assert_nil(@filters.where([nil], "ok"))
+  end
+
+  def test_where_deep_default_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+    ]
+    assert_equal(expectation, @filters.where(input, "foo.bar", "baz", { "deep" => true }))
+  end
+
+  def test_where_deep_custom_separator
+    input = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+      { "foo" => { "bar" => "qux", "handle" => "charlie" } },
+    ]
+    expectation = [
+      { "foo" => { "bar" => "baz", "handle" => "alpha" } },
+      { "foo" => { "bar" => "baz", "handle" => "beta" } },
+    ]
+    assert_equal(expectation, @filters.where(input, "foo_bar", "baz", { "deep" => "_" }))
+  end
+
+  def test_where_deep_off_by_default
+    input = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.bar" => "baz", "handle" => "beta" },
+      { "foo.bar" => "qux", "handle" => "charlie" },
+    ]
+    expectation = [
+      { "foo.bar" => "baz", "handle" => "alpha" },
+      { "foo.bar" => "baz", "handle" => "beta" },
+    ]
+    assert_equal(expectation, @filters.where(input, "foo.bar", "baz"))
   end
 
   def test_all_filters_never_raise_non_liquid_exception


### PR DESCRIPTION
This PR allows for backward compatibility deep search :woah:

Like so:
```liquid
{{ input | where: 'some.nested.property', 'foo', deep: true }}
{{ input | where: 'some_nested_property', 'foo', deep: '_' }} # Custom separator
```

Added deep search for the following filters. This should be all Liquid filters which takes in a property argument:
- [x] map
- [x] sort
- [x] sort_natural
- [x] sum
- [x] uniq
- [x] where
- [x] compact