### PR TITLE
Add `remove_last`, `replace_last` documentation

### DIFF
--- a/_filters/remove_last.md
+++ b/_filters/remove_last.md
@@ -1,0 +1,19 @@
+---
+title: remove_last
+description: Liquid filter that removes the last occurence of a given substring from a string.
+version-badge: 5.2.0
+---
+
+Removes only the last occurrence of the specified substring from a string.
+
+<p class="code-label">Input</p>
+```liquid
+{%- raw -%}
+{{ "I strained to see the train through the rain" | remove_last: "rain" }}
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```text
+I strained to see the train through the
+```

--- a/_filters/replace_last.md
+++ b/_filters/replace_last.md
@@ -1,0 +1,19 @@
+---
+title: replace_last
+description: Liquid filter that replaces the last occurrence of a given substring in a string.
+version-badge: 5.2.0
+---
+
+Replaces only the last occurrence of the first argument in a string with the second argument.
+
+<p class="code-label">Input</p>
+```liquid
+{%- raw -%}
+{{ "Take my protein pills and put my helmet on" | replace_last: "my", "your" }}
+{% endraw %}
+```
+
+<p class="code-label">Output</p>
+```text
+Take my protein pills and put your helmet on
+```


### PR DESCRIPTION
Adds documentation for `remove_last` and `replace_last` filters [added in 5.2.0](https://github.com/Shopify/liquid/pull/1422). Content is adapted from `remove_first` and `replace_first` filter pages.