### PR TITLE
Update liquid docs for named parameters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -877,7 +877,7 @@ module Liquid
     #   - [`nil`](/docs/api/liquid/basics#nil)
     # @liquid_syntax variable | default: variable
     # @liquid_return [untyped]
-    # @liquid_optional_param allow_false [boolean] Whether to use false values instead of the default.
+    # @liquid_optional_param allow_false: [boolean] Whether to use false values instead of the default.
     def default(input, default_value = '', options = {})
       options = {} unless options.is_a?(Hash)
       false_check = options['allow_false'] ? input.nil? : !Liquid::Utils.to_liquid_value(input)


### PR DESCRIPTION
The YARD liquid gem now supports specifying named parameters. For the core liquid tags and filters this is the only object I could find that needed to be updated.

To specify a named parameter you need to add a `:` to the end of the name:

```ruby
# @liquid_optional_param foo [string] This is a positional parameter
# @liquid_optional_param bar: [string] This is a named parameter
```

Adding a colon will make sure that the newly added `positional` attribute in the JSON docs will be set to `false`.