### PR TITLE
Fix JavaScript div id variable

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,7 +26,7 @@
 
     {%- if sections contains page.collection -%}
     <script type="text/javascript">
-        document.getElementById("{{ page.collection }}").scrollIntoView();
+        document.getElementById("{{ page.collection }}-section").scrollIntoView();
     </script>
     {%- endif -%}
   </nav>


### PR DESCRIPTION
Automatic scrolling wasn't working because of a wrong `div` id.