### PR TITLE
Bump to v5.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    liquid (5.5.0)
+    liquid (5.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.5.0"
+  VERSION = "5.5.1"
 end


### PR DESCRIPTION
Minimal changes in this patch release:

https://github.com/Shopify/liquid/compare/v5.5.0..6af0863265dafa02ae04237722aaa0d5a67e4ea1