### PR TITLE
Add squish filter

### DIFF
--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -297,6 +297,19 @@ module Liquid
     # @liquid_type filter
     # @liquid_category string
     # @liquid_summary
+    #   Removes leading and trailing whitespace and collapses consecutive whitespace to a single space.
+    # @liquid_syntax string | squish
+    # @liquid_return [string]
+    def squish(input)
+      return if input.nil?
+
+      Utils.to_s(input).strip.gsub(/\s+/, ' ')
+    end
+
+    # @liquid_public_docs
+    # @liquid_type filter
+    # @liquid_category string
+    # @liquid_summary
     #   Strips all whitespace from the left and right of a string.
     # @liquid_syntax string | strip
     # @liquid_return [string]

--- a/test/integration/standard_filter_test.rb
+++ b/test/integration/standard_filter_test.rb
@@ -164,6 +164,13 @@ class StandardFiltersTest < Minitest::Test
     assert_equal(['A', 'Z'], @filters.split('A1Z', 1))
   end
 
+  def test_squish_filter
+    assert_equal("foo bar boo", Liquid::Template.parse(%Q({{ " foo   bar    
+\t   boo   " | squish }})).render)
+    assert_equal("", Liquid::Template.parse('{{ nil | squish }}').render)
+    assert_equal("", Liquid::Template.parse('{{ " " | squish }}').render)
+  end
+
   def test_escape
     assert_equal('&lt;strong&gt;', @filters.escape('<strong>'))
     assert_equal('1', @filters.escape(1))


### PR DESCRIPTION
Hello,

This PR provides a clean solution to https://github.com/Shopify/liquid/issues/2040

This PR answers a common use case we're facing with Shopify themes. As themes now become more complex, it is often needed to compose classes or inline styles, for instance using capture tags:

```liquid
{% capture styles %}
   --foo: {% if section.settings.foo %}10%{% else %}20%{% endif %};
   --bar: 10px;
{% endcapture %}
```

This, however, messes with whitespace. While this technically works, this makes it harder to debug. Horizon (Shopify free theme), especially, has this problem:

<img width="607" height="224" alt="image" src="https://github.com/user-attachments/assets/a2594e4e-7cd9-46d4-abcb-d2597048c2b4" />

There are workarounds but they are fragile:

* You can use whitespace controls {%- -%} but they won't work in some cases (for instance in this capture example) and it is also easy to forget a -%}.
* You can use this solution but this is verbose and probably quite inefficient on long strings: {% foo | strip_newlines | split: ' ' | join: ' ' %}

This PR adds a new filter. The name follows the one from Ruby on Rails (https://api.rubyonrails.org/classes/String.html#method-i-squish) and offers a simple, elegant solution:

```liquid
<div style="{{ style_attribute | squish }}">
</div>
```

I've signed the CLA. The associated documentation PR is #2051 