### PR TITLE
Bump Liquid to 5.8.7

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 # Liquid Change Log
 
-## 5.8.1 (unreleased)
+## 5.8.7
+* Expose body content in the `Doc` tag [James Meng]
 
 ## 5.8.1
 

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.8.6"
+  VERSION = "5.8.7"
 end


### PR DESCRIPTION
Bumping Liquid to 5.8.7 to include https://github.com/Shopify/liquid/pull/1954 in the latest release