### PR TITLE
fix parsing comment tag with extra string

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -15,8 +15,6 @@ module Liquid
   #   {% endcomment %}
   # @liquid_syntax_keyword content The content of the comment.
   class Comment < Block
-    TAG_DELIMITER = /\A(.*)#{TagStart}#{WhitespaceControl}?\s*(endcomment)\s*(\s.*)?#{WhitespaceControl}?#{TagEnd}\z/om
-
     def render_to_output_buffer(_context, output)
       output
     end
@@ -51,12 +49,9 @@ module Liquid
             next if tag_name_match.nil?
 
             tag_name_match[1]
-          elsif TAG_DELIMITER.match?(token)
-            # aggressively match comment delimiter
-            "endcomment"
-          elsif token =~ BlockBody::FullToken && Regexp.last_match(2) == "comment"
-            # aggressively match comment tag
-            "comment"
+          elsif token =~ BlockBody::FullToken && Regexp.last_match(2) == "comment" || Regexp.last_match(2) == "endcomment"
+            # aggressively match comment tag or comment tag delimiter
+            Regexp.last_match(2)
           else
             tag_name_match = BlockBody::FullTokenPossiblyInvalid.match(token)
 

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -154,6 +154,7 @@ class CommentTagUnitTest < Minitest::Test
     assert_template_result('', "{% comment %}123{% endcomment\txyz %}")
     assert_template_result('', "{% comment %}123{% endcomment\nxyz %}")
     assert_template_result('', "{% comment %}123{% endcomment\n   xyz  endcomment %}")
+    assert_template_result('', "{%comment}{% assign a = 1 %}{%endcomment}{% endif %}")
   end
 
   def test_with_whitespace_control


### PR DESCRIPTION
### What are you trying to solve?

https://github.com/Shopify/liquid/pull/1755 introduced a bug in `comment` tag that prevents the tag from having extra string inside.

With the bug, this valid template fails to be parsed
```liquid
{%comment}{% assign a = 1 %}
  {% if true %}
{%endcomment}{% endif %}
```