### PR TITLE
don't reset Liquid tag's whitespace control from comment tag

### DIFF
--- a/lib/liquid/tags/comment.rb
+++ b/lib/liquid/tags/comment.rb
@@ -61,11 +61,11 @@ module Liquid
             comment_tag_depth += 1
           when "endcomment"
             comment_tag_depth -= 1
+          end
 
-            if comment_tag_depth.zero?
-              parse_context.trim_whitespace = (token[-3] == WhitespaceControl)
-              return false
-            end
+          if comment_tag_depth.zero?
+            parse_context.trim_whitespace = (token[-3] == WhitespaceControl) unless tokenizer.for_liquid_tag
+            return false
           end
         end
 

--- a/test/unit/tags/comment_tag_unit_test.rb
+++ b/test/unit/tags/comment_tag_unit_test.rb
@@ -187,4 +187,16 @@ class CommentTagUnitTest < Minitest::Test
       Hello!
     LIQUID
   end
+
+  def test_dont_override_liquid_tag_whitespace_control
+    assert_template_result("Hello!World!", <<~LIQUID.chomp)
+      Hello!
+      {%- liquid
+        comment
+         this is inside a liquid tag
+        endcomment
+      -%}
+      World!
+    LIQUID
+  end
 end


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/1764 introduced a bug that a `comment` tag inside a `liquid` tag overrides the `liquid` tag's whitespace control.

A Liquid template like this would expected to output `Hello!World!`  but since the `endcomment` tag delimiter disables the whitespace control, it outputs `Hello!\nWorld!`
```liquid
Hello!
{%- liquid
  comment
    this is inside a liquid tag
  endcomment
-%}
World!
```