### PR TITLE
Add for_loop? to Include tag for AST-based keyword detection

### DIFF
--- a/lib/liquid/tags/include.rb
+++ b/lib/liquid/tags/include.rb
@@ -20,7 +20,8 @@ module Liquid
   class Include < Tag
     prepend Tag::Disableable
 
-    SYNTAX = /(#{QuotedFragment}+)(\s+(?:with|for)\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
+    FOR = 'for'
+    SYNTAX = /(#{QuotedFragment}+)(\s+(with|#{FOR})\s+(#{QuotedFragment}+))?(\s+(?:as)\s+(#{VariableSegment}+))?/o
     Syntax = SYNTAX
 
     attr_reader :template_name_expr, :variable_name_expr, :attributes
@@ -84,12 +85,18 @@ module Liquid
     alias_method :parse_context, :options
     private :parse_context
 
+    def for_loop?
+      @is_for_loop
+    end
+
     def strict2_parse(markup)
       p = @parse_context.new_parser(markup)
 
       @template_name_expr = safe_parse_expression(p)
-      @variable_name_expr = safe_parse_expression(p) if p.id?("for") || p.id?("with")
+      with_or_for         = p.id?("for") || p.id?("with")
+      @variable_name_expr = safe_parse_expression(p) if with_or_for
       @alias_name         = p.consume(:id) if p.id?("as")
+      @is_for_loop        = (with_or_for == FOR)
 
       p.consume?(:comma)
 
@@ -111,11 +118,13 @@ module Liquid
     def lax_parse(markup)
       if markup =~ SYNTAX
         template_name = Regexp.last_match(1)
-        variable_name = Regexp.last_match(3)
+        with_or_for   = Regexp.last_match(3)
+        variable_name = Regexp.last_match(4)
 
-        @alias_name         = Regexp.last_match(5)
+        @alias_name         = Regexp.last_match(6)
         @variable_name_expr = variable_name ? parse_expression(variable_name) : nil
         @template_name_expr = parse_expression(template_name)
+        @is_for_loop        = (with_or_for == FOR)
         @attributes         = {}
 
         markup.scan(TagAttributes) do |key, value|

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -439,4 +439,49 @@ class IncludeTagTest < Minitest::Test
       assert_match(/Unexpected character =/, error.message)
     end
   end
+
+  def test_include_for_loop_true_with_for_keyword
+    with_error_modes(:lax, :strict, :strict2) do
+      template = Template.parse("{% include 'product' for products %}")
+      include_node = template.root.nodelist.first
+
+      assert(include_node.for_loop?, "Expected for_loop? to be true for 'for' keyword")
+    end
+  end
+
+  def test_include_for_loop_false_with_with_keyword
+    with_error_modes(:lax, :strict, :strict2) do
+      template = Template.parse("{% include 'product' with product %}")
+      include_node = template.root.nodelist.first
+
+      refute(include_node.for_loop?, "Expected for_loop? to be false for 'with' keyword")
+    end
+  end
+
+  def test_include_for_loop_false_without_keyword
+    with_error_modes(:lax, :strict, :strict2) do
+      template = Template.parse("{% include 'header' %}")
+      include_node = template.root.nodelist.first
+
+      refute(include_node.for_loop?, "Expected for_loop? to be false when no keyword")
+    end
+  end
+
+  def test_include_for_loop_with_alias
+    with_error_modes(:lax, :strict, :strict2) do
+      template = Template.parse("{% include 'product' for products as item %}")
+      include_node = template.root.nodelist.first
+
+      assert(include_node.for_loop?, "Expected for_loop? to be true for 'for' with alias")
+    end
+  end
+
+  def test_include_with_keyword_and_alias
+    with_error_modes(:lax, :strict, :strict2) do
+      template = Template.parse("{% include 'product' with products[0] as item %}")
+      include_node = template.root.nodelist.first
+
+      refute(include_node.for_loop?, "Expected for_loop? to be false for 'with' with alias")
+    end
+  end
 end # IncludeTagTest


### PR DESCRIPTION
## Summary

Stores `@is_for_loop` during parsing in the `Include` tag, matching the existing pattern in the `Render` tag. This allows consumers (like the liquid-rewriter) to determine the `with`/`for` keyword from the parsed AST instead of re-parsing raw markup with regex.

**Changes:**
- Added `FOR = 'for'` constant
- Added `for_loop?` public method
- `strict2_parse`: captures the `with`/`for` token from `p.id?` and stores `@is_for_loop`
- `lax_parse`: updated `SYNTAX` regex to capture the keyword in its own group (group 3), stores `@is_for_loop`
- Regex capture groups shifted: variable name is now group 4, alias name is now group 6

No runtime behavior change — `Include#render_to_output_buffer` still uses `variable.is_a?(Array)` for iteration, not `@is_for_loop`.

Depends on: [Shopify/liquid-rewriter-private#214](https://github.com/Shopify/liquid-rewriter-private/pull/214)

## Tophat

```bash
bundle install
bundle exec irb -r liquid
```

```ruby
# for keyword detected
t = Liquid::Template.parse("{% include 'product' for products %}")
t.root.nodelist.first.for_loop?  # => true

# with keyword detected
t = Liquid::Template.parse("{% include 'product' with product %}")
t.root.nodelist.first.for_loop?  # => false

# no keyword
t = Liquid::Template.parse("{% include 'header' %}")
t.root.nodelist.first.for_loop?  # => false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)