### PR TITLE
Remove `Liquid.cache_classes` option

### DIFF
--- a/lib/liquid.rb
+++ b/lib/liquid.rb
@@ -44,9 +44,6 @@ module Liquid
   VariableParser              = /\[(?>[^\[\]]+|\g<0>)*\]|#{VariableSegment}+\??/o
 
   RAISE_EXCEPTION_LAMBDA = ->(_e) { raise }
-
-  singleton_class.send(:attr_accessor, :cache_classes)
-  self.cache_classes = true
 end
 
 require "liquid/version"

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -20,25 +20,6 @@ class TemplateUnitTest < Minitest::Test
     assert_equal(fixture("en_locale.yml"), locale.path)
   end
 
-  def test_with_cache_classes_tags_returns_the_same_class
-    original_cache_setting = Liquid.cache_classes
-    Liquid.cache_classes   = true
-
-    original_klass = Class.new
-    Object.send(:const_set, :CustomTag, original_klass)
-    Template.register_tag('custom', CustomTag)
-
-    Object.send(:remove_const, :CustomTag)
-
-    new_klass = Class.new
-    Object.send(:const_set, :CustomTag, new_klass)
-
-    assert(Template.tags['custom'].equal?(original_klass))
-  ensure
-    Object.send(:remove_const, :CustomTag)
-    Liquid.cache_classes = original_cache_setting
-  end
-
   class FakeTag; end
 
   def test_tags_can_be_looped_over


### PR DESCRIPTION
This no longer does anything now that we've `Liquid::TagRegistry` in #1845 