### PR TITLE
Bump to v5.6.0.alpha

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    liquid (5.5.1)
+    liquid (5.6.0.alpha)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.5.1"
+  VERSION = "5.6.0.alpha"
 end


### PR DESCRIPTION
Next minor release will be 5.6, tagging it as alpha now to allow for `github:` semver when using bundler