### PR TITLE
Don't parse nodes inside a comment tag

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -6,6 +6,7 @@ module Liquid
   class BlockBody
     LiquidTagToken      = /\A\s*(#{TagName})\s*(.*?)\z/o
     FullToken           = /\A#{TagStart}#{WhitespaceControl}?(\s*)(#{TagName})(\s*)(.*?)#{WhitespaceControl}?#{TagEnd}\z/om
+    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(\w+)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
     ContentOfVariable   = /\A#{VariableStart}#{WhitespaceControl}?(.*?)#{WhitespaceControl}?#{VariableEnd}\z/om
     WhitespaceOrNothing = /\A\s*\z/
     TAGSTART            = "{%"

--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -47,16 +47,12 @@ module Liquid
 
           tag_name = tag_name_match[2]
 
-          if tag_name == "raw"
-            # raw tags are required to be closed
+          case tag_name
+          when "raw"
             parse_raw_tag_body(tokens)
-            next
-          end
-
-          if tag_name_match[2] == "comment"
+          when "comment"
             comment_tag_depth += 1
-            next
-          elsif tag_name_match[2] == "endcomment"
+          when "endcomment"
             comment_tag_depth -= 1
 
             return false if comment_tag_depth.zero?

--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -15,6 +15,8 @@ module Liquid
   #   {% endcomment %}
   # @liquid_syntax_keyword content The content of the comment.
   class Comment < Block
+    TagDelimiter = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
+
     def render_to_output_buffer(_context, output)
       output
     end
@@ -49,6 +51,9 @@ module Liquid
             next if tag_name_match.nil?
 
             tag_name_match[1]
+          elsif TagDelimiter.match?(token)
+            # aggressively match comment delimiter first
+            "endcomment"
           else
             tag_name_match = BlockBody::FullTokenPossiblyInvalid.match(token)
 

--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -15,7 +15,7 @@ module Liquid
   #   {% endcomment %}
   # @liquid_syntax_keyword content The content of the comment.
   class Comment < Block
-    TagDelimiter = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
+    TAG_DELIMITER = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
 
     def render_to_output_buffer(_context, output)
       output
@@ -51,9 +51,12 @@ module Liquid
             next if tag_name_match.nil?
 
             tag_name_match[1]
-          elsif TagDelimiter.match?(token)
-            # aggressively match comment delimiter first
+          elsif TAG_DELIMITER.match?(token)
+            # aggressively match comment delimiter
             "endcomment"
+          elsif token =~ BlockBody::FullToken && Regexp.last_match(2) == "comment"
+            # aggressively match comment tag
+            "comment"
           else
             tag_name_match = BlockBody::FullTokenPossiblyInvalid.match(token)
 

--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -41,7 +41,7 @@ module Liquid
         # The children tag doesn't require to be a valid Liquid except the comment and raw tag.
         # The child comment and raw tag must be closed.
         while (token = tokens.send(:shift))
-          tag_name_match = BlockBody::FullToken.match(token)
+          tag_name_match = BlockBody::FullTokenPossiblyInvalid.match(token)
 
           next if tag_name_match.nil?
 
@@ -69,7 +69,7 @@ module Liquid
 
     def parse_raw_tag_body(tokens)
       while (token = tokens.send(:shift))
-        return if token =~ Raw::FullTokenPossiblyInvalid && "endraw" == Regexp.last_match(2)
+        return if token =~ BlockBody::FullTokenPossiblyInvalid && "endraw" == Regexp.last_match(2)
       end
 
       raise_tag_never_closed("raw")

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -14,7 +14,6 @@ module Liquid
   # @liquid_syntax_keyword expression The expression to be output without being rendered.
   class Raw < Block
     Syntax = /\A\s*\z/
-    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(\w+)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
 
     def initialize(tag_name, markup, parse_context)
       super
@@ -25,7 +24,7 @@ module Liquid
     def parse(tokens)
       @body = +''
       while (token = tokens.shift)
-        if token =~ FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
+        if token =~ BlockBody::FullTokenPossiblyInvalid && block_delimiter == Regexp.last_match(2)
           parse_context.trim_whitespace = (token[-3] == WhitespaceControl)
           @body << Regexp.last_match(1) if Regexp.last_match(1) != ""
           return

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -121,4 +121,18 @@ class CommentTagUnitTest < Minitest::Test
       LIQUID
     )
   end
+
+  def test_nested_comment_tag_with_extra_strings
+    assert_template_result(
+      '',
+      <<~LIQUID.chomp,
+        {% comment %}
+          {% comment
+            {% assign foo = 1 %}
+          {% endcomment
+          {% assign foo = 1 %}
+        {% endcomment %}
+      LIQUID
+    )
+  end
 end

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class CommentTagUnitTest < Minitest::Test
   def test_does_not_parse_nodes_inside_a_comment
-    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+    assert_template_result("", <<~LIQUID.chomp)
       {% comment %}
         {% if true %}
         {% if ... %}
@@ -16,22 +16,31 @@ class CommentTagUnitTest < Minitest::Test
         {% endcase %}
       {% endcomment %}
     LIQUID
-
-    assert_equal("", template.render)
   end
 
   def test_allows_incomplete_tags_inside_a_comment
-    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+    assert_template_result("", <<~LIQUID.chomp)
       {% comment %}
         {% assign foo = "1"
       {% endcomment %}
     LIQUID
 
-    assert_equal("", template.render)
+    assert_template_result("", <<~LIQUID.chomp)
+      {% comment %}
+        {% comment %}
+          {% invalid
+        {% endcomment %}
+      {% endcomment %}
+    LIQUID
+
+    assert_template_result("", <<~LIQUID.chomp)
+      {% comment %}
+      {% {{ {%- endcomment %}
+    LIQUID
   end
 
   def test_child_comment_tags_need_to_be_closed
-    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+    assert_template_result("", <<~LIQUID.chomp)
       {% comment %}
         {% comment %}
           {% comment %}{%    endcomment     %}
@@ -39,10 +48,8 @@ class CommentTagUnitTest < Minitest::Test
       {% endcomment %}
     LIQUID
 
-    assert_equal("", template.render)
-
     assert_raises(Liquid::SyntaxError) do
-      Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      assert_template_result("", <<~LIQUID.chomp)
         {% comment %}
           {% comment %}
             {% comment %}
@@ -53,7 +60,7 @@ class CommentTagUnitTest < Minitest::Test
   end
 
   def test_child_raw_tags_need_to_be_closed
-    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+    assert_template_result("", <<~LIQUID.chomp)
       {% comment %}
         {% raw %}
           {% endcomment %}
@@ -61,10 +68,8 @@ class CommentTagUnitTest < Minitest::Test
       {% endcomment %}
     LIQUID
 
-    assert_equal("", template.render)
-
     assert_raises(Liquid::SyntaxError) do
-      Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      Liquid::Template.parse(<<~LIQUID.chomp)
         {% comment %}
           {% raw %}
           {% endcomment %}

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -107,4 +107,18 @@ class CommentTagUnitTest < Minitest::Test
 
     assert_equal(expected, output)
   end
+
+  def test_comment_tag_delimiter_with_extra_strings
+    assert_template_result(
+      '',
+      <<~LIQUID.chomp,
+        {% comment %}
+          {% comment %}
+          {% endcomment
+          {% if true %}
+          {% endif %}
+        {% endcomment %}
+      LIQUID
+    )
+  end
 end

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -20,6 +20,16 @@ class CommentTagUnitTest < Minitest::Test
     assert_equal("", template.render)
   end
 
+  def test_allows_incomplete_tags_inside_a_comment
+    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      {% comment %}
+        {% assign foo = "1"
+      {% endcomment %}
+    LIQUID
+
+    assert_equal("", template.render)
+  end
+
   def test_child_comment_tags_need_to_be_closed
     template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
       {% comment %}

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -3,6 +3,19 @@
 require 'test_helper'
 
 class CommentTagUnitTest < Minitest::Test
+  def test_comment_inside_liquid_tag
+    assert_template_result("", <<~LIQUID.chomp)
+      {% liquid
+        if 1 != 1
+        comment
+        else
+          echo 123
+        endcomment
+        endif
+      %}
+    LIQUID
+  end
+
   def test_does_not_parse_nodes_inside_a_comment
     assert_template_result("", <<~LIQUID.chomp)
       {% comment %}

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CommentTagUnitTest < Minitest::Test
+  def test_does_not_parse_nodes_inside_a_comment
+    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      {% comment %}
+        {% if true %}
+        {% if ... %}
+        {%- for ? -%}
+        {% while true %}
+        {%
+          unless if
+        %}
+        {% endcase %}
+      {% endcomment %}
+    LIQUID
+
+    assert_equal("", template.render)
+  end
+
+  def test_child_comment_tags_need_to_be_closed
+    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      {% comment %}
+        {% comment %}
+          {% comment %}{%    endcomment     %}
+        {% endcomment %}
+      {% endcomment %}
+    LIQUID
+
+    assert_equal("", template.render)
+
+    assert_raises(Liquid::SyntaxError) do
+      Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+        {% comment %}
+          {% comment %}
+            {% comment %}
+          {% endcomment %}
+        {% endcomment %}
+      LIQUID
+    end
+  end
+
+  def test_child_raw_tags_need_to_be_closed
+    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      {% comment %}
+        {% raw %}
+          {% endcomment %}
+        {% endraw %}
+      {% endcomment %}
+    LIQUID
+
+    assert_equal("", template.render)
+
+    assert_raises(Liquid::SyntaxError) do
+      Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+        {% comment %}
+          {% raw %}
+          {% endcomment %}
+        {% endcomment %}
+      LIQUID
+    end
+  end
+
+  def test_error_line_number_is_correct
+    template = Liquid::Template.parse(<<~LIQUID.chomp, line_numbers: true)
+      {% comment %}
+        {% if true %}
+      {% endcomment %}
+      {{ errors.standard_error }}
+    LIQUID
+
+    output = template.render('errors' => ErrorDrop.new)
+    expected = <<~TEXT.chomp
+
+      Liquid error (line 4): standard error
+    TEXT
+
+    assert_equal(expected, output)
+  end
+end


### PR DESCRIPTION
depends on https://github.com/Shopify/liquid-c/pull/209

# What are you trying to solve?
Liquid Tags inside a `comment` tag are getting parsed, and any Liquid tags are required to be valid.

```ruby
require 'liquid'

template = Liquid::Template.parse(<<~LIQUID)
  {% comment %}
    {% assign foo = "123" %}
  {% endcomment %}
  {{ foo}}
LIQUID

puts template.root.nodelist[0] # => Liquid::Comment
puts template.root.nodelist[0].nodelist[1].class # => Liquid::Assign
```

Because of this parsing behaviour, the Liquid codes inside the comment tag has to be valid.
A known workaround of this issue is using a `raw` tag inside the comment tag:
```liquid
{% comment %}{% raw %}
  {% if WIP ... %}
{% endraw %}{% endcomment %}
```

# How are you solving this?
This PR updates the `comment` tag to only consume the tokens without creating child nodes.
```ruby
require 'liquid'

template = Liquid::Template.parse(<<~LIQUID)
  {% comment %}
    {% assign foo = "123" %}
  {% endcomment %}
  {{ foo}}
LIQUID

puts template.root.nodelist[0] # => Liquid::Comment
puts template.root.nodelist[0].nodelist.empty? # => true
```

This change will improve the `comment` tag's Template parsing speed, and allow developers to have incomplete code inside the `comment` tag.

```liquid
{% comment %}
  {% if 1 > 0 %}
    incomplete code...
{% endcomment %}
```

# Legacy Support
Inside a `comment` tag, children `comment` tag and `raw` tags will have be valid and closed.

This `comment` tag inside a comment will have to be closed because `{% endcomment %}` tag delimiters needs to be balanced. (Closing the first `comment` tag in line 4 will result a syntax error)
```liquid
{% comment %}
  {% comment %}
    child comment
  {% endcomment %}
{% endcomment %}
```

This `raw` tag inside a comment will have to be closed because `{% endcomment %}` inside a `raw` tag has been ignored:
```liquid
{% comment %}
  {% raw %}
    {% endcomment %}
  {% endraw %}
{% endcomment %}
```