### PR TITLE
Fix bug in tokenizer with nil source value

### DIFF
--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -5,7 +5,7 @@ module Liquid
     attr_reader :line_number, :for_liquid_tag
 
     def initialize(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
-      @source         = source
+      @source         = source.to_s
       @line_number    = line_number || (line_numbers ? 1 : nil)
       @for_liquid_tag = for_liquid_tag
       @offset         = 0

--- a/test/unit/tokenizer_unit_test.rb
+++ b/test/unit/tokenizer_unit_test.rb
@@ -30,6 +30,10 @@ class TokenizerTest < Minitest::Test
     assert_equal([1, 1, 3], tokenize_line_numbers(" {{\n funk \n}} "))
   end
 
+  def test_tokenize_with_nil_source_returns_empty_array
+    assert_equal([], tokenize(nil))
+  end
+
   private
 
   def new_tokenizer(source, parse_context: Liquid::ParseContext.new, start_line_number: nil)


### PR DESCRIPTION
Resolves https://github.com/Shopify/shopify/issues/560829

Fixes the Tokenizer to handle `source` with `null` value gracefully. The longer explanation can be found in this [comment](https://github.com/Shopify/shopify/issues/560829#issuecomment-2548695386) as I was investigating a Bugsnag exception. 

**Tl;Dr**
The Tokenizer isn't currently resilient to `source` with `nil` value.  Liquid C does a graceful conversion [here](https://github.com/Shopify/liquid-c/blob/main/lib/liquid/c.rb#L77). This has been causing a lot of exception when we run liquid ruby and the asset value is nil. I followed the same pattern as Liquid C tokenizer to convert nil to empty string.  

### Test 
I added a test and able to reproduce the exception with the test (before adding the fix).

**Before**

The new test fails with an exception. `Tokenizer.new(nil).tokenize` raises: 
```
NoMethodError: undefined method `empty?' for nil
    lib/liquid/tokenizer.rb:31:in `tokenize'
    lib/liquid/tokenizer.rb:12:in `initialize'
    .....
```
**After**

The new test passes. `Tokenizer.new(nil).tokenize` returns `[]`.