### PR TITLE
Handle boolean values in sort filter comparison

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -1006,8 +1006,8 @@ module Liquid
     end
 
     def nil_safe_compare(a, b)
-      a = a ? 0 : 1 if boolean?(a)
-      b = b ? 0 : 1 if boolean?(b)
+      a = a ? 1 : 0 if boolean?(a)
+      b = b ? 1 : 0 if boolean?(b)
 
       result = a <=> b
 

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -305,14 +305,15 @@ class StandardFiltersTest < Minitest::Test
 
   def test_sort
     assert_equal([1, 2, 3, 4], @filters.sort([4, 3, 2, 1]))
+    assert_equal([false, false, true, true], @filters.sort([true, false, true, false]))
     assert_equal([{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }], @filters.sort([{ "a" => 4 }, { "a" => 3 }, { "a" => 1 }, { "a" => 2 }], "a"))
-    assert_equal([{ "a" => true }, { "a" => true }, { "a" => false }, { "a" => false }], @filters.sort([{ "a" => true }, { "a" => false }, { "a" => true }, { "a" => false }], "a"))
+    assert_equal([{ "a" => false }, { "a" => false }, { "a" => true }, { "a" => true }], @filters.sort([{ "a" => true }, { "a" => false }, { "a" => true }, { "a" => false }], "a"))
   end
 
   def test_sort_with_nils
     assert_equal([1, 2, 3, 4, nil], @filters.sort([nil, 4, 3, 2, 1]))
     assert_equal([{ "a" => 1 }, { "a" => 2 }, { "a" => 3 }, { "a" => 4 }, {}], @filters.sort([{ "a" => 4 }, { "a" => 3 }, {}, { "a" => 1 }, { "a" => 2 }], "a"))
-    assert_equal([{ "a" => true }, { "a" => true }, { "a" => false }, { "a" => false }, {}], @filters.sort([{ "a" => true }, {}, { "a" => false }, { "a" => true }, { "a" => false }], "a"))
+    assert_equal([{ "a" => false }, { "a" => false }, { "a" => true }, { "a" => true }, {}], @filters.sort([{ "a" => true }, {}, { "a" => false }, { "a" => true }, { "a" => false }], "a"))
   end
 
   def test_sort_when_property_is_sometimes_missing_puts_nils_last


### PR DESCRIPTION
- Updated nil_safe_compare to treat booleans
- Added tests to verify correct sorting of arrays containing boolean values and nils.

Solves weird hacks like this:
```liquid
{% liquid
  assign available_variants = product.variants | where: 'available', true
  assign unavailable_variants = product.variants | where: 'available', false
  assign sorted_variants = available_variants | concat: unavailable_variants
```

_Unsure why I didn't get a fresh master branch when creating this branch. Sorry..._