### PR TITLE
Remove {{ foo }} and {{ bar }} from `doc` tag description

### DIFF
--- a/lib/liquid/tags/doc.rb
+++ b/lib/liquid/tags/doc.rb
@@ -27,7 +27,6 @@ module Liquid
   #     @example
   #     {% render 'message', foo: 'Hello', bar: 'World' %}
   #   {% enddoc %}
-  #   {{ foo }}, {{ bar }}!
   class Doc < Block
     NO_UNEXPECTED_ARGS = /\A\s*\z/
 


### PR DESCRIPTION
Simply removes the  `#   {{ foo }}, {{ bar }}!` excerpt at the end of the description