### PR TITLE
Omit padding in base64_url_safe_encode filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -177,7 +177,7 @@ module Liquid
     # @liquid_syntax string | base64_url_safe_encode
     # @liquid_return [string]
     def base64_url_safe_encode(input)
-      Base64.urlsafe_encode64(Utils.to_s(input))
+      Base64.urlsafe_encode64(Utils.to_s(input), padding: false)
     end
 
     # @liquid_public_docs

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -212,6 +212,7 @@ class StandardFiltersTest < Minitest::Test
       'YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXogQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVogMTIzNDU2Nzg5MCAhQCMkJV4mKigpLT1fKy8_Ljo7W117fVx8',
       @filters.base64_url_safe_encode('abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 !@#$%^&*()-=_+/?.:;[]{}\|'),
     )
+    assert_equal('XyMvLg', @filters.base64_url_safe_encode('_#/.'))
     assert_equal('', @filters.base64_url_safe_encode(nil))
   end
 


### PR DESCRIPTION
Fixes #1862

`base64_url_safe_encode` should not render `=` characters. This change is compatible with already encoded strings, meaning `base64_url_safe_decode` will work on string encoded with the previous version that emitted padding characters.