### PR TITLE
[4.0] add bigdecimal to gemspec for ruby 3.4

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
+  s.add_dependency("bigdecimal")
+
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
`bigdecimal` was removed from stdlib in Ruby 3.4 and liquid fails to be loaded:

```
0.679 /usr/local/bundle/gems/liquid-4.0.4/lib/liquid/standardfilters.rb:2:in 'Kernel#require': cannot load such file -- bigdecimal (LoadError)                                                                     
0.679   from /usr/local/bundle/gems/liquid-4.0.4/lib/liquid/standardfilters.rb:2:in '<top (required)>'
0.679   from /usr/local/bundle/gems/liquid-4.0.4/lib/liquid.rb:72:in 'Kernel#require'
0.679   from /usr/local/bundle/gems/liquid-4.0.4/lib/liquid.rb:72:in '<top (required)>'
0.679   from /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll.rb:35:in 'Kernel#require'
```

Fixes https://github.com/Shopify/liquid/issues/1772 which also mentions `base64`, but the later is not directly used by liquid thus not added.

Similar pull request but targeted at main which already has the change (`5.x` releases [have the depenency](https://github.com/Shopify/liquid/blob/v5.6.0/liquid.gemspec#L32)), can likely be closed: https://github.com/Shopify/liquid/pull/1779