### PR TITLE
allow non-string template source

### DIFF
--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -107,8 +107,9 @@ module Liquid
     # Returns self for easy chaining
     def parse(source, options = {})
       parse_context = configure_options(options)
+      source = source.to_s.to_str
 
-      if source.is_a?(String) && !source.valid_encoding?
+      unless source.valid_encoding?
         raise SyntaxError, parse_context.locale.t("errors.syntax.invalid_template_encoding")
       end
 

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -108,7 +108,7 @@ module Liquid
     def parse(source, options = {})
       parse_context = configure_options(options)
 
-      unless source.valid_encoding?
+      if source.is_a?(String) && !source.valid_encoding?
         raise SyntaxError, parse_context.locale.t("errors.syntax.invalid_template_encoding")
       end
 

--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -5,7 +5,7 @@ module Liquid
     attr_reader :line_number, :for_liquid_tag
 
     def initialize(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
-      @source         = source.to_s.to_str
+      @source         = source
       @line_number    = line_number || (line_numbers ? 1 : nil)
       @for_liquid_tag = for_liquid_tag
       @offset         = 0

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -349,4 +349,9 @@ class TemplateTest < Minitest::Test
 
     assert_equal('Liquid syntax error: Invalid template encoding', e.message)
   end
+
+  def test_allows_nil_as_source
+    template = Template.parse(nil)
+    assert_equal('', template.render)
+  end
 end

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -350,8 +350,9 @@ class TemplateTest < Minitest::Test
     assert_equal('Liquid syntax error: Invalid template encoding', e.message)
   end
 
-  def test_allows_nil_as_source
-    template = Template.parse(nil)
-    assert_equal('', template.render)
+  def test_allows_non_string_values_as_source
+    assert_equal('', Template.parse(nil).render)
+    assert_equal('1', Template.parse(1).render)
+    assert_equal('true', Template.parse(true).render)
   end
 end


### PR DESCRIPTION
### What are you trying to solve?

https://github.com/Shopify/liquid/pull/1774 introduced a bug that doesn't allow non-string values such as `nil` or `Integer` as a template source.

Expected behaviour:
```ruby
require 'liquid'

Liquid::Template.parse(nil).render # => ""
Liquid::Template.parse(1).render # => "1"
```

### How are you solving this?

This PR updates the `Template#parse` to only check the template's validity if the template is a `String`