### PR TITLE
Add bigdecimal as a dependency to gemspec

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -28,9 +28,7 @@ Gem::Specification.new do |s|
 
   s.require_path = "lib"
 
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4')
-    s.add_dependency('bigdecimal', '~> 3.1')
-  end
+  s.add_dependency('bigdecimal', '~> 3.1')
 
   s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('minitest')


### PR DESCRIPTION
This PR adds `bigdecimal` as a dependency in the `liquid` gemspec file.

While using Ruby 3.3.0, I encountered this warning related to the `liquid` package.

`/Users/my_name/.gem/ruby/3.3.0/gems/liquid-4.0.4/lib/liquid/standardfilters.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of liquid-4.0.4 to add bigdecimal into its gemspec.`

I have chosen version 3.1 for `bigdecimal` to start, but there should be a different version that should be more appropriate.