### PR TITLE
Fix array filters to not support nested properties

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,10 @@
 
 ## 5.8.0 (unreleased)
 
+## 5.7.2 2025-01-31
+
+* Fix array filters to not support nested properties
+
 ## 5.7.1 2025-01-24
 
 * Fix the `find` and `find_index`filters to return `nil` when filtering empty arrays

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.7.1"
+  VERSION = "5.7.2"
 end


### PR DESCRIPTION
This PR removes support for nested properties.

We have conducted additional assessments regarding the backward compatibility aspect of this change and discovered it is not 100% backward compatible with all runtimes and temples. We are keeping the new filters, but nested properties will be re-assessed and implemented by https://github.com/Shopify/liquid/issues/1906.

We have [valuable concerns](https://github.com/Shopify/liquid/pull/1899#issuecomment-2598286898) raised by the community, along with [powerful alternatives](https://github.com/jg-rp/python-liquid2/issues/15) that warrant deeper consideration.

Nested properties must still be supported, but they will not be part of 5.7.x, as the required work is more significant than initially stated.