### PR TITLE
Use `VariableLookup` instead of dot notation in standard array filters

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1007,10 +1007,10 @@ module Liquid
 
       return value if !value.nil? || !property_or_keys.is_a?(String)
 
-      keys = property_or_keys.split('.')
-      keys.reduce(drop) do |drop, key|
-        drop.respond_to?(:[]) ? drop[key] : drop
-      end
+      variable_lookup = Liquid::VariableLookup.parse("drop.#{property_or_keys}")
+      variable_lookup.evaluate(
+        Liquid::Context.new("drop" => drop),
+      )
     end
 
     def raise_property_error(property)

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -1337,6 +1337,30 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result(expected_output, template, { "products" => TestDeepEnumerable.new })
   end
 
+  def test_access_arrays
+    template = <<~LIQUID
+      {{- products | map: 'colors[0]["name"]' | join: ", " -}}
+    LIQUID
+    expected_output = "red, red, blue"
+
+    assert_template_result(expected_output, template, {
+      "products" => [
+        { "title" => { "content" => "Pro goggles" },    "colors" => [{ "name" => "red",  "hex" => "#ff0000" }] },
+        { "title" => { "content" => "Thermal gloves" }, "colors" => [{ "name" => "red",  "hex" => "#ff0000" }] },
+        { "title" => { "content" => "Alpine jacket" },  "colors" => [{ "name" => "blue", "hex" => "#0000ff" }] },
+      ],
+    })
+  end
+
+  def test_access_lookup_with_brackets
+    template = <<~LIQUID
+      {{- products | map: 'title["content"]' | join: ', ' -}}
+    LIQUID
+    expected_output = "Pro goggles, Thermal gloves, Alpine jacket, Mountain boots, Safety helmet"
+
+    assert_template_result(expected_output, template, { "products" => TestDeepEnumerable.new })
+  end
+
   private
 
   def with_timezone(tz)


### PR DESCRIPTION
Following @ianks' suggestion (https://github.com/Shopify/liquid/pull/1869/files#r1919321969), this PR updates standard array filters to use `Liquid::VariableLookup` instead of the dot notation convention.

I initially considered using `Liquid::VariableLookup`, but recognized that it opens the door to broader use cases like accessing arrays, which might not be ideal as mentioned here (https://github.com/Shopify/liquid/pull/1869#discussion_r1907113691).

However, in the interest of a consistent implementation, we see value in evaluating this approach, which is the goal of this PR :)





