### PR TITLE
Fix for custom tag rendering

### DIFF
--- a/lib/liquid/tag.rb
+++ b/lib/liquid/tag.rb
@@ -54,7 +54,8 @@ module Liquid
     # of the `render_to_output_buffer` method will become the default and the `render`
     # method will be removed.
     def render_to_output_buffer(context, output)
-      output << render(context)
+      render_result = render(context)
+      output << render_result if render_result
       output
     end
 

--- a/test/unit/tag_unit_test.rb
+++ b/test/unit/tag_unit_test.rb
@@ -20,4 +20,13 @@ class TagUnitTest < Minitest::Test
     tag = Tag.parse("some_tag", "", Tokenizer.new(""), ParseContext.new)
     assert_equal('some_tag', tag.tag_name)
   end
+
+  class CustomTag < Liquid::Tag
+    def render(_context); end
+  end
+
+  def test_tag_render_to_output_buffer_nil_value
+    custom_tag = CustomTag.parse("some_tag", "", Tokenizer.new(""), ParseContext.new)
+    assert_equal('some string', custom_tag.render_to_output_buffer(Context.new, "some string"))
+  end
 end


### PR DESCRIPTION
After https://github.com/Shopify/liquid/pull/1091 the behaviour when a render method of custom tags returns nil has changed. Before something like 
``` 
 Liquid::Template.parse('foo {% custom_url%20SOME-CUSTOM-PARAM %}').render()
```
that depends on

```
 class CustomUrl < Liquid::Tag
     ...
    def render(_context)
      return unless something

      #build url
    end
```

Would return just `foo `.
After the change it returns `foo Liquid error: internal` 
Because [this line here ](https://github.com/Shopify/liquid/blob/e3dcc75ab533eb177cabf3df16ed27c1a21fc33c/lib/liquid/tag.rb#L57) throws `TypeError:    no implicit conversion of nil into String` 