### PR TITLE
Let environment `self` shadow `SelfDrop`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
 end
 
 group :spec do
-  gem 'liquid-spec', github: 'Shopify/liquid-spec', branch: 'main'
+  # Using feature branch until https://github.com/Shopify/liquid-spec/pull/144 is merged
+  gem 'liquid-spec', github: 'Shopify/liquid-spec', branch: 'self-drop-env-lookup-specs'
   gem 'activesupport', require: false
 end

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -206,15 +206,20 @@ module Liquid
       # path and find_index() is optimized in MRI to reduce object allocation
       index = @scopes.find_index { |s| s.key?(key) }
 
-      # `self` resolves to a SelfDrop (enabling `self['var']` lookups),
-      # but only when it hasn't been explicitly assigned as a local variable.
-      return @self_drop ||= SelfDrop.new(self) if key == Expression::SELF && !index
+      fallback_to_self_drop = key == Expression::SELF && index.nil?
 
       variable = if index
         lookup_and_evaluate(@scopes[index], key, raise_on_not_found: raise_on_not_found)
       else
-        try_variable_find_in_environments(key, raise_on_not_found: raise_on_not_found)
+        try_variable_find_in_environments(
+          key,
+          raise_on_not_found: raise_on_not_found && !fallback_to_self_drop,
+        )
       end
+
+      # `self` resolves to a SelfDrop (enabling `self['var']` lookups),
+      # but only after the normal environment lookup doesn't find a value.
+      return @self_drop ||= SelfDrop.new(self) if fallback_to_self_drop && variable.nil?
 
       # update variable's context before invoking #to_liquid
       variable.context = self if variable.respond_to?(:context=)


### PR DESCRIPTION
Previously, bare `self` returned `SelfDrop` as soon as local scopes missed, which meant an environment or counter variable named `self` couldn't shadow it. This PR fixes that by checking environments before falling back to `SelfDrop`, while still suppressing strict-variable errors for the fallback path.
