### PR TITLE
don't allow invalid syntax inside comment tag

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -49,15 +49,9 @@ module Liquid
             next if tag_name_match.nil?
 
             tag_name_match[1]
-          elsif token =~ BlockBody::FullToken && Regexp.last_match(2) == "comment" || Regexp.last_match(2) == "endcomment"
-            # aggressively match comment tag or comment tag delimiter
-            Regexp.last_match(2)
           else
-            tag_name_match = BlockBody::FullTokenPossiblyInvalid.match(token)
-
-            next if tag_name_match.nil?
-
-            tag_name_match[2]
+            token =~ BlockBody::FullToken
+            Regexp.last_match(2)
           end
 
           case tag_name

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -39,7 +39,7 @@ class CommentTagUnitTest < Minitest::Test
     LIQUID
   end
 
-  def test_block_body_must_be_valid
+  def test_open_tags_in_comment
     assert_template_result('', <<~LIQUID.chomp)
       {% comment %}
         {% assign a = 123 {% comment %}

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -31,25 +31,45 @@ class CommentTagUnitTest < Minitest::Test
     LIQUID
   end
 
-  def test_allows_incomplete_tags_inside_a_comment
-    assert_template_result("", <<~LIQUID.chomp)
+  def test_allows_unclosed_tags
+    assert_template_result('', <<~LIQUID.chomp)
       {% comment %}
-        {% assign foo = "1"
+        {% if true %}
+      {% endcomment %}
+    LIQUID
+  end
+
+  def test_block_body_must_be_valid
+    assert_template_result('', <<~LIQUID.chomp)
+      {% comment %}
+        {% assign a = 123 {% comment %}
       {% endcomment %}
     LIQUID
 
-    assert_template_result("", <<~LIQUID.chomp)
-      {% comment %}
+    assert_raises(Liquid::SyntaxError) do
+      assert_template_result("", <<~LIQUID.chomp)
         {% comment %}
-          {% invalid
+          {% assign foo = "1"
         {% endcomment %}
-      {% endcomment %}
-    LIQUID
+      LIQUID
+    end
 
-    assert_template_result("", <<~LIQUID.chomp)
-      {% comment %}
-      {% {{ {%- endcomment %}
-    LIQUID
+    assert_raises(Liquid::SyntaxError) do
+      assert_template_result("", <<~LIQUID.chomp)
+        {% comment %}
+          {% comment %}
+            {% invalid
+          {% endcomment %}
+        {% endcomment %}
+      LIQUID
+    end
+
+    assert_raises(Liquid::SyntaxError) do
+      assert_template_result("", <<~LIQUID.chomp)
+        {% comment %}
+        {% {{ {%- endcomment %}
+      LIQUID
+    end
   end
 
   def test_child_comment_tags_need_to_be_closed


### PR DESCRIPTION
### What are you trying to solve?
https://github.com/Shopify/liquid/pull/1755 introduced a new feature that allows invalid code to be inside a `comment` tag.

For Liquid version `5.4.0`, this is a valid template, and not with our current `main` branch:
```liquid
{% comment %}
  {% assign a = 1
  {% endcomment %}
{% endcomment %}
```
The `assign` tag is not closed immediately, `{% assign a = 1  {% endcomment %}` is parsed as the `assign` tag.

Since the https://github.com/Shopify/liquid/pull/1755 changed the `comment` tag parser to use the `BlockBody::FullTokenPossiblyInvalid` regex pattern, it parses `{% assign a = 1  {% endcomment %}` to be the `comment` tag delimiter, and it raises a syntax error by the extra `{% endcomment %}` token.

### How are you solving this issue?

In order to remove this breaking change, this PR updates the `comment` to parse tokens like `BlockBody` and not like `raw` tag.
However, the `comment` tag will still allow unclosed tags such as this example:
```liquid
{% comment %}
  {% if true %}
  {% if  %}
{% endcomment %}
```