### PR TITLE
Remove "strict2" from bare bracket error message

### DIFF
--- a/lib/liquid/parser.rb
+++ b/lib/liquid/parser.rb
@@ -55,7 +55,7 @@ module Liquid
         str << variable_lookups
       when :open_square
         if @reject_bare_brackets
-          raise SyntaxError, "Bare bracket access is not allowed in strict2 mode. Use #{Expression::SELF}['...'] instead"
+          raise SyntaxError, "Bare bracket access is not allowed. Use #{Expression::SELF}['...'] instead"
         end
         str = consume.dup
         str << expression


### PR DESCRIPTION
## Summary
- Removes the `strict2 mode` qualifier from the bare bracket access error message in `lib/liquid/parser.rb` so the error reads generically regardless of which parser surfaced it.

## Test plan
- [ ] Existing tests (e.g. `test_assign_rejects_brackets_in_variable_name_in_strict2`, `test_tablerow_with_bracketed_access_in_strict2_mode`) continue to pass — they only assert that a `SyntaxError` is raised, not the exact message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)