### PR TITLE
Write one value at a time for array variables

### DIFF
--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -97,7 +97,7 @@ module Liquid
       obj = render(context)
 
       if obj.is_a?(Array)
-        output << obj.join
+        obj.each { |o| output << o.to_s }
       elsif obj.nil?
       else
         output << obj.to_s


### PR DESCRIPTION
Slight optimization: this approach avoids creating an unnecessary intermediate buffer.