### PR TITLE
Fix `bundle exec rake example`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,14 @@ group :benchmark, :test do
   gem 'memory_profiler'
   gem 'terminal-table'
   gem "lru_redux"
-  gem "webrick"
 
   install_if -> { RUBY_PLATFORM !~ /mingw|mswin|java/ && RUBY_ENGINE != 'truffleruby' } do
     gem 'stackprof'
   end
+end
+
+group :development do
+  gem "webrick"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :benchmark, :test do
   gem 'memory_profiler'
   gem 'terminal-table'
   gem "lru_redux"
+  gem "webrick"
 
   install_if -> { RUBY_PLATFORM !~ /mingw|mswin|java/ && RUBY_ENGINE != 'truffleruby' } do
     gem 'stackprof'


### PR DESCRIPTION
I frequently use the `bundle exec rake example` command to experiment with Liquid features, but we're missing `webrick` in the `Gemfile` to make it work as expected :)

Before:
![image](https://github.com/user-attachments/assets/7be44dc1-1e6f-4ac5-b403-884dc393beb9)

After:
![image](https://github.com/user-attachments/assets/e5b6415f-8dca-4ad9-a0f9-99f4e693c1c4)
