### PR TITLE
Ensure liquid values when comparing using the spaceship operator

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1018,7 +1018,7 @@ module Liquid
     end
 
     def nil_safe_compare(a, b)
-      result = a <=> b
+      result = Utils.to_liquid_value(a) <=> Utils.to_liquid_value(b)
 
       if result
         result


### PR DESCRIPTION
Not doing this can cause argument errors on types that should be comparable (like `IntegerDrop`s).