### PR TITLE
Add base64 as runtime dependency

### DIFF
--- a/liquid.gemspec
+++ b/liquid.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("strscan", ">= 3.1.1")
   s.add_dependency("bigdecimal")
+  s.add_dependency("base64")
 
   s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('minitest')


### PR DESCRIPTION
## Problem

Ruby 3.3+ no longer includes `base64` as a default gem. Loading liquid on Ruby 3.3+ produces a deprecation warning:

```
liquid-5.4.0/lib/liquid/standardfilters.rb:4: warning: base64 was loaded from the standard library,
but will no longer be part of the default gems since Ruby 3.4.0.
Add base64 to your Gemfile or gemspec.
```

## Solution

Add `base64` as an explicit runtime dependency in the gemspec, matching the approach already used for `bigdecimal` and `strscan`.

## Testing

All 774 existing tests pass on Ruby 3.4.7.

Fixes #1772