### PR TITLE
Bump to 5.7.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,5 +30,7 @@
 ## Releasing
 
 * Bump the version in `lib/liquid/version.rb` and merge it on `main`
+* Update the `History.md` file
+* Open a PR like [this one](https://github.com/Shopify/liquid/pull/1894) and merge it
 * Create a new release using the [GitHub UI](https://github.com/Shopify/liquid/releases/new)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@
 
 ## Releasing
 
-* Bump the version in `lib/liquid/version.rb` and merge it on `main`
+* Bump the version in `lib/liquid/version.rb`
 * Update the `History.md` file
-* Open a PR like [this one](https://github.com/Shopify/liquid/pull/1894) and merge it
+* Open a PR like [this one](https://github.com/Shopify/liquid/pull/1894) and merge it to `main`
 * Create a new release using the [GitHub UI](https://github.com/Shopify/liquid/releases/new)
 

--- a/History.md
+++ b/History.md
@@ -6,6 +6,7 @@
 
 ### Features
 * Add `find`, `find_index`, `has`, and `reject` filters to arrays
+* Compatibility with Ruby 3.4
 
 ## 5.6.4 2025-01-14
 

--- a/History.md
+++ b/History.md
@@ -1,11 +1,52 @@
 # Liquid Change Log
 
-## 5.6.0 (unreleased)
+## 5.8.0 (unreleased)
+
+## 5.7.0 2025-01-16
+
+### Features
+* Add `find`, `find_index`, `has`, and `reject` filters to arrays
+
+## 5.6.4 2025-01-14
 
 ### Fixes
+* Add a default `string_scanner` to avoid errors with `Liquid::VariableLookup.parse("foo.bar")` [Ian Ker-Seymer]
 
+## 5.6.3 2025-01-13
+* Remove `lru_redux` dependency [Michael Go]
+
+## 5.6.2 2025-01-13
+
+### Fixes
+* Preserve the old behavior of requiring floats to start with a digit [Michael Go]
+
+## 5.6.1 2025-01-13
+
+### Performance improvements
+* Faster Expression parser / Tokenizer with StringScanner [Michael Go]
+
+## 5.6.0 2024-12-19
+
+### Architectural changes
+* Added new `Environment` class to manage configuration and state that was previously stored in `Template` [Ian Ker-Seymer]
+* Moved tag registration from `Template` to `Environment` [Ian Ker-Seymer]
+* Removed `StrainerFactory` in favor of `Environment`-based strainer creation [Ian Ker-Seymer]
+* Consolidated standard tags into a new `Tags` module with `STANDARD_TAGS` constant [Ian Ker-Seymer]
+
+### Performance improvements
+* Optimized `Lexer` with a new `Lexer2` implementation using jump tables for faster tokenization, requires Ruby 3.4 [Ian Ker-Seymer]
+* Improved variable rendering with specialized handling for different types [Michael Go]
+* Reduced array allocations by using frozen empty constants [Michael Go]
+
+### API changes
+* Deprecated several `Template` class methods in favor of `Environment` methods [Ian Ker-Seymer]
+* Added deprecation warnings system [Ian Ker-Seymer]
+* Changed how filters and tags are registered to use Environment [Ian Ker-Seymer]
+
+### Fixes
+* Fixed table row handling of break interrupts [Alex Coco]
+* Improved variable output handling for arrays [Ian Ker-Seymer]
 * Fix Tokenizer to handle null source value (#1873) [Bahar Pourazar]
-
 
 ## 5.5.0 2024-03-21
 

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.6.5"
+  VERSION = "5.7.0"
 end


### PR DESCRIPTION
Bumping Liquid to 5.7.0 as the addition of [new filters](https://github.com/Shopify/liquid/pull/1869) in the standard library represents a minor bump.