### PR TITLE
Add strict2_parse to increment and decrement tags

### DIFF
--- a/lib/liquid/tags/decrement.rb
+++ b/lib/liquid/tags/decrement.rb
@@ -23,11 +23,27 @@ module Liquid
   #   {% decrement variable_name %}
   # @liquid_syntax_keyword variable_name The name of the variable being decremented.
   class Decrement < Tag
+    include ParserSwitching
+
     attr_reader :variable_name
 
     def initialize(tag_name, markup, options)
       super
+      parse_with_selected_parser(markup)
+    end
+
+    def lax_parse(markup)
       @variable_name = markup.strip
+    end
+
+    def strict_parse(markup)
+      lax_parse(markup)
+    end
+
+    def strict2_parse(markup)
+      p = @parse_context.new_parser(markup.strip)
+      @variable_name = p.consume(:id)
+      p.consume(:end_of_string)
     end
 
     def render_to_output_buffer(context, output)

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -23,11 +23,27 @@ module Liquid
   #   {% increment variable_name %}
   # @liquid_syntax_keyword variable_name The name of the variable being incremented.
   class Increment < Tag
+    include ParserSwitching
+
     attr_reader :variable_name
 
     def initialize(tag_name, markup, options)
       super
+      parse_with_selected_parser(markup)
+    end
+
+    def lax_parse(markup)
       @variable_name = markup.strip
+    end
+
+    def strict_parse(markup)
+      lax_parse(markup)
+    end
+
+    def strict2_parse(markup)
+      p = @parse_context.new_parser(markup.strip)
+      @variable_name = p.consume(:id)
+      p.consume(:end_of_string)
     end
 
     def render_to_output_buffer(context, output)

--- a/test/integration/tags/increment_tag_test.rb
+++ b/test/integration/tags/increment_tag_test.rb
@@ -27,4 +27,50 @@ class IncrementTagTest < Minitest::Test
       '{%decrement starboard %}',
     )
   end
+
+  def test_increment_strict2_rejects_invalid_variable_name
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% increment foo bar %}', error_mode: :strict2)
+    end
+  end
+
+  def test_increment_strict2_rejects_variable_starting_with_number
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% increment 11aa %}', error_mode: :strict2)
+    end
+  end
+
+  def test_increment_strict2_accepts_valid_variable_name
+    template = Template.parse('{% increment my-var %}', error_mode: :strict2)
+    assert_equal('0', template.render)
+  end
+
+  def test_decrement_strict2_rejects_invalid_variable_name
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% decrement foo bar %}', error_mode: :strict2)
+    end
+  end
+
+  def test_decrement_strict2_rejects_variable_starting_with_number
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% decrement 11aa %}', error_mode: :strict2)
+    end
+  end
+
+  def test_decrement_strict2_accepts_valid_variable_name
+    template = Template.parse('{% decrement my-var %}', error_mode: :strict2)
+    assert_equal('-1', template.render)
+  end
+
+  def test_increment_strict2_rejects_empty_variable_name
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% increment %}', error_mode: :strict2)
+    end
+  end
+
+  def test_decrement_strict2_rejects_empty_variable_name
+    assert_raises(Liquid::SyntaxError) do
+      Template.parse('{% decrement %}', error_mode: :strict2)
+    end
+  end
 end

--- a/test/integration/tags/render_tag_test.rb
+++ b/test/integration/tags/render_tag_test.rb
@@ -174,16 +174,16 @@ class RenderTagTest < Minitest::Test
   def test_increment_is_isolated_between_renders
     assert_template_result(
       '010',
-      '{% increment %}{% increment %}{% render "incr" %}',
-      partials: { 'incr' => '{% increment %}' },
+      '{% increment port %}{% increment port %}{% render "incr" %}',
+      partials: { 'incr' => '{% increment port %}' },
     )
   end
 
   def test_decrement_is_isolated_between_renders
     assert_template_result(
       '-1-2-1',
-      '{% decrement %}{% decrement %}{% render "decr" %}',
-      partials: { 'decr' => '{% decrement %}' },
+      '{% decrement port %}{% decrement port %}{% render "decr" %}',
+      partials: { 'decr' => '{% decrement port %}' },
     )
   end
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on [Shopify/liquid#2065](https://github.com/Shopify/liquid/pull/2065) (assign/capture strict2_parse)

## Summary

Adds `strict2_parse` to `Increment` and `Decrement` tags. Both tags previously accepted any string as a variable name via `markup.strip` — no Parser validation was performed in any mode.

**Changes:**
- Both tags now `include ParserSwitching` and use `parse_with_selected_parser`
- `lax_parse`: preserves the original `markup.strip` behavior
- `strict_parse`: delegates to `lax_parse`
- `strict2_parse`: validates the variable name via `p.consume(:id)` + `p.consume(:end_of_string)`

This means `{% increment foo bar %}` and `{% decrement 11aa %}` are now rejected in strict2 mode.

## Tophat

```bash
bundle install
bundle exec irb -r liquid
```

```ruby
# Rejected in strict2
Liquid::Template.parse('{% increment foo bar %}', error_mode: :strict2)
# => Liquid::SyntaxError

Liquid::Template.parse('{% decrement 11aa %}', error_mode: :strict2)
# => Liquid::SyntaxError

# Accepted
Liquid::Template.parse('{% increment my-var %}', error_mode: :strict2)
# => OK

# Lax mode unchanged
Liquid::Template.parse('{% increment foo bar %}', error_mode: :lax)
# => OK (preserves backward compatibility)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)