### PR TITLE
check template UTF8 validity before parsing

### DIFF
--- a/lib/liquid/locales/en.yml
+++ b/lib/liquid/locales/en.yml
@@ -15,6 +15,7 @@
       include: "Error in tag 'include' - Valid syntax: include '[template]' (with|for) [object|collection]"
       inline_comment_invalid: "Syntax error in tag '#' - Each line of comments must be prefixed by the '#' character"
       invalid_delimiter: "'%{tag}' is not a valid delimiter for %{block_name} tags. use %{block_delimiter}"
+      invalid_template_encoding: "Invalid template encoding"
       render: "Syntax error in tag 'render' - Template name must be a quoted string"
       table_row: "Syntax Error in 'table_row loop' - Valid syntax: table_row [item] in [collection] cols=3"
       tag_never_closed: "'%{block_name}' tag was never closed"

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -107,6 +107,11 @@ module Liquid
     # Returns self for easy chaining
     def parse(source, options = {})
       parse_context = configure_options(options)
+
+      unless source.valid_encoding?
+        raise SyntaxError, parse_context.locale.t("errors.syntax.invalid_template_encoding")
+      end
+
       tokenizer     = parse_context.new_tokenizer(source, start_line_number: @line_numbers && 1)
       @root         = Document.parse(tokenizer, parse_context)
       self

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -337,4 +337,16 @@ class TemplateTest < Minitest::Test
     assert_equal("x=2", output)
     assert_instance_of(String, output)
   end
+
+  def test_raises_error_with_invalid_utf8
+    e = assert_raises(SyntaxError) do
+      Template.parse(<<~LIQUID)
+        {% comment %}
+          \xC0
+        {% endcomment %}
+      LIQUID
+    end
+
+    assert_equal('Liquid syntax error: Invalid template encoding', e.message)
+  end
 end


### PR DESCRIPTION
### What are you trying to solve?

Liquid relies on `regex` for parsing, and Liquid needs to check the template's String encoding validity.

Currently, Liquid is raising a `ArgumentError` when a template includes an invalid UTF8 byte sequence.
```ruby
require 'liquid'
Liquid::Template.parse("{% assign foo = '\xC0' %}") 

# lib/liquid/tokenizer.rb:31:in `split': invalid byte sequence in UTF-8 (ArgumentError)
```

Instead of throwing the `ArgumentError`, this PR updates Liquid to raise a `Syntax` error when a template has a invalid encoding.

With this change, the developers won't have to catch the invalid encoding error like this:
```ruby
begin
  Liquid::Template.parse("\xC0")
rescue ArugmentError => e
  if e.message == "invalid byte sequence in UTF-8"
     ...
  else
    raise e
  end
end
```

Instead, the error can be handled like this
```ruby
begin
  Liquid::Template.parse("\xC0")
rescue Liquid::Error
     ...
end
```