### PR TITLE
fix parsing Variable blockbody with multibyte character

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -252,7 +252,7 @@ module Liquid
         parse_end = token.length - 3
         parse_end -= 1 if token[parse_end] == "-"
         markup_end = parse_end - i + 1
-        markup = markup_end <= 0 ? "" : token.byteslice(i, markup_end)
+        markup = markup_end <= 0 ? "" : token.slice(i, markup_end)
 
         return Variable.new(markup, parse_context)
       end

--- a/test/unit/block_unit_test.rb
+++ b/test/unit/block_unit_test.rb
@@ -32,6 +32,12 @@ class BlockUnitTest < Minitest::Test
     assert_equal(String, template.root.nodelist[2].class)
   end
 
+  def test_variable_with_multibyte_character
+    template = Liquid::Template.parse("{{ '❤️' }}")
+    assert_equal(1, template.root.nodelist.size)
+    assert_equal(Variable, template.root.nodelist[0].class)
+  end
+
   def test_variable_many_embedded_fragments
     template = Liquid::Template.parse("  {{funk}} {{so}} {{brother}} ")
     assert_equal(7, template.root.nodelist.size)


### PR DESCRIPTION
PR https://github.com/Shopify/liquid/pull/1833 introduced a parsing bug.
When a Variable block body has a multi-byte character, `BlockBody#create_variable` returns a incomplete markup because it uses `String#byteslice` 