### PR TITLE
Handle interrupts in table row

### DIFF
--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -65,6 +65,12 @@ module Liquid
           super
           output << '</td>'
 
+          # Handle any interrupts if they exist.
+          if context.interrupt?
+            interrupt = context.pop_interrupt
+            break if interrupt.is_a?(BreakInterrupt)
+          end
+
           if tablerowloop.col_last && !tablerowloop.last
             output << "</tr>\n<tr class=\"row#{tablerowloop.row + 1}\">"
           end


### PR DESCRIPTION
`tablerow` behaves very similarly to a `for` loop but does not handle interrupts. Interrupts in the `BlockBody` of a `Tablerow` tag will stop rendering the block body but will continue to loop through the entire collection, even with pending interrupts. This is because `Tablerow` does not check for and pop interrupts.

The effect of this is the full collection will be iterated and it's possible, if the first node in the `Tablerow`'s body is a `continue` or `break`, that the interrupts keep stacking (since `BlockBody` only checks interrupts _after_ rendering the node). This behaviour can lead to causing outer loops to prematurely exit due to stacked/leaked interrupts.

In this PR, I propose we treat `Tablerow` like a loop which means it needs to pop and handle interrupts. `continue` interrupts are popped but ignored because we still want to output the appropriate `</tr>` strings before continuing to the next iteration.

This is a small behaviour change that would shift handling interrupts inside `Tablerow` bodies to the `Tablerow` itself instead of a `For` loop that may enclose it. That said, I believe this is the more expected behaviour.