### PR TITLE
Stop testing against `liquid-c`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,4 @@ group :test do
   gem 'rubocop', '~> 1.61.0'
   gem 'rubocop-shopify', '~> 2.12.0', require: false
   gem 'rubocop-performance', require: false
-
-  platform :mri, :truffleruby do
-    gem 'liquid-c', github: 'Shopify/liquid-c', ref: 'main'
-  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,8 +43,6 @@ task :test do
   Rake::Task['base_test'].invoke
 
   if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'truffleruby'
-    ENV['LIQUID_C'] = '1'
-
     ENV['LIQUID_PARSER_MODE'] = 'lax'
     Rake::Task['integration_test'].reenable
     Rake::Task['integration_test'].invoke

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.6.0.rc1"
+  VERSION = "5.6.0.rc2"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,11 +15,6 @@ if (env_mode = ENV['LIQUID_PARSER_MODE'])
 end
 Liquid::Environment.default.error_mode = mode
 
-if ENV['LIQUID_C'] == '1'
-  puts "-- LIQUID C"
-  require 'liquid/c'
-end
-
 if Minitest.const_defined?('Test')
   # We're on Minitest 5+. Nothing to do here.
 else


### PR DESCRIPTION
It doesn't make sense to test against `liquid-c` in this repo, it just adds complexity.