### PR TITLE
fix parsing comment tag delimiter

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -15,7 +15,7 @@ module Liquid
   #   {% endcomment %}
   # @liquid_syntax_keyword content The content of the comment.
   class Comment < Block
-    TAG_DELIMITER = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(.*)?#{WhitespaceControl}?#{TagEnd}\z/om
+    TAG_DELIMITER = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(\s.*)?#{WhitespaceControl}?#{TagEnd}\z/om
 
     def render_to_output_buffer(_context, output)
       output

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -135,4 +135,24 @@ class CommentTagUnitTest < Minitest::Test
       LIQUID
     )
   end
+
+  def test_ignores_delimiter_with_extra_strings
+    assert_template_result(
+      '',
+      <<~LIQUID.chomp,
+        {% if true %}
+          {% comment %}
+            {% commentXXXXX %}wut{% endcommentXXXXX %}
+          {% endcomment %}
+        {% endif %}
+      LIQUID
+    )
+  end
+
+  def test_delimiter_can_have_extra_strings
+    assert_template_result('', "{% comment %}123{% endcomment xyz %}")
+    assert_template_result('', "{% comment %}123{% endcomment\txyz %}")
+    assert_template_result('', "{% comment %}123{% endcomment\nxyz %}")
+    assert_template_result('', "{% comment %}123{% endcomment\n   xyz  endcomment %}")
+  end
 end


### PR DESCRIPTION
### What are you trying to solve?
https://github.com/Shopify/liquid/pull/1755 introduced a bug to `comment` tag parsing.

The `comment` tag uses this regex to match the tag delimiter:
```regex
 /\A(.*)(?-mix:\{\%)-?\s*(endcomment)\s*(.*)?-?(?-mix:\%\})\z/m
```

After matching the `endcomment`, the regex is also matching the extra string with `\s*(.*)?`
Since it doesn't require a whitespace after matching with the tag delimiter, it allows delimiters like `{% endcommentABC %}` to be matched.
