### PR TITLE
implement whitespace control to comment tag

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -73,7 +73,10 @@ module Liquid
           when "endcomment"
             comment_tag_depth -= 1
 
-            return false if comment_tag_depth.zero?
+            if comment_tag_depth.zero?
+              parse_context.trim_whitespace = (token[-3] == WhitespaceControl)
+              return false
+            end
           end
         end
 

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -155,4 +155,15 @@ class CommentTagUnitTest < Minitest::Test
     assert_template_result('', "{% comment %}123{% endcomment\nxyz %}")
     assert_template_result('', "{% comment %}123{% endcomment\n   xyz  endcomment %}")
   end
+
+  def test_with_whitespace_control
+    assert_template_result("Hello!", "      {%- comment -%}123{%- endcomment -%}Hello!")
+    assert_template_result("Hello!", "{%- comment -%}123{%- endcomment -%}     Hello!")
+    assert_template_result("Hello!", "      {%- comment -%}123{%- endcomment -%}     Hello!")
+
+    assert_template_result("Hello!", <<~LIQUID.chomp)
+      {%- comment %}Whitespace control!{% endcomment -%}
+      Hello!
+    LIQUID
+  end
 end


### PR DESCRIPTION
### What are you trying to solve?
https://github.com/Shopify/liquid/pull/1755 introduced a whitespace control bug to `comment` tag parsing.

The `comment` tag is now updated to update the `parse_context.trim_whitespace` when it recognises a whitespace control character like the [raw tag](https://github.com/Shopify/liquid/blob/cbb422e5d39b52671cacf86ca684713d565b4bed/lib/liquid/tags/raw.rb#L27-L30). 
