### PR TITLE
Preserve literal semantics in strict2 case/when

### DIFF
--- a/lib/liquid/tags/case.rb
+++ b/lib/liquid/tags/case.rb
@@ -118,7 +118,7 @@ module Liquid
       parser = @parse_context.new_parser(markup)
 
       loop do
-        expr = safe_parse_expression(parser)
+        expr = Condition.parse_expression(parse_context, parser.expression, safe: true)
         block = Condition.new(@left, '==', expr)
         block.attach(body)
         @blocks << block

--- a/test/unit/tags/case_tag_unit_test.rb
+++ b/test/unit/tags/case_tag_unit_test.rb
@@ -82,6 +82,26 @@ class CaseTagUnitTest < Minitest::Test
     end
   end
 
+  def test_case_when_empty
+    template = <<~LIQUID
+      {%- case x -%}
+        {%- when 2 or empty -%}
+          2 or empty
+        {%- else -%}
+          not 2 or empty
+      {%- endcase -%}
+    LIQUID
+
+    with_error_modes(:lax, :strict, :strict2) do
+      assert_template_result("2 or empty", template, { 'x' => 2 })
+      assert_template_result("2 or empty", template, { 'x' => {} })
+      assert_template_result("2 or empty", template, { 'x' => [] })
+      assert_template_result("not 2 or empty", template, { 'x' => { 'a' => 'b' } })
+      assert_template_result("not 2 or empty", template, { 'x' => ['a'] })
+      assert_template_result("not 2 or empty", template, { 'x' => 4 })
+    end
+  end
+
   def test_case_with_invalid_expression
     template = <<~LIQUID
       {%- case foo=>bar -%}


### PR DESCRIPTION
Previously, `strict2` used `safe_parse_expression` to parse `when` expressions causing `blank` and `empty` to be treated as string literals (Expression::LITERALS maps 'empty' => ''), rather than method literals

This caused unexpected behaviour:

```liquid
{%- case products -%}
  {%- when empty -%}
    previously: doesn't render (products == '' is false)
    now: renders (products.empty? is true)
{%- endcase -%}
```

This PR instead calls `Condition.parse_expression` with `safe: true`, which will correctly handle `blank`/`empty`

<details><summary>Example</summary>

<img width="1162" height="539" alt="example" src="https://github.com/user-attachments/assets/e2f3bd25-4ec8-4edb-8702-730b19bc3fc0" />
</details> 
