### PR TITLE
Fallback to binary comparison when `contains` RHS is  UTF8 encoded

### DIFF
--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -24,6 +24,9 @@ module Liquid
         else
           false
         end
+      rescue Encoding::CompatibilityError
+        # "✅".b.include?("✅") raises Encoding::CompatibilityError despite being materially equal
+        left.b.include?(right.b)
       end,
     }
 

--- a/test/unit/condition_unit_test.rb
+++ b/test/unit/condition_unit_test.rb
@@ -55,6 +55,11 @@ class ConditionUnitTest < Minitest::Test
     assert_evaluates_false('bob', 'contains', '---')
   end
 
+  def test_contains_binary_encoding_compatibility_with_utf8
+    assert_evaluates_true('🙈'.b, 'contains', '🙈')
+    assert_evaluates_true('🙈', 'contains', '🙈'.b)
+  end
+
   def test_invalid_comparation_operator
     assert_evaluates_argument_error(1, '~~', 0)
   end
@@ -166,14 +171,14 @@ class ConditionUnitTest < Minitest::Test
   def assert_evaluates_true(left, op, right)
     assert(
       Condition.new(left, op, right).evaluate(@context),
-      "Evaluated false: #{left} #{op} #{right}",
+      "Evaluated false: #{left.inspect} #{op} #{right.inspect}",
     )
   end
 
   def assert_evaluates_false(left, op, right)
     assert(
       !Condition.new(left, op, right).evaluate(@context),
-      "Evaluated true: #{left} #{op} #{right}",
+      "Evaluated true: #{left.inspect} #{op} #{right.inspect}",
     )
   end
 


### PR DESCRIPTION
Base64 decoding of strings always results in a `Encoding::BINARY` string result. Unfortunately, this means the `contains` operator will throw an `Encoding::CompatibilityError` whenever we attempt to compare the decoded result against a UTF8 string. 

```liquid
{% assign cuties = "🙈 🙉" | base64_encode | base64_decode %}

{% if cuties contains "🙈" %}
  😻
{% endif %}
```

Today, the result of the above templates is:

```html
Liquid error (templates/index line 3): internal
```

But what about this template?

```liquid
{% assign alphabet = "abcdef 🔤" | base64_encode | base64_decode %}

{% if alphabet contains "abc" %}
  Next time won't you sing with me?
{% endif %}
```

If you don't know off the top of your head, you're in good company. Neither did I.

```
  Next time won't you sing with me?
```

Obviously, throwing an internal error is not ideal. Instead, let's fallback to binary comparison of the string since that seems to me like the most "unsuprising" thing to do here. 