### PR TITLE
Add an ontional limit argument to split filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -284,11 +284,13 @@ module Liquid
     # @liquid_type filter
     # @liquid_category string
     # @liquid_summary
-    #   Splits a string into an array of substrings based on a given separator.
+    #   Splits a string into an array of substrings based on a given separator and an optional limit number
     # @liquid_syntax string | split: string
     # @liquid_return [array[string]]
-    def split(input, pattern)
-      input.to_s.split(pattern.to_s)
+    def split(input, pattern, limit = nil)
+      limit = limit.respond_to?(:to_i) ? limit.to_i : 0
+
+      input.to_s.split(pattern.to_s, limit.to_i)
     end
 
     # @liquid_public_docs

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -150,6 +150,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal(['A?Z'], @filters.split('A?Z', '~'))
     assert_equal([], @filters.split(nil, ' '))
     assert_equal(['A', 'Z'], @filters.split('A1Z', 1))
+    assert_equal(['a', 'b', 'c,d,e'], @filters.split('a,b,c,d,e', ',', 3))
   end
 
   def test_escape


### PR DESCRIPTION
This PR adds an optional limit argument to the `split` filter in Liquid to make it work similar to the Ruby `split` method.

Closes #1800  