### PR TITLE
Another template tokenizer implementation

### DIFF
--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -44,7 +44,6 @@ module Liquid
     def new_tokenizer(source, start_line_number: nil, for_liquid_tag: false)
       Tokenizer.new(
         source: source,
-        string_scanner: @string_scanner,
         line_number: start_line_number,
         for_liquid_tag: for_liquid_tag,
       )

--- a/lib/liquid/tokenizer.rb
+++ b/lib/liquid/tokenizer.rb
@@ -1,22 +1,11 @@
 # frozen_string_literal: true
 
-require "strscan"
-
 module Liquid
   class Tokenizer
     attr_reader :line_number, :for_liquid_tag
 
-    TAG_END = /%\}/
-    TAG_OR_VARIABLE_START = /\{[\{\%]/
-    NEWLINE = /\n/
-
-    OPEN_CURLEY = "{".ord
-    CLOSE_CURLEY = "}".ord
-    PERCENTAGE = "%".ord
-
     def initialize(
       source:,
-      string_scanner:,
       line_numbers: false,
       line_number: nil,
       for_liquid_tag: false
@@ -28,8 +17,6 @@ module Liquid
       @tokens = []
 
       if @source
-        @ss = string_scanner
-        @ss.string = @source
         tokenize
       end
     end
@@ -51,111 +38,86 @@ module Liquid
     private
 
     def tokenize
-      if @for_liquid_tag
-        @tokens = @source.split("\n")
+      @tokens = if @for_liquid_tag
+        @source.split("\n")
       else
-        @tokens << shift_normal until @ss.eos?
+        scan(@source)
       end
 
       @source = nil
-      @ss = nil
     end
 
-    def shift_normal
-      token = next_token
+    # @param source [String]
+    # @return [Array<String>]
+    def scan(source)
+      raise SyntaxError, "Invalid byte sequence in #{source.encoding}" unless source.valid_encoding?
 
-      return unless token
+      tokens = [] # : Array[String]
+      pos = 0
+      eos = source.bytesize
 
-      token
-    end
+      # rubocop:disable Metrics/BlockNesting
+      while pos < eos
+        byte = source.getbyte(pos)
+        next_byte = source.getbyte(pos + 1)
 
-    def next_token
-      # possible states: :text, :tag, :variable
-      byte_a = @ss.peek_byte
-
-      if byte_a == OPEN_CURLEY
-        @ss.scan_byte
-
-        byte_b = @ss.peek_byte
-
-        if byte_b == PERCENTAGE
-          @ss.scan_byte
-          return next_tag_token
-        elsif byte_b == OPEN_CURLEY
-          @ss.scan_byte
-          return next_variable_token
-        end
-
-        @ss.pos -= 1
-      end
-
-      next_text_token
-    end
-
-    def next_text_token
-      start = @ss.pos
-
-      unless @ss.skip_until(TAG_OR_VARIABLE_START)
-        token = @ss.rest
-        @ss.terminate
-        return token
-      end
-
-      pos = @ss.pos -= 2
-      @source.byteslice(start, pos - start)
-    rescue ::ArgumentError => e
-      if e.message == "invalid byte sequence in #{@ss.string.encoding}"
-        raise SyntaxError, "Invalid byte sequence in #{@ss.string.encoding}"
-      else
-        raise
-      end
-    end
-
-    def next_variable_token
-      start = @ss.pos - 2
-
-      byte_a = byte_b = @ss.scan_byte
-
-      while byte_b
-        byte_a = @ss.scan_byte while byte_a && byte_a != CLOSE_CURLEY && byte_a != OPEN_CURLEY
-
-        break unless byte_a
-
-        if @ss.eos?
-          return byte_a == CLOSE_CURLEY ? @source.byteslice(start, @ss.pos - start) : "{{"
-        end
-
-        byte_b = @ss.scan_byte
-
-        if byte_a == CLOSE_CURLEY
-          if byte_b == CLOSE_CURLEY
-            return @source.byteslice(start, @ss.pos - start)
-          elsif byte_b != CLOSE_CURLEY
-            @ss.pos -= 1
-            return @source.byteslice(start, @ss.pos - start)
+        if byte == 123 && next_byte == 123 # {{
+          if (index = source.byteindex("}", pos + 2))
+            if source.getbyte(index + 1) == 125 # }}
+              tokens << source.byteslice(pos, index + 2 - pos)
+              pos = index + 2
+            else # } or %}
+              tokens << source.byteslice(pos, index + 1 - pos)
+              pos = index + 1
+            end
+          else
+            tokens << "{{"
+            pos += 2
           end
-        elsif byte_a == OPEN_CURLEY && byte_b == PERCENTAGE
-          return next_tag_token_with_start(start)
+        elsif byte == 123 && next_byte == 37 # {%
+          if (index = source.byteindex("%}", pos + 2))
+            tokens << source.byteslice(pos, index + 2 - pos)
+            pos = index + 2
+          else
+            tokens << "{%"
+            pos += 2
+          end
+        else
+          # Not markup. Scan until but not including {{ or {%
+          index = source.byteindex("{", pos)
+
+          unless index
+            # No more markup. Scan until end of string.
+            tokens << source.byteslice(pos, eos - pos)
+            break
+          end
+
+          next_byte = source.getbyte(index + 1)
+
+          while next_byte != 37 && next_byte != 123
+            index = source.byteindex("{", index + 1)
+            break unless index
+
+            next_byte = source.getbyte(index + 1)
+            unless next_byte
+              index = nil
+              break
+            end
+          end
+
+          if index
+            tokens << source.byteslice(pos, index - pos)
+            pos = index
+          else
+            # No more markup. Scan until end of string.
+            tokens << source.byteslice(pos, eos - pos)
+            break
+          end
         end
-
-        byte_a = byte_b
       end
+      # rubocop:enable Metrics/BlockNesting
 
-      "{{"
-    end
-
-    def next_tag_token
-      start = @ss.pos - 2
-      if (len = @ss.skip_until(TAG_END))
-        @source.byteslice(start, len + 2)
-      else
-        "{%"
-      end
-    end
-
-    def next_tag_token_with_start(start)
-      @ss.skip_until(TAG_END)
-      @source.byteslice(start, @ss.pos - start)
+      tokens
     end
   end
 end

--- a/performance/theme_runner.rb
+++ b/performance/theme_runner.rb
@@ -50,11 +50,9 @@ class ThemeRunner
 
   # `tokenize` will just test the tokenizen portion of liquid without any templates
   def tokenize
-    ss = StringScanner.new("")
     @tests.each do |test_hash|
       tokenizer = Liquid::Tokenizer.new(
         source: test_hash[:liquid],
-        string_scanner: ss,
         line_numbers: true,
       )
       while tokenizer.shift; end

--- a/test/unit/tag_unit_test.rb
+++ b/test/unit/tag_unit_test.rb
@@ -33,9 +33,6 @@ class TagUnitTest < Minitest::Test
   private
 
   def new_tokenizer
-    Tokenizer.new(
-      source: "",
-      string_scanner: StringScanner.new(""),
-    )
+    Tokenizer.new(source: "")
   end
 end

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -39,7 +39,7 @@ class TemplateUnitTest < Minitest::Test
   def test_invalid_utf8
     input = "\xff\x00"
     error = assert_raises(SyntaxError) do
-      Liquid::Tokenizer.new(source: input, string_scanner: StringScanner.new(input))
+      Liquid::Tokenizer.new(source: input)
     end
     assert_equal(
       'Liquid syntax error: Invalid byte sequence in UTF-8',


### PR DESCRIPTION
This pull request demonstrates an alternative template tokenizer implementation.

Like the tokenizer from #2056, we use `String#getbyte`, `String#byteindex` and `String#byteslice` instead of a `StringScanner`.

On an M2 Mac Mini, running `PHASE=tokenize bundle exec rake benchmark:strict2` gives:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
           tokenize:   511.000 i/100ms
Calculating -------------------------------------
           tokenize:      5.112k (± 0.1%) i/s  (195.61 μs/i) -    102.711k in  20.091372s
``` 

The same benchmark for Liquid v5.12.0:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
           tokenize:   265.000 i/100ms
Calculating -------------------------------------
           tokenize:      2.658k (± 0.1%) i/s  (376.29 μs/i) -     53.265k in  20.043212s
```

And for #2056:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
           tokenize:   454.000 i/100ms
Calculating -------------------------------------
           tokenize:      4.567k (± 0.1%) i/s  (218.96 μs/i) -     91.708k in  20.080724s
```

Unlike v5.12.0 and #2056, the tokenizer in this PR also outperforms the old splitting regex approach from v5.6.0 when benchmarking **without YJIT**.

---

I did want to suggest a`StringScanner` implementation like this:

```ruby
RE_START = /\{[{%]/
RE_OUT = /\{\{[^}]*\}\}?|\{\{.*%\}/
RE_TAG = /\{%[^%}]*%\}/

# @param scanner [StringScanner]
# @return [Array[String]]
def tokenize(scanner)
  tokens = [] # : Array[String]

  loop do
    case scanner.peek(2)
    when "{{"
      if (match = scanner.scan(RE_OUT))
        tokens << match
      else
        tokens << "{{"
        scanner.pos += 2
      end
    when "{%"
      if (match = scanner.scan(RE_TAG))
        tokens << match
      else
        tokens << "{%"
        scanner.pos += 2
      end
    else
      if (match = scanner.scan_until(RE_START))
        tokens << match.chop!.chop!
        scanner.pos -= 2
      else
        tokens << scanner.rest unless scanner.eos?
        break
      end
    end
  end

  tokens
end
```

Which is a performance improvement over v5.12.0, but does not come close to the byte scanning approach, and doesn't have the same performance characteristics without YJIT.