### PR TITLE
Faster Variable BlockBody Matching

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -251,8 +251,9 @@ module Liquid
         i = 3 if token[i] == "-"
         parse_end = token.length - 3
         parse_end -= 1 if token[parse_end] == "-"
+        markup_end = parse_end - i + 1
+        markup = markup_end <= 0 ? "" : token.byteslice(i, markup_end)
 
-        markup = token[i..parse_end]
         return Variable.new(markup, parse_context)
       end
 

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -246,10 +246,16 @@ module Liquid
     end
 
     def create_variable(token, parse_context)
-      if token =~ ContentOfVariable
-        markup = Regexp.last_match(1)
+      if token.end_with?("}}")
+        i = 2
+        i = 3 if token[i] == "-"
+        parse_end = token.length - 3
+        parse_end -= 1 if token[parse_end] == "-"
+
+        markup = token[i..parse_end]
         return Variable.new(markup, parse_context)
       end
+
       BlockBody.raise_missing_variable_terminator(token, parse_context)
     end
 


### PR DESCRIPTION
Benchmark testing result:
```bash
bundle exec rake benchmark:run 
```

Before:
```
ruby 3.4.0dev (2024-04-23T16:59:11Z v3.4.0-pshopify-pr.. 70b931820e) +YJIT [arm64-darwin23]
Warming up --------------------------------------
              parse:    10.000 i/100ms
             render:    72.000 i/100ms
     parse & render:     8.000 i/100ms
Calculating -------------------------------------
              parse:     97.222 (± 1.0%) i/s   (10.29 ms/i) -    980.000 in  10.081357s
             render:    695.303 (± 2.7%) i/s    (1.44 ms/i) -      6.984k in  10.053073s
     parse & render:     81.088 (± 2.5%) i/s   (12.33 ms/i) -    816.000 in  10.069440s
```

After:
```
ruby 3.4.0dev (2024-04-23T16:59:11Z v3.4.0-pshopify-pr.. 70b931820e) +YJIT [arm64-darwin23]
Warming up --------------------------------------
              parse:    10.000 i/100ms
             render:    70.000 i/100ms
     parse & render:     8.000 i/100ms
Calculating -------------------------------------
              parse:    101.534 (± 0.0%) i/s    (9.85 ms/i) -      1.020k in  10.046007s
             render:    687.268 (± 1.3%) i/s    (1.46 ms/i) -      6.930k in  10.084962s
     parse & render:     84.576 (± 2.4%) i/s   (11.82 ms/i) -    848.000 in  10.033386s
```

This PR improves the parsing speed by ~4%