### PR TITLE
Stringify properties before filtering arrays

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -979,8 +979,10 @@ module Liquid
     attr_reader :context
 
     def filter_array(input, property, target_value, default_value = [], &block)
-      ary = InputIterator.new(input, context)
+      property = Liquid::Utils.to_s(property)
+      return default_value if property.empty?
 
+      ary = InputIterator.new(input, context)
       return default_value if ary.empty?
 
       block.call(ary) do |item|

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -1061,6 +1061,19 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result(expected_output, template, { "array" => array })
   end
 
+  def test_where_with_non_string_property
+    array = [
+      { "handle" => "alpha", "{}" => true },
+      { "handle" => "beta", "{}" => false },
+      { "handle" => "gamma", "{}" => false },
+      { "handle" => "delta", "{}" => true },
+    ]
+    template = "{{ array | where: some_property, true | map: 'handle' | join: ' ' }}"
+    expected_output = "alpha delta"
+
+    assert_template_result(expected_output, template, { "array" => array, "some_property" => {} })
+  end
+
   def test_where_string_keys
     input = [
       "alpha", "beta", "gamma", "delta"


### PR DESCRIPTION
Previously, filtering code allowed would blindly pass the `property` when calling `#[]` on the target input. While this usually works, it falls apart with non-string keys and can lead to some strange behaviors:

```ruby
template = Liquid::Template.parse("{{ input | where: property, 0 }}")
template.render({ "input" => [5, 10, 15, 20], "property" => 1 }) # => "520"
template.render({ "input" => [5, 10, 15, 20], "property" => 0 }) # => "1020"
```

Let's just always coerce properties to strings, first.