### PR TITLE
Add `sort_numeric` filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1062,7 +1062,7 @@ module Liquid
     end
 
     def numbers(obj)
-      if obj.is_a?(Integer) || obj.is_a?(Float) || obj.is_a?(BigDecimal)
+      if obj.is_a?(Numeric)
         [obj]
       else
         numeric = obj.to_s.scan(/(?<=\.)0+|-?\d+/)

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -429,7 +429,7 @@ module Liquid
     # @liquid_type filter
     # @liquid_category array
     # @liquid_summary
-    #   Sorts an array by numerical values extracted from runs of digits within the string representation of each item.
+    #   Sorts an array by numerical values extracted from runs of digits within each item.
     # @liquid_syntax array | sort_numeric
     # @liquid_return [array[untyped]]
     def sort_numeric(input, property = nil)

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -102,6 +102,32 @@ class FiltersTest < Minitest::Test
     assert_equal('A b C', Template.parse("{{objects | sort_natural: 'a' | map: 'a' | join}}").render(@context))
   end
 
+  def test_sort_numeric
+    assert_template_result(
+      "1 2 3 10",
+      "{{ array | sort_numeric | join }}",
+      { "array" => ["10", "3", "1", "2"] },
+    )
+
+    assert_template_result(
+      "0001 02 17 042 107",
+      "{{ array | sort_numeric | join }}",
+      { "array" => ["107", "042", "0001", "02", "17"] },
+    )
+
+    assert_template_result(
+      "1 2 10",
+      "{{ hash | sort_numeric: 'a' | map: 'a' | join }}",
+      { "hash" => [{ "a" => "10" }, { "a" => 1 }, { "a" => "2" }] },
+    )
+
+    assert_template_result(
+      "v0.1 v1.1.0 v1.10",
+      "{{ objects | sort_numeric: 'a' | map: 'a' | join }}",
+      { "objects" => [TestObject.new("v0.1"), TestObject.new("v1.10"), TestObject.new("v1.1.0")] },
+    )
+  end
+
   def test_compact
     # Test strings
     assert_template_result(

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -425,6 +425,49 @@ class StandardFiltersTest < Minitest::Test
     assert_equal([{ "a" => "10" }, { "a" => "2" }], @filters.sort([{ "a" => "10" }, { "a" => "2" }], "a"))
   end
 
+  def test_sort_numeric
+    assert_equal([], @filters.sort_numeric([]))
+    assert_equal([1, 2, 3, 10], @filters.sort_numeric([10, 3, 1, 2]))
+    assert_equal(["1", "2", "3", "10"], @filters.sort_numeric(["10", "3", "1", "2"]))
+    assert_equal([1.01, 1.1, 2.3, 3.5, 10.1], @filters.sort_numeric([10.1, 3.5, 2.3, 1.1, 1.01]))
+    assert_equal(["1.01", "1.1", "2.3", "3.5", "10.1"], @filters.sort_numeric(["10.1", "3.5", "2.3", "1.1", "1.01"]))
+    assert_equal(["-1", "1"], @filters.sort_numeric(["1", "-1"]))
+    assert_equal(["1", "2", "3", "10", nil], @filters.sort_numeric(["10", "3", nil, "1", "2"]))
+    assert_equal(["v0.1", "v1.1.0", "v1.2", "v1.9", "v1.10", "v10.0"], @filters.sort_numeric(["v1.2", "v1.9", "v10.0", "v0.1", "v1.10", "v1.1.0"]))
+    assert_equal(["0001", "02", "17", "042", "107"], @filters.sort_numeric(["107", "042", "0001", "02", "17"]))
+    assert_equal(["7 The Street", "42 The Street", "101 The Street"], @filters.sort_numeric(["42 The Street", "7 The Street", "101 The Street"]))
+    assert_equal(["1", "2", "no numbers"], @filters.sort_numeric(["no numbers", "1", "2"]))
+    assert_equal(["1", 2, 3, "10"], @filters.sort_numeric(["10", 3, "1", 2]))
+    assert_equal([1, 2, 3], @filters.sort_numeric([[1], [3], [2]])) # nested arrays get flattened
+  end
+
+  def test_sort_numeric_with_property
+    assert_equal([], @filters.sort_numeric([], "a"))
+    assert_equal([{}], @filters.sort_numeric([{}], "a"))
+    assert_equal([{ "a" => 2 }, { "a" => 10 }], @filters.sort_numeric([{ "a" => 10 }, { "a" => 2 }], "a"))
+    assert_equal([{ "a" => "2" }, { "a" => "10" }], @filters.sort_numeric([{ "a" => "10" }, { "a" => "2" }], "a"))
+    assert_equal([{ "a" => "2" }, { "a" => "10" }, { "b" => "1" }], @filters.sort_numeric([{ "a" => "10" }, { "b" => "1" }, { "a" => "2" }], "a"))
+    assert_equal([{ "a" => 1 }, { "a" => "2" }, { "a" => "10" }], @filters.sort_numeric([{ "a" => "10" }, { "a" => 1 }, { "a" => "2" }], "a"))
+    assert_equal([1, 2, 3], @filters.sort_numeric([[1], [3], [2]]), "a")
+  end
+
+  def test_sort_numeric_input_is_not_an_array
+    assert_equal([], @filters.sort_numeric(nil))
+    assert_equal([true], @filters.sort_numeric(true))
+    assert_equal([false], @filters.sort_numeric(false))
+    assert_equal([42], @filters.sort_numeric(42))
+    assert_equal([42.5], @filters.sort_numeric(42.5))
+    assert_equal(["42.5"], @filters.sort_numeric("42.5"))
+    assert_equal([{ "a" => "42.5" }], @filters.sort_numeric({ "a" => "42.5" }))
+    assert_equal([], @filters.sort_numeric(nil, "a"))
+    assert_nil(@filters.sort_numeric(true, "a"))
+    assert_nil(@filters.sort_numeric(false, "a"))
+    assert_equal([42], @filters.sort_numeric(42, "a"))
+    assert_nil(@filters.sort_numeric(42.5, "a"))
+    assert_equal(["42.5"], @filters.sort_numeric("42.5", "a"))
+    assert_equal([{ "a" => "42.5" }], @filters.sort_numeric({ "a" => "42.5" }, "a"))
+  end
+
   def test_uniq
     assert_equal(["foo"], @filters.uniq("foo"))
     assert_equal([1, 3, 2, 4], @filters.uniq([1, 1, 3, 2, 3, 1, 4, 3, 2, 1]))

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -439,6 +439,7 @@ class StandardFiltersTest < Minitest::Test
     assert_equal(["1", "2", "no numbers"], @filters.sort_numeric(["no numbers", "1", "2"]))
     assert_equal(["1", 2, 3, "10"], @filters.sort_numeric(["10", 3, "1", 2]))
     assert_equal([1, 2, 3], @filters.sort_numeric([[1], [3], [2]])) # nested arrays get flattened
+    assert_equal([1.1, 2, BigDecimal(3), 10], @filters.sort_numeric([10, BigDecimal(3), 1.1, 2]))
   end
 
   def test_sort_numeric_with_property


### PR DESCRIPTION
This PR adds a `sort_numeric` filter. See also https://github.com/Shopify/liquid/pull/1028 and https://github.com/Shopify/liquid/issues/980.

`sort_numeric` sorts an array by numerical values extracted from runs of digits within the string representation of each item.

```ruby
require "liquid"

template = Liquid::Template.parse("{{ array | sort_numeric | join }}")

puts template.render({ "array" => ["v1.2", "v1.9", "v10.0", "v0.1", "v1.10", "v1.1.0"] })
# v0.1 v1.1.0 v1.2 v1.9 v1.10 v10.0

puts template.render({ "array" => ["107", "042", "0001", "02", "17"] })
# 0001 02 17 042 107

puts template.render({ "array" => ["10.1", "3.5", "2.3", "1.1", "1.01"] })
# 1.01 1.1 2.3 3.5 10.1
```