### PR TITLE
Bump to 5.10.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,14 @@
 # Liquid Change Log
 
+## 5.10.0
+* Introduce support for Inline Snippets [Julia Boutin]
+  ```
+  {%- snippet snowdevil -%}
+    Snowdevil
+  {%- endsnippet -%}
+  {% render snowdevil %}
+  ```
+
 ## 5.9.0
 * Introduce `:rigid` error mode for stricter, safer parsing of all tags [CP Clermont, Guilherme Carreiro]
 

--- a/lib/liquid/version.rb
+++ b/lib/liquid/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Liquid
-  VERSION = "5.9.0"
+  VERSION = "5.10.0"
 end


### PR DESCRIPTION
Bumping Liquid to 5.10.0 with the addition of Inline Snippets.

```liquid
{%- snippet snowdevil -%}
  Snowdevil
{%- endsnippet -%}
{% render snowdevil %}
```