### PR TITLE
Implement nodelist in the Doc tag so it may be visited

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,10 @@
 
 ## 5.8.1 (unreleased)
 
+## 5.8.1
+
+* Fix `{% doc %}` tag to be visitable [Guilherme Carreiro]
+
 ## 5.8.0
 
 * Introduce the new `{% doc %}` tag [Guilherme Carreiro]

--- a/lib/liquid/tags/doc.rb
+++ b/lib/liquid/tags/doc.rb
@@ -55,6 +55,10 @@ module Liquid
       true
     end
 
+    def nodelist
+      []
+    end
+
     private
 
     def ensure_valid_markup(tag_name, markup, parse_context)

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.8.0"
+  VERSION = "5.8.1"
 end

--- a/test/unit/tags/doc_tag_unit_test.rb
+++ b/test/unit/tags/doc_tag_unit_test.rb
@@ -157,4 +157,28 @@ class DocTagUnitTest < Minitest::Test
     assert_template_result('', "{% doc %}123{% enddoc\nxyz %}")
     assert_template_result('', "{% doc %}123{% enddoc\n   xyz  enddoc %}")
   end
+
+  def test_doc_tag_visitor
+    template_source = '{% doc %}{% enddoc %}'
+
+    assert_equal(
+      [Liquid::Doc],
+      visit(template_source),
+    )
+  end
+
+  private
+
+  def traversal(template)
+    ParseTreeVisitor
+      .for(Template.parse(template).root)
+      .add_callback_for(Liquid::Doc) do |tag|
+        tag_class = tag.class
+        tag_class
+      end
+  end
+
+  def visit(template)
+    traversal(template).visit.flatten.compact
+  end
 end


### PR DESCRIPTION
Implement `Liquid::Doc#tag` so the `{% doc %}` node may be visited.