### PR TITLE
Fix `NoMethodError` unless `line_numbers: true`

### DIFF
--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -48,7 +48,7 @@ module Liquid
           markup   = Regexp.last_match(2)
 
           if tag_name == 'liquid'
-            parse_context.line_number -= 1
+            parse_context.line_number -= 1 if parse_context.line_number
             next parse_liquid_tag(markup, parse_context)
           end
 

--- a/test/integration/tags/liquid_tag_test.rb
+++ b/test/integration/tags/liquid_tag_test.rb
@@ -146,4 +146,10 @@ class LiquidTagTest < Minitest::Test
       -%}
     LIQUID
   end
+
+  def test_nested_liquid_tags_do_not_raise_NoMethodError_when_line_numbers_is_false
+    assert_template_result('good', <<~LIQUID, line_numbers: false)
+      {% liquid liquid echo "good" %}
+    LIQUID
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,11 +35,11 @@ module Minitest
     def assert_template_result(
       expected, template, assigns = {},
       message: nil, partials: nil, error_mode: Liquid::Environment.default.error_mode, render_errors: false,
-      template_factory: nil
+      template_factory: nil, line_numbers: true
     )
       file_system = StubFileSystem.new(partials || {})
       environment = Liquid::Environment.build(file_system: file_system)
-      template = Liquid::Template.parse(template, line_numbers: true, error_mode: error_mode&.to_sym, environment: environment)
+      template = Liquid::Template.parse(template, line_numbers: line_numbers, error_mode: error_mode&.to_sym, environment: environment)
       registers = Liquid::Registers.new(file_system: file_system, template_factory: template_factory)
       context = Liquid::Context.build(static_environments: assigns, rethrow_errors: !render_errors, registers: registers, environment: environment)
       output = template.render(context)


### PR DESCRIPTION
This PR fixes a bug in `BlockBody#parse_for_liquid_tag` where nested `liquid` tags would raise a `NoMethodError` unless `line_numbers: true` is passed to `Template.parse`.

Closes #1734 
Closes #2101 