### PR TITLE
float has to start with a digit

### DIFF
--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -79,10 +79,17 @@ module Liquid
         end
 
         ss.string = markup
-        # the first byte must be a digit, a period, or  a dash
+        # the first byte must be a digit or  a dash
         byte = ss.scan_byte
 
-        return false if byte != DASH && byte != DOT && (byte < ZERO || byte > NINE)
+        return false if byte != DASH && (byte < ZERO || byte > NINE)
+
+        if byte == DASH
+          peek_byte = ss.peek_byte
+
+          # if it starts with a dash, the next byte must be a digit
+          return false if peek_byte.nil? || !(peek_byte >= ZERO && peek_byte <= NINE)
+        end
 
         # The markup could be a float with multiple dots
         first_dot_pos = nil

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.6.1"
+  VERSION = "5.6.2"
 end

--- a/test/integration/expression_test.rb
+++ b/test/integration/expression_test.rb
@@ -26,7 +26,16 @@ class ExpressionTest < Minitest::Test
   def test_float
     assert_template_result("-17.42", "{{ -17.42 }}")
     assert_template_result("2.5", "{{ 2.5 }}")
+    assert_expression_result(0.0, "0.....5")
+    assert_expression_result(0.0, "-0..1")
     assert_expression_result(1.5, "1.5")
+
+    # this is a unfortunate quirky behavior of Liquid
+    result = Expression.parse(".5")
+    assert_kind_of(Liquid::VariableLookup, result)
+
+    result = Expression.parse("-.5")
+    assert_kind_of(Liquid::VariableLookup, result)
   end
 
   def test_range


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/1844 introduced a new parsing behaviour which parsed the string like `.05` to a Float instead of a `VariableLookup`

Even, the new behaviour seems like a correct behaviour, it will break existing Shopify themes.
Therefore, the Expression parser needs to preserve the old parsing behaviour. 