### PR TITLE
change: make nil_safe_casecmp judge compatible for nil-nil comparison

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -944,6 +944,8 @@ module Liquid
     def nil_safe_casecmp(a, b)
       if !a.nil? && !b.nil?
         a.to_s.casecmp(b.to_s)
+      elsif a.nil? && b.nil?
+        0
       else
         a.nil? ? 1 : -1
       end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -331,8 +331,8 @@ class StandardFiltersTest < Minitest::Test
       { "price" => "1", "handle" => "gamma" },
       { "price" => 2, "handle" => "epsilon" },
       { "price" => "4", "handle" => "alpha" },
-      { "handle" => "delta" },
       { "handle" => "beta" },
+      { "handle" => "delta" },
     ]
     assert_equal(expectation, @filters.sort_natural(input, "price"))
   end


### PR DESCRIPTION
Ruby returns 0 (not nil) for nil <=> nil, i.e. nil and nil are judged as equal for comparison, and so returns nil_safe_compare . ref: https://github.com/Shopify/liquid/pull/1476

To make the behavior of nil_safe_casecmp consistent with nil_safe_compare , change nil_safe_casecmp so that comparison between nil <=> nil return 0 (equal).

Also change testsuite to reflect this change.

Fixes #1759 .