### PR TITLE
propagate Environment on new Context creation

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -19,7 +19,7 @@ module Liquid
 
     # rubocop:disable Metrics/ParameterLists
     def self.build(environment: Environment.default, environments: {}, outer_scope: {}, registers: {}, rethrow_errors: false, resource_limits: nil, static_environments: {}, &block)
-      new(environments, outer_scope, registers, rethrow_errors, resource_limits, static_environments, &block)
+      new(environments, outer_scope, registers, rethrow_errors, resource_limits, static_environments, environment, &block)
     end
 
     def initialize(environments = {}, outer_scope = {}, registers = {}, rethrow_errors = false, resource_limits = nil, static_environments = {}, environment = Environment.default)
@@ -143,6 +143,7 @@ module Liquid
       check_overflow
 
       self.class.build(
+        environment: @environment,
         resource_limits: resource_limits,
         static_environments: static_environments,
         registers: Registers.new(registers),

--- a/test/integration/context_test.rb
+++ b/test/integration/context_test.rb
@@ -672,6 +672,21 @@ class ContextTest < Minitest::Test
     assert_includes(result, "unscoped_products_count: 5")
   end
 
+  def test_new_isolated_context_inherits_parent_environment
+    global_environment = Liquid::Environment.build(tags: {})
+    context = Context.build(environment: global_environment)
+
+    subcontext = context.new_isolated_subcontext
+    assert_equal(global_environment, subcontext.environment)
+  end
+
+  def test_newly_built_context_inherits_parent_environment
+    global_environment = Liquid::Environment.build(tags: {})
+    context = Context.build(environment: global_environment)
+    assert_equal(global_environment, context.environment)
+    assert(context.environment.tags.each.to_a.empty?)
+  end
+
   private
 
   def assert_no_object_allocations


### PR DESCRIPTION
closes https://github.com/Shopify/liquid/issues/1820

On creating a new `Context`, propagate the `Environment` 