### PR TITLE
Fix Marshal serialization of Template, Environment, and ParseContext

### DIFF
--- a/lib/liquid/environment.rb
+++ b/lib/liquid/environment.rb
@@ -155,5 +155,18 @@ module Liquid
       # @strainer_template.freeze
       super
     end
+
+    def marshal_dump
+      filter_modules = @strainer_template.ancestors[1...@strainer_template.ancestors.index(StrainerTemplate)]
+      [@tags, @error_mode, @file_system, @default_resource_limits, filter_modules]
+    end
+
+    def marshal_load(data)
+      @tags, @error_mode, @file_system, @default_resource_limits, filter_modules = data
+      @exception_renderer = ->(exception) { exception }
+      @strainer_template = Class.new(StrainerTemplate)
+      filter_modules.reverse_each { |m| @strainer_template.add_filter(m) }
+      @strainer_template_class_cache = {}
+    end
   end
 end

--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -88,5 +88,14 @@ module Liquid
         end
       end
     end
+
+    def marshal_dump
+      instance_variables.reject { |v| v == :@string_scanner }.map { |v| [v, instance_variable_get(v)] }.to_h
+    end
+
+    def marshal_load(data)
+      data.each { |k, v| instance_variable_set(k, v) }
+      @string_scanner = StringScanner.new("")
+    end
   end
 end

--- a/test/unit/template_unit_test.rb
+++ b/test/unit/template_unit_test.rb
@@ -46,4 +46,26 @@ class TemplateUnitTest < Minitest::Test
       error.message,
     )
   end
+
+  module UpFilter
+    def up(input) = input.upcase
+  end
+
+  def test_marshal_roundtrip
+    env = Liquid::Environment.build { |e| e.register_filter(UpFilter) }
+    t = Template.parse("Hello {{ name | up }}", environment: env)
+    t2 = Marshal.load(Marshal.dump(t))
+    assert_equal("Hello WORLD", t2.render("name" => "world"))
+  end
+
+  module ShoutFilter
+    def shout(input) = input.upcase + "!"
+  end
+
+  def test_marshal_roundtrip_with_custom_filter
+    env = Liquid::Environment.build { |e| e.register_filter(ShoutFilter) }
+    t = Template.parse("{{ name | shout }}", environment: env)
+    t2 = Marshal.load(Marshal.dump(t))
+    assert_equal("WORLD!", t2.render("name" => "world"))
+  end
 end


### PR DESCRIPTION
Templates can be compiled once and cached (as described in the wiki), but since 5.6.0 calling `Marshal.dump` on a compiled template raises `TypeError: can't dump anonymous class` because `Environment` holds an anonymous `Class.new(StrainerTemplate)` and `ParseContext` holds a `StringScanner`.

This PR adds `marshal_dump`/`marshal_load` to both `Environment` and `ParseContext`. `Environment` rebuilds its strainer template from the serialized filter module list on load; `ParseContext` excludes `@string_scanner` and creates a fresh one on load. The `exception_renderer` proc is not serializable and is restored to the default lambda on load.

Fixes #1913.