### PR TITLE
Experiment: Hardcode parser to :strict everywhere

### DIFF
--- a/lib/liquid/environment.rb
+++ b/lib/liquid/environment.rb
@@ -4,10 +4,6 @@ module Liquid
   # The Environment is the container for all configuration options of Liquid, such as
   # the registered tags, filters, and the default error mode.
   class Environment
-    # The default error mode for all templates. This can be overridden on a
-    # per-template basis.
-    attr_accessor :error_mode
-
     # The tags that are available to use in the template.
     attr_accessor :tags
 
@@ -75,7 +71,7 @@ module Liquid
     # @api private
     def initialize
       @tags = Tags::STANDARD_TAGS.dup
-      @error_mode = :lax
+      @error_mode = :strict
       @strainer_template = Class.new(StrainerTemplate).tap do |klass|
         klass.add_filter(StandardFilters)
       end
@@ -83,6 +79,14 @@ module Liquid
       @file_system = BlankFileSystem.new
       @default_resource_limits = Const::EMPTY_HASH
       @strainer_template_class_cache = {}
+    end
+
+    def error_mode
+      :strict
+    end
+
+    def error_mode=(mode)
+      :strict
     end
 
     # Registers a new tag with the environment.

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -27,11 +27,11 @@ module Liquid
       # :strict will enforce correct syntax.
       def error_mode=(mode)
         Deprecations.warn("Template.error_mode=", "Environment#error_mode=")
-        Environment.default.error_mode = mode
+        Environment.default.error_mode = :strict
       end
 
       def error_mode
-        Environment.default.error_mode
+        :strict
       end
 
       def default_exception_renderer=(renderer)


### PR DESCRIPTION
This will be part of a Verifier experiment to monitor for impact of such a change away from lax parsing.

This is part of a larger plan to support boolean inline conditionals. We would like to assess how much liquid code would break if we started by increasing the strictness of the parsing alone.