### PR TITLE
Use floating-point format for BigDecimal stringification

### DIFF
--- a/lib/liquid/utils.rb
+++ b/lib/liquid/utils.rb
@@ -95,6 +95,8 @@ module Liquid
 
     def self.to_s(obj, seen = {})
       case obj
+      when BigDecimal
+        obj.to_s("F")
       when Hash
         # If the custom hash implementation overrides `#to_s`, use their
         # custom implementation. Otherwise we use Liquid's default


### PR DESCRIPTION
## Summary

- BigDecimal values now stringify using `to_s("F")` format instead of the default `to_s`

## Why

Ruby's default `BigDecimal#to_s` produces engineering/scientific notation for certain values:

```ruby
BigDecimal("0.00001").to_s      # => "0.1E-4"
BigDecimal("12345678.9").to_s   # => "0.123456789E8"
```

This is rarely the desired output in templates. Using `to_s("F")` produces the expected floating-point format:

```ruby
BigDecimal("0.00001").to_s("F")      # => "0.00001"
BigDecimal("12345678.9").to_s("F")   # => "12345678.9"
```