### PR TITLE
Add base64 dependency to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ end
 
 gemspec
 
-gem "base64"
-
 group :benchmark, :test do
   gem 'benchmark-ips'
   gem 'memory_profiler'

--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("strscan", ">= 3.1.1")
   s.add_dependency("bigdecimal")
+  s.add_dependency("base64")
 
   s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('minitest')


### PR DESCRIPTION
`base64` is already removed starting from Ruby 3.4. We have to add this to gemspec. Otherwise, projects using Ruby 3.4 depending on `liquid` need to manually add `base64` to their Gemfile.

Closes #1772. In that issue, @olegantonyan says he did not open a PR to add `base64` to gemspec because there were no dependencies in gemspec at that time. Now there is `bigdecimal` and `strscan` dependency in gemspec, I think it is proper to add `base64` too.

Related:
- https://github.com/Shopify/liquid/pull/1882