### PR TITLE
Fix `SelfDrop` equality

### DIFF
--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -208,7 +208,7 @@ module Liquid
 
       # `self` resolves to a SelfDrop (enabling `self['var']` lookups),
       # but only when it hasn't been explicitly assigned as a local variable.
-      return SelfDrop.new(self) if key == Expression::SELF && !index
+      return @self_drop ||= SelfDrop.new(self) if key == Expression::SELF && !index
 
       variable = if index
         lookup_and_evaluate(@scopes[index], key, raise_on_not_found: raise_on_not_found)

--- a/lib/liquid/self_drop.rb
+++ b/lib/liquid/self_drop.rb
@@ -35,6 +35,20 @@ module Liquid
       self
     end
 
+    def ==(other)
+      other.is_a?(SelfDrop) && other.self_context.equal?(@self_context)
+    end
+
+    alias_method :eql?, :==
+
+    def hash
+      @self_context.object_id.hash
+    end
+
+    protected
+
+    attr_reader :self_context
+
     undef context=
   end
 end

--- a/test/integration/self_drop_context_test.rb
+++ b/test/integration/self_drop_context_test.rb
@@ -77,6 +77,24 @@ class SelfDropContextTest < Minitest::Test
     assert_template_result('42', '{{ self.x }}', { 'x' => 42 })
   end
 
+  def test_self_drop_repeated_lookups_compare_equal_for_same_context
+    context = Context.new
+
+    assert_equal(context.find_variable("self"), context.find_variable("self"))
+  end
+
+  def test_assigned_self_drop_compares_equal_to_itself
+    assert_template_result('T', '{% assign s = self %}{% if s == s %}T{% else %}F{% endif %}')
+  end
+
+  def test_distinct_self_assignments_compare_equal_for_same_context
+    assert_template_result('T', '{% assign a = self %}{% assign b = self %}{% if a == b %}T{% else %}F{% endif %}')
+  end
+
+  def test_bare_self_compares_equal_to_bare_self
+    assert_template_result('T', '{% if self == self %}T{% else %}F{% endif %}')
+  end
+
   def test_self_drop_with_strict_variables_does_not_raise_for_defined_var
     t = Template.parse('{{ self.x }}')
     result = t.render({ 'x' => 42 }, strict_variables: true)

--- a/test/integration/self_drop_context_test.rb
+++ b/test/integration/self_drop_context_test.rb
@@ -79,8 +79,12 @@ class SelfDropContextTest < Minitest::Test
 
   def test_self_drop_repeated_lookups_compare_equal_for_same_context
     context = Context.new
+    drop = context.find_variable("self")
+    cached_drop = context.find_variable("self")
 
-    assert_equal(context.find_variable("self"), context.find_variable("self"))
+    assert_same(drop, cached_drop)
+    assert_equal(drop.object_id, cached_drop.object_id)
+    assert_equal(drop, cached_drop)
   end
 
   def test_assigned_self_drop_compares_equal_to_itself


### PR DESCRIPTION
`Liquid::SelfDrop` currently behaves like a wrapper object for equality, even though every meaningful operation delegates back to the captured context. That means two separate `self` lookups from the same context compare as different values, leaking implementation detail into both Ruby callers and template behavior:

```ruby
ctx = Liquid::Context.new({})
a = ctx.find_variable("self")
b = ctx.find_variable("self")

[a == b, a.equal?(b), a == a]
# Before: [false, false, true]
# After:  [true,  false, true]
```

This change makes `SelfDrop` equality compare the captured context identity, and aligns `eql?`/`hash` with the same rule so Ruby hash-key semantics stay coherent.
