### PR TITLE
Add default string_scanner to `Liquid::VariableLookup.parse`

### DIFF
--- a/lib/liquid/variable_lookup.rb
+++ b/lib/liquid/variable_lookup.rb
@@ -6,7 +6,7 @@ module Liquid
 
     attr_reader :name, :lookups
 
-    def self.parse(markup, string_scanner, cache = nil)
+    def self.parse(markup, string_scanner = StringScanner.new(""), cache = nil)
       new(markup, string_scanner, cache)
     end
 

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.6.3"
+  VERSION = "5.6.4"
 end


### PR DESCRIPTION
This change unintentionally broke code that relied on `Liquid::VariableLookup.parse("foo.bar")` (without a string scanner arg).