### PR TITLE
Prevent `SelfDrop` context mutation across render boundaries

### DIFF
--- a/lib/liquid/self_drop.rb
+++ b/lib/liquid/self_drop.rb
@@ -16,19 +16,19 @@ module Liquid
   #   then the local value takes precedence over the `self` object.
   # @liquid_access global
   class SelfDrop < Drop
-    def initialize(context)
+    def initialize(self_context)
       super()
-      @context = context
+      @self_context = self_context
     end
 
     def [](key)
-      @context.find_variable(key)
+      @self_context.find_variable(key)
     rescue UndefinedVariable
       nil
     end
 
     def key?(key)
-      @context.variable_defined?(key)
+      @self_context.variable_defined?(key)
     end
 
     def to_liquid

--- a/lib/liquid/self_drop.rb
+++ b/lib/liquid/self_drop.rb
@@ -31,10 +31,10 @@ module Liquid
       @self_context.variable_defined?(key)
     end
 
-    undef context
-
     def to_liquid
       self
     end
+
+    undef context=
   end
 end

--- a/lib/liquid/self_drop.rb
+++ b/lib/liquid/self_drop.rb
@@ -31,7 +31,7 @@ module Liquid
       @self_context.variable_defined?(key)
     end
 
-    def context=(_); end
+    undef context
 
     def to_liquid
       self

--- a/lib/liquid/self_drop.rb
+++ b/lib/liquid/self_drop.rb
@@ -31,6 +31,8 @@ module Liquid
       @self_context.variable_defined?(key)
     end
 
+    def context=(_); end
+
     def to_liquid
       self
     end

--- a/lib/liquid/template.rb
+++ b/lib/liquid/template.rb
@@ -151,8 +151,10 @@ module Liquid
 
         c
       when Liquid::Drop
-        drop         = args.shift
-        drop.context = Context.new([drop, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits, {}, @environment)
+        drop = args.shift
+        c    = Context.new([drop, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits, {}, @environment)
+        drop.context = c if drop.respond_to?(:context=)
+        c
       when Hash
         Context.new([args.shift, assigns], instance_assigns, registers, @rethrow_errors, @resource_limits, {}, @environment)
       when nil

--- a/test/integration/self_drop_context_test.rb
+++ b/test/integration/self_drop_context_test.rb
@@ -68,4 +68,24 @@ class SelfDropContextTest < Minitest::Test
 
     assert_template_result('42', source)
   end
+
+  def test_self_drop_context_writer_is_a_noop
+    context = Context.new
+    drop = SelfDrop.new(context)
+    assert(drop.respond_to?(:context=))
+    drop.context = Context.new
+    assert_nil(drop.instance_variable_get(:@context))
+  end
+
+  def test_self_drop_with_strict_variables_does_not_raise_for_defined_var
+    t = Template.parse('{{ self.x }}')
+    result = t.render({ 'x' => 42 }, strict_variables: true)
+    assert_equal('42', result)
+  end
+
+  def test_self_drop_with_strict_variables_returns_nil_for_undefined_var
+    t = Template.parse('{{ self.x }}')
+    result = t.render({}, strict_variables: true)
+    assert_equal('', result)
+  end
 end

--- a/test/integration/self_drop_context_test.rb
+++ b/test/integration/self_drop_context_test.rb
@@ -69,12 +69,12 @@ class SelfDropContextTest < Minitest::Test
     assert_template_result('42', source)
   end
 
-  def test_self_drop_context_writer_is_a_noop
+  def test_self_drop_context_setter_is_undefined
     context = Context.new
     drop = SelfDrop.new(context)
-    assert(drop.respond_to?(:context=))
-    drop.context = Context.new
-    assert_nil(drop.instance_variable_get(:@context))
+    refute(drop.respond_to?(:context=))
+
+    assert_template_result('42', '{{ self.x }}', { 'x' => 42 })
   end
 
   def test_self_drop_with_strict_variables_does_not_raise_for_defined_var
@@ -87,5 +87,12 @@ class SelfDropContextTest < Minitest::Test
     t = Template.parse('{{ self.x }}')
     result = t.render({}, strict_variables: true)
     assert_equal('', result)
+  end
+
+  def test_self_drop_can_be_passed_as_bare_drop_to_render
+    t = Template.parse('{{ self.x }}')
+    drop = SelfDrop.new(Context.new({ 'x' => 42 }))
+    result = t.render(drop)
+    assert_equal('42', result)
   end
 end

--- a/test/integration/self_drop_context_test.rb
+++ b/test/integration/self_drop_context_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class SelfDropTest < Minitest::Test
+class SelfDropContextTest < Minitest::Test
   include Liquid
 
   def test_self_drop_passed_as_render_param_preserves_original_scope

--- a/test/integration/self_drop_test.rb
+++ b/test/integration/self_drop_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SelfDropTest < Minitest::Test
+  include Liquid
+
+  def test_self_drop_passed_as_render_param_preserves_original_scope
+    source = <<~LIQUID
+      {%- assign var = 42 -%}
+      {%- assign s = self -%}
+      {%- render "snippet1", other_self: s -%}
+    LIQUID
+
+    partials = {
+      'snippet1' => <<~LIQUID,
+        {%- assign var = 43 -%}
+        {{- other_self.var }}|{{ self.var -}}
+      LIQUID
+    }
+
+    assert_template_result('42|43', source, partials: partials)
+  end
+
+  def test_self_drop_in_render_without_passing_resolves_inner_scope
+    source = <<~LIQUID
+      {%- assign var = 42 -%}
+      {%- render "snippet1" -%}
+    LIQUID
+
+    partials = {
+      'snippet1' => <<~LIQUID,
+        {%- assign var = 99 -%}
+        {{- self.var -}}
+      LIQUID
+    }
+
+    assert_template_result('99', source, partials: partials)
+  end
+
+  def test_self_drop_passed_to_nested_renders_preserves_each_level
+    source = <<~LIQUID
+      {%- assign a = 1 -%}
+      {%- assign s1 = self -%}
+      {%- render "snippet1", outer: s1 -%}
+    LIQUID
+
+    partials = {
+      'snippet1' => <<~LIQUID,
+        {%- assign a = 2 -%}
+        {%- assign s2 = self -%}
+        {%- render "snippet2", outer: outer, middle: s2 -%}
+      LIQUID
+      'snippet2' => <<~LIQUID,
+        {%- assign a = 3 -%}
+        {{- outer.a }}|{{ middle.a }}|{{ self.a -}}
+      LIQUID
+    }
+
+    assert_template_result('1|2|3', source, partials: partials)
+  end
+
+  def test_self_drop_reflects_variables_assigned_after_creation
+    source = <<~LIQUID
+      {%- assign s = self -%}
+      {%- assign x = 42 %}{{ s.x -}}
+    LIQUID
+
+    assert_template_result('42', source)
+  end
+end


### PR DESCRIPTION
This PR fixes `SelfDrop` scoping so a `self` assigned in one template preserves its original scope when passed to a rendered template.

```liquid
# template1.liquid
{% assign var = 42 %}
{% assign s = self %}
{% render 'template2', other_self: s %}

# template2.liquid
{% assign var = 43 %}
{{ other_self.var }}  => 43 (wrong — should be 42)
```

The fix renames `@context` to `@self_context` in `SelfDrop`, so the drop has a specific reference to its originating context instead of reusing the inherited `context` that gets overwritten at the `context.rb` level on line 220.
