### PR TITLE
Always return boolean in `has` filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -460,7 +460,7 @@ module Liquid
     # @liquid_syntax array | has: string, string
     # @liquid_return [boolean]
     def has(input, property, target_value = nil)
-      filter_array(input, property, target_value, false) { |ary, &block| ary.any?(&block) }
+      filter_array(input, property, target_value, false) { |ary, &block| ary.any?(&block) } || false
     end
 
     # @liquid_public_docs

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.8.3"
+  VERSION = "5.8.4"
 end

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -977,6 +977,12 @@ class StandardFiltersTest < Minitest::Test
     assert_template_result(expected_output, template, { "array" => array })
   end
 
+  def test_has_with_boolean_input
+    template = "Result: {{a0 | has: a1, a2}}"
+
+    assert_template_result("Result: false", template, { "a0" => false })
+  end
+
   def test_has_with_false_value_when_does_not_have_it
     array = [
       { "handle" => "alpha", "ok" => true },


### PR DESCRIPTION
Previously, `filter_array` could return `nil` in certain cases which breaks the expectation that `has` should return a boolean. This PR fixes that.