### PR TITLE
fix lexer parsing ID 'contains' as comparison

### DIFF
--- a/lib/liquid/lexer.rb
+++ b/lib/liquid/lexer.rb
@@ -73,7 +73,6 @@ module Liquid
     COMPARISON_LESS_THAN = [:comparison, "<"].freeze
     COMPARISON_LESS_THAN_OR_EQUAL = [:comparison, "<="].freeze
     COMPARISON_NOT_EQUAL_ALT = [:comparison, "<>"].freeze
-    CONTAINS = /contains(?=\s)/
     DASH = [:dash, "-"].freeze
     DOT = [:dot, "."].freeze
     DOTDOT = [:dotdot, ".."].freeze
@@ -212,7 +211,7 @@ module Liquid
 
           if type && (t = @ss.scan(pattern))
             # Special case for "contains"
-            @output << if type == :id && t == "contains"
+            @output << if type == :id && t == "contains" && @output.last&.first != :dot
               COMPARISON_CONTAINS
             else
               [type, t]

--- a/test/unit/lexer_unit_test.rb
+++ b/test/unit/lexer_unit_test.rb
@@ -95,4 +95,11 @@ class LexerUnitTest < Minitest::Test
       error.message,
     )
   end
+
+  def test_contains_as_attribute_name
+    assert_equal(
+      [[:id, "a"], [:dot, "."], [:id, "contains"], [:dot, "."], [:id, "b"], [:end_of_string]],
+      Lexer.new("a.contains.b").tokenize,
+    )
+  end
 end


### PR DESCRIPTION
With the new `Lexer` parser, we are always parsing `contains` as a `comparison` when it could also be an `id`.

Example:
```liquid
Lexer.new("a.contains.b").tokenize
```

Expected output:
```ruby
[[:id, "a"], [:dot, "."], [:id, "contains"], [:dot, "."], [:id, "b"], [:end_of_string]]
```

Current output
```ruby
[[:id, "a"], [:dot, "."], [:comparison, "contains"], [:dot, "."], [:id, "b"], [:end_of_string]]
```