### PR TITLE
Fix tokenizer to skip closing braces inside quoted strings

### DIFF
--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -13,6 +13,8 @@ module Liquid
     OPEN_CURLEY = "{".ord
     CLOSE_CURLEY = "}".ord
     PERCENTAGE = "%".ord
+    SINGLE_QUOTE = "'".ord
+    DOUBLE_QUOTE = '"'.ord
 
     def initialize(
       source:,
@@ -117,9 +119,18 @@ module Liquid
       byte_a = byte_b = @ss.scan_byte
 
       while byte_b
-        byte_a = @ss.scan_byte while byte_a && byte_a != CLOSE_CURLEY && byte_a != OPEN_CURLEY
+        byte_a = @ss.scan_byte while byte_a &&
+            byte_a != CLOSE_CURLEY && byte_a != OPEN_CURLEY &&
+            byte_a != SINGLE_QUOTE && byte_a != DOUBLE_QUOTE
 
         break unless byte_a
+
+        if byte_a == SINGLE_QUOTE || byte_a == DOUBLE_QUOTE
+          @ss.skip_until(byte_a == SINGLE_QUOTE ? /'/ : /"/)
+
+          byte_a = @ss.scan_byte
+          next
+        end
 
         if @ss.eos?
           return byte_a == CLOSE_CURLEY ? @source.byteslice(start, @ss.pos - start) : "{{"

--- a/test/unit/tokenizer_unit_test.rb
+++ b/test/unit/tokenizer_unit_test.rb
@@ -41,6 +41,12 @@ class TokenizerTest < Minitest::Test
     assert_equal(["{{}}", "}"], tokenize('{{}}}'))
   end
 
+  def test_closing_brace_in_quoted_string
+    assert_equal(['{{ msg | replace: "{name}", name }}'], tokenize('{{ msg | replace: "{name}", name }}'))
+    assert_equal(["{{ msg | replace: '{name}', name }}"], tokenize("{{ msg | replace: '{name}', name }}"))
+    assert_equal(['{{ x | prepend: " {{ " | append: " }} " }}'], tokenize('{{ x | prepend: " {{ " | append: " }} " }}'))
+  end
+
   def test_unmatching_start_and_end
     assert_equal(["{{%}"], tokenize('{{%}'))
     assert_equal(["{{%%%}}"], tokenize('{{%%%}}'))


### PR DESCRIPTION
The byte-scanning tokenizer does not account for quoted strings when scanning for `}}` to terminate a variable token.  A `}` inside a quoted filter argument prematurely ends the token, causing a SyntaxError.

For example, the following valid template fails to parse:

    {{ message | replace: "{name}", customer_name }}

This patch makes `next_variable_token` skip over single- and double-quoted strings so that their contents do not interfere with `}}` detection.