### PR TITLE
Bump to 5.9.0

### DIFF
--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.8.7"
+  VERSION = "5.9.0"
 end


### PR DESCRIPTION
Bumping Liquid to 5.9.0 with the addition of the `rigid` parser mode.