### PR TITLE
Add a link to the LiquidDoc tooling reference in `doc` tag documentation

### DIFF
--- a/lib/liquid/tags/doc.rb
+++ b/lib/liquid/tags/doc.rb
@@ -15,7 +15,7 @@ module Liquid
   #   documentation.
   #
   #   For detailed documentation syntax and examples, see the
-  #   [`LiquidDoc` reference](/themes/tools/liquid-doc).
+  #   [`LiquidDoc` reference](/docs/storefronts/themes/tools/liquid-doc).
   #
   # @liquid_syntax
   #   {% doc %}


### PR DESCRIPTION
This will point users to LiquidDoc Reference which will ship with [this PR](https://github.com/Shopify/shopify-dev/pull/54338)

⚠️⚠️⚠️ I copied the reference URL from [here](https://github.com/search?q=repo%3AShopify%2Fliquid+%22%2Fthemes%2F%22&type=code)

Which [should work](https://shopify.dev/docs/api/liquid/tags/decrement)