### PR TITLE
update variable's context before invoking its to_liquid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,6 @@ group :test do
   gem 'rubocop-performance', require: false
 
   platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'master'
+    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'main'
   end
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -197,10 +197,14 @@ module Liquid
         try_variable_find_in_environments(key, raise_on_not_found: raise_on_not_found)
       end
 
-      variable         = variable.to_liquid
+      # update variable's context before invoking #to_liquid
       variable.context = self if variable.respond_to?(:context=)
 
-      variable
+      liquid_variable = variable.to_liquid
+
+      liquid_variable.context = self if variable != liquid_variable && liquid_variable.respond_to?(:context=)
+
+      liquid_variable
     end
 
     def lookup_and_evaluate(obj, key, raise_on_not_found: true)

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -36,6 +36,24 @@ class Category
   end
 end
 
+class ProductsDrop < Liquid::Drop
+  def initialize(products)
+    @products = products
+  end
+
+  def size
+    @products.size
+  end
+
+  def to_liquid
+    if @context["forloop"]
+      @products.first(@context["forloop"].length)
+    else
+      @products
+    end
+  end
+end
+
 class CategoryDrop < Liquid::Drop
   attr_accessor :category, :context
 
@@ -633,6 +651,25 @@ class ContextTest < Minitest::Test
     c = Context.new({}, {}, r)
     assert_instance_of(Registers, c.registers)
     assert_equal(:my_value, c.registers[:my_register])
+  end
+
+  def test_variable_to_liquid_returns_contextual_drop
+    context = {
+      "products" => ProductsDrop.new(["A", "B", "C", "D", "E"]),
+    }
+
+    template = Liquid::Template.parse(<<~LIQUID)
+      {%- for i in (1..3) -%}
+        for_loop_products_count: {{ products | size }}
+      {% endfor %}
+
+      unscoped_products_count: {{ products | size }}
+    LIQUID
+
+    result = template.render(context)
+
+    assert_includes(result, "for_loop_products_count: 3")
+    assert_includes(result, "unscoped_products_count: 5")
   end
 
   private


### PR DESCRIPTION
### What are you trying to solve?

Liquid-C PR: https://github.com/Shopify/liquid-c/pull/212 (Liquid-C PR needs to be merged first)

On variable lookups, `Context` is invoking the drop's `to_liquid` function, and update the values `context`  to itself.

This becomes problematic if the drop's `to_liquid` has some contextual checks:

```ruby
require 'liquid'

class ProductsDrop < Liquid::Drop
  def initialize(products)
    @products = products
  end

  def size
    @products.size
  end

  def to_liquid
    if @context["forloop"]
      @products.first(@context["forloop"].length)
    else
      @products
    end
  end
end

context = {
  "products" => ProductsDrop.new(["A", "B", "C", "D", "E"]),
}

template = Liquid::Template.parse(<<~LIQUID)
  {% for i in (1..3) %}
    for-loop: {{ products | size }} # returns 3
  {% endfor %}

  {{ products }} # it still returns 3 instead of 5
LIQUID

puts template.render(context)
```

We could solve issue by updating the `Context#find_variable` to update the drop's `context` before invoking its `to_liquid` method.